### PR TITLE
Validate if the tag type in the file does not match the class used to open the file

### DIFF
--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -40,7 +40,7 @@ class DataModel:
             asdffile = self.open_asdf(init, **kwargs)
             if not self.check_type(asdffile):
                 raise ValueError(
-                    f'ASDF file is not of the type expected. Expected {self.__class__.___name__}')
+                    f'ASDF file is not of the type expected. Expected {self.__class__.__name__}')
             self._instance = asdffile.tree['roman']
         elif isinstance(init, asdf.AsdfFile):
             asdffile = init
@@ -59,6 +59,18 @@ class DataModel:
         '''
         Subclass is expected to check for proper type of node
         '''
+        if 'roman' not in asdffile_instance.tree:
+            raise ValueError(
+                'ASDF file does not have expected "roman" attribute')
+        topnode = asdffile_instance.tree['roman']
+        if model_registry[topnode.__class__] != self.__class__:
+            # First check to see if there is a casting function
+            if topnode.__class__ not in casting_registry:
+                return False
+            casting_functions = casting_registry[topnode.__class__]
+            if self.__class__ not in casting_functions:
+                return False
+            casting_functions[self.__class__](self)
         return True
 
     @property
@@ -348,4 +360,13 @@ model_registry = {
     stnode.MaskRef: MaskRefModel,
     stnode.ReadnoiseRef: ReadnoiseRefModel,
     stnode.WfiImgPhotomRef: WfiImgPhotomRefModel,
+}
+
+
+def scienceraw_to_ramp(scienceraw_instance):
+    pass
+
+
+casting_registry = {
+    stnode.WfiScienceRaw: {RampModel: scienceraw_to_ramp}
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -233,3 +233,14 @@ def test_add_model_attribute(tmp_path):
     assert readnoise.new_attribute == 77
     with pytest.raises(ValueError):
         readnoise['_underscore'] = 'bad'
+
+
+def test_open_with_model_class(tmp_path):
+    # First make test reference file
+    file_path = tmp_path / 'testreadnoise.asdf'
+    utils.mk_readnoise(filepath=file_path)
+    rnmod = datamodels.ReadnoiseRefModel(file_path)
+    assert rnmod.meta.reftype == "READNOISE"
+    assert rnmod.data.shape == (4096, 4224)
+    with pytest.raises(ValueError):
+        wrongmod = datamodels.RampModel(file_path)


### PR DESCRIPTION
The changes here address issue #34. Now if this happens, a ValueError is raised.

Note that this does not use the normal validation machinery but instead explicitly compares the class types. Is there a good reason to do it otherwise?