### PR TITLE
added ability to add attributes to datamodels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.6.0 (unreleased)
 ==================
 
+- Added ability to add attributes to datamodels [#33]
+
 0.5.2 (2021-08-26)
 ==================
 

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -184,7 +184,11 @@ class DataModel:
         if key.startswith('_'):
             raise ValueError(
                 'May not specify attributes/keys that start with _')
-        self._instance._data[key] = value
+        if hasattr(self._instance, key):
+            print('XXXXXX')
+            setattr(self._instance, key, value)
+        else:
+            self._instance._data[key] = value
 
     def to_flat_dict(self, include_arrays=True):
         """

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -185,7 +185,6 @@ class DataModel:
             raise ValueError(
                 'May not specify attributes/keys that start with _')
         if hasattr(self._instance, key):
-            print('XXXXXX')
             setattr(self._instance, key, value)
         else:
             self._instance._data[key] = value

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -19,6 +19,7 @@ from . import stnode
 from . import validate
 from . extensions import DATAMODEL_EXTENSIONS
 
+
 class DataModel:
     '''Base class for all top level datamodels'''
 
@@ -179,6 +180,9 @@ class DataModel:
     def __getattr__(self, attr):
         return getattr(self._instance, attr)
 
+    def __setitem__(self, key, value):
+        self._instance._data[key] = value
+
     def to_flat_dict(self, include_arrays=True):
         """
         Returns a dictionary of all of the model items as a flat dictionary.
@@ -270,29 +274,38 @@ class DataModel:
 class ImageModel(DataModel):
     pass
 
+
 class ScienceRawModel(DataModel):
     pass
+
 
 class RampModel(DataModel):
     pass
 
+
 class RampFitOutputModel(DataModel):
     pass
+
 
 class FlatRefModel(DataModel):
     pass
 
+
 class DarkRefModel(DataModel):
     pass
+
 
 class GainRefModel(DataModel):
     pass
 
+
 class MaskRefModel(DataModel):
     pass
 
+
 class ReadnoiseRefModel(DataModel):
     pass
+
 
 class WfiImgPhotomRefModel(DataModel):
     pass

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -181,6 +181,9 @@ class DataModel:
         return getattr(self._instance, attr)
 
     def __setitem__(self, key, value):
+        if key.startswith('_'):
+            raise ValueError(
+                'May not specify attributes/keys that start with _')
         self._instance._data[key] = value
 
     def to_flat_dict(self, include_arrays=True):

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -179,7 +179,7 @@ class DNode(UserDict):
                                     break
                     else:
                         schema = schema.get(key, None)
-                    if _validate(key, value, schema, self.ctx):
+                    if schema is None or _validate(key, value, schema, self.ctx):
                         self._data[key] = value
                 self.__dict__['_data'][key] = value
             else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -142,16 +142,17 @@ def test_flat_model(tmp_path):
 
 # Dark Current tests
 def test_make_dark():
-    dark = utils.mk_dark(shape=(3, 20,20))
+    dark = utils.mk_dark(shape=(3, 20, 20))
     assert dark.meta.reftype == 'DARK'
     assert dark.data.dtype == np.float32
     assert dark.dq.dtype == np.uint32
-    assert dark.dq.shape == (20,20)
+    assert dark.dq.shape == (20, 20)
     assert dark.err.dtype == np.float32
 
     # Test validation
     dark_model = datamodels.DarkRefModel(dark)
     assert dark_model.validate() is None
+
 
 def test_opening_dark_ref(tmp_path):
     # First make test reference file
@@ -162,14 +163,17 @@ def test_opening_dark_ref(tmp_path):
     assert isinstance(dark, datamodels.DarkRefModel)
 
 # Gain tests
+
+
 def test_make_gain():
-    gain = utils.mk_gain(shape=(20,20))
+    gain = utils.mk_gain(shape=(20, 20))
     assert gain.meta.reftype == 'GAIN'
     assert gain.data.dtype == np.float32
 
     # Test validation
     gain_model = datamodels.RampModel(gain)
     assert gain_model.validate() is None
+
 
 def test_opening_gain_ref(tmp_path):
     # First make test reference file
@@ -182,13 +186,14 @@ def test_opening_gain_ref(tmp_path):
 
 # Mask tests
 def test_make_mask():
-    mask = utils.mk_mask(shape=(20,20))
+    mask = utils.mk_mask(shape=(20, 20))
     assert mask.meta.reftype == 'MASK'
     assert mask.dq.dtype == np.uint32
 
     # Test validation
     mask_model = datamodels.RampModel(mask)
     assert mask_model.validate() is None
+
 
 def test_opening_mask_ref(tmp_path):
     # First make test reference file
@@ -201,13 +206,14 @@ def test_opening_mask_ref(tmp_path):
 
 # Read Noise tests
 def test_make_readnoise():
-    readnoise = utils.mk_readnoise(shape=(20,20))
+    readnoise = utils.mk_readnoise(shape=(20, 20))
     assert readnoise.meta.reftype == 'READNOISE'
     assert readnoise.data.dtype == np.float32
 
     # Test validation
     readnoise_model = datamodels.RampModel(readnoise)
     assert readnoise_model.validate() is None
+
 
 def test_opening_readnoise_ref(tmp_path):
     # First make test reference file
@@ -217,10 +223,13 @@ def test_opening_readnoise_ref(tmp_path):
     assert readnoise.meta.instrument.optical_element == 'F158'
     assert isinstance(readnoise, datamodels.ReadnoiseRefModel)
 
-def test_add_model_attribute(tmp_path):    
+
+def test_add_model_attribute(tmp_path):
     # First make test reference file
     file_path = tmp_path / 'testreadnoise.asdf'
     utils.mk_readnoise(filepath=file_path)
     readnoise = datamodels.open(file_path)
     readnoise['new_attribute'] = 77
     assert readnoise.new_attribute == 77
+    with pytest.raises(ValueError):
+        readnoise['_underscore'] = 'bad'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -233,3 +233,11 @@ def test_add_model_attribute(tmp_path):
     assert readnoise.new_attribute == 77
     with pytest.raises(ValueError):
         readnoise['_underscore'] = 'bad'
+    file_path2 = tmp_path / 'testreadnoise2.asdf'
+    readnoise.save(file_path2)
+    readnoise2 = datamodels.open(file_path2)
+    assert readnoise2.new_attribute == 77
+    readnoise2.new_attribute = 88
+    assert readnoise2.new_attribute == 88
+    with pytest.raises(ValidationError):
+        readnoise['data'] = 'bad_data_value'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -216,3 +216,11 @@ def test_opening_readnoise_ref(tmp_path):
     readnoise = datamodels.open(file_path)
     assert readnoise.meta.instrument.optical_element == 'F158'
     assert isinstance(readnoise, datamodels.ReadnoiseRefModel)
+
+def test_add_model_attribute(tmp_path):    
+    # First make test reference file
+    file_path = tmp_path / 'testreadnoise.asdf'
+    utils.mk_readnoise(filepath=file_path)
+    readnoise = datamodels.open(file_path)
+    readnoise['new_attribute'] = 77
+    assert readnoise.new_attribute == 77


### PR DESCRIPTION
Added the ability to add attributes to datamodels (using the same mechanism as for TaggedObjectNodes, i.e., by using dictionary indices).

Closes [#32]