### PR TITLE
Rcal 173 ramp wfi image rdm support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
 0.2.0 (unreleased)
 ==================
 
+- Added support for ramp, ramp_fit_output, wfi_img_photom models. [#15]
+
 - Set rad requirement to 0.2.0 and update factories and tests.  Add ``DarkRefModel``,
   ``GainRefModel``, and ``MaskRefModel``. [#11]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     psutil>=5.7.2
     numpy>=1.16
     astropy>=4.0
-    romanad==0.2.0
+    romanad==0.3.0
 package_dir =
     =src
 packages = find:

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -271,6 +271,9 @@ class DataModel:
 class ImageModel(DataModel):
     pass
 
+class RampModel(DataModel):
+    pass
+
 
 class FlatRefModel(DataModel):
     pass
@@ -317,6 +320,7 @@ def open(init, memmap=False, **kwargs):
 
 model_registry = {
     stnode.WfiImage: ImageModel,
+    stnode.Ramp: RampModel,
     stnode.FlatRef: FlatRefModel,
     stnode.DarkRef: DarkRefModel,
     stnode.GainRef: GainRefModel,

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -274,24 +274,25 @@ class ImageModel(DataModel):
 class RampModel(DataModel):
     pass
 
+class RampFitOutputModel(DataModel):
+    pass
 
 class FlatRefModel(DataModel):
     pass
 
-
 class DarkRefModel(DataModel):
     pass
-
 
 class GainRefModel(DataModel):
     pass
 
-
 class MaskRefModel(DataModel):
     pass
 
-
 class ReadnoiseRefModel(DataModel):
+    pass
+
+class WfiImgPhotomRefModel(DataModel):
     pass
 
 
@@ -321,9 +322,11 @@ def open(init, memmap=False, **kwargs):
 model_registry = {
     stnode.WfiImage: ImageModel,
     stnode.Ramp: RampModel,
+    stnode.Rampfitoutput: RampFitOutputModel,
     stnode.FlatRef: FlatRefModel,
     stnode.DarkRef: DarkRefModel,
     stnode.GainRef: GainRefModel,
     stnode.MaskRef: MaskRefModel,
     stnode.ReadnoiseRef: ReadnoiseRefModel,
+    stnode.WfiImgPhotomRef: WfiImgPhotomRefModel,
 }

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -322,7 +322,7 @@ def open(init, memmap=False, **kwargs):
 model_registry = {
     stnode.WfiImage: ImageModel,
     stnode.Ramp: RampModel,
-    stnode.Rampfitoutput: RampFitOutputModel,
+    stnode.RampFitOutput: RampFitOutputModel,
     stnode.FlatRef: FlatRefModel,
     stnode.DarkRef: DarkRefModel,
     stnode.GainRef: GainRefModel,

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -829,7 +829,7 @@ def create_ramp(**kwargs):
 
     return stnode.Ramp(raw)
 
-def create_rampfitoutput(**kwargs):
+def create_ramp_fit_output(**kwargs):
     """
     Create a dummy RampFitOutput instance with valid values for attributes
     required by the schema.
@@ -862,7 +862,7 @@ def create_rampfitoutput(**kwargs):
 
     print("In create_rampfitoutput ")
 
-    return stnode.Rampfitoutput(raw)
+    return stnode.RampFitOutput(raw)
 
 
 def create_target(**kwargs):

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -862,8 +862,6 @@ def create_ramp_fit_output(**kwargs):
     }
     raw.update(kwargs)
 
-    print("In create_rampfitoutput ")
-
     return stnode.RampFitOutput(raw)
 
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -543,12 +543,14 @@ def create_wfi_img_photom_ref(**kwargs):
     raw_dict = {
         "W146":
              {"photmjsr":(10 * np.random.random()),
-              "uncertainty":np.random.random()}
-
+              "uncertainty":np.random.random()},
+        "F184":
+            {"photmjsr": (10 * np.random.random()),
+             "uncertainty": np.random.random()}
     }
 
     raw = {
-        "phot_table": [raw_dict],
+        "phot_table": raw_dict,
         "meta": create_ref_meta(reftype="PHOTOM"),
     }
     raw.update(kwargs)

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -127,6 +127,12 @@ def _random_array_float32(size=(4096, 4096), min=None, max=None):
     array = np.random.default_rng().random(size=size, dtype=np.float32)
     return min + max * array - min * array
 
+def _random_array_uint8(size=(4096, 4096), min=None, max=None):
+    if min is None:
+        min = np.iinfo("uint8").min
+    if max is None:
+        max = np.iinfo("uint8").max
+    return np.random.randint(min, high=max, size=size, dtype=np.uint8)
 
 def _random_array_uint16(size=(4096, 4096), min=None, max=None):
     if min is None:
@@ -520,6 +526,35 @@ def create_readnoise_ref(**kwargs):
 
     return stnode.ReadnoiseRef(raw)
 
+def create_wfi_img_photom_ref(**kwargs):
+    """
+    Create a dummy WfiImgPhotomRef instance with valid values for attributes
+    required by the schema.
+
+    Parameters
+    ----------
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    roman_datamodels.stnode.WfiImgPhotomRef
+    """
+    raw_dict = {
+        "W146":
+             {"photmjsr":(10 * np.random.random()),
+              "uncertainty":np.random.random()}
+
+    }
+
+    raw = {
+        "phot_table": [raw_dict],
+        "meta": create_ref_meta(reftype="PHOTOM"),
+    }
+    raw.update(kwargs)
+
+    return stnode.WfiImgPhotomRef(raw)
+
 
 def create_guidestar(**kwargs):
     """
@@ -765,6 +800,69 @@ def create_program(**kwargs):
     raw.update(kwargs)
 
     return stnode.Program(raw)
+
+
+def create_ramp(**kwargs):
+    """
+    Create a dummy Ramp instance with valid values for attributes
+    required by the schema.
+
+    Parameters
+    ----------
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    roman_datamodels.stnode.Ramp
+    """
+
+    raw = {
+        "meta": create_meta(),
+        "data": _random_array_float32((4096, 4096, 8)),
+        "pixeldq": _random_array_uint32(),
+        "groupdq": _random_array_uint8((4096, 4096, 8)),
+        "err": _random_array_float32(min=0.0),
+        "refout": _random_array_float32((1024, 4096, 8)),
+    }
+    raw.update(kwargs)
+
+    return stnode.Ramp(raw)
+
+def create_rampfitoutput(**kwargs):
+    """
+    Create a dummy RampFitOutput instance with valid values for attributes
+    required by the schema.
+
+    Parameters
+    ----------
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    roman_datamodels.stnode.RampFitOutput
+    """
+
+    seg_shape = (4, 4096, 4096)
+
+    raw = {
+        "meta": create_meta(),
+        "slope": _random_array_float32(seg_shape),
+        "sigslope": _random_array_float32(seg_shape),
+        "yint": _random_array_float32(seg_shape),
+        "sigyint": _random_array_float32(seg_shape),
+        "pedestal": _random_array_float32(seg_shape),
+        "weights": _random_array_float32(seg_shape),
+        "crmag": _random_array_float32(seg_shape),
+        "var_poisson": _random_array_float32(seg_shape),
+        "var_rnoise": _random_array_float32(seg_shape),
+    }
+    raw.update(kwargs)
+
+    print("In create_rampfitoutput ")
+
+    return stnode.Rampfitoutput(raw)
 
 
 def create_target(**kwargs):


### PR DESCRIPTION
Added support and factories for the following models:
- Ramp
- Rampfitoutput
- WFIImgPhotom