### PR TITLE
point to released version of rad

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ install_requires =
     psutil>=5.7.2
     numpy>=1.16
     astropy>=4.0
-    # romanad>=0.4.0
-    romanad @ git+https://github.com/spacetelescope/rad.git@main
+    romanad>=0.5.0
+
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
I forgot to change setup.cfg and point to the latest released version of rad. This PR sets `romanad>=0.5.0`.
A new release will follow.