### PR TITLE
RCAL-223 Update RDM for 2D Ramp Pedestal Array and Misc

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@
 - Added ability to add attributes to datamodels [#33]
 
 - Added support for Saturation reference files. [#37]
-  
+
+- Update Ramp Pedestal Array to 2D. Fixed reference model casting in test_models. [#38]
 
 0.5.2 (2021-08-26)
 ==================

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -856,7 +856,7 @@ def create_ramp_fit_output(**kwargs):
         "sigslope": _random_array_float32(seg_shape),
         "yint": _random_array_float32(seg_shape),
         "sigyint": _random_array_float32(seg_shape),
-        "pedestal": _random_array_float32(seg_shape),
+        "pedestal": _random_array_float32(seg_shape[1:]),
         "weights": _random_array_float32(seg_shape),
         "crmag": _random_array_float32(seg_shape),
         "var_poisson": _random_array_float32(seg_shape),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -171,7 +171,7 @@ def test_make_gain():
     assert gain.data.dtype == np.float32
 
     # Test validation
-    gain_model = datamodels.RampModel(gain)
+    gain_model = datamodels.GainRefModel(gain)
     assert gain_model.validate() is None
 
 
@@ -191,7 +191,7 @@ def test_make_mask():
     assert mask.dq.dtype == np.uint32
 
     # Test validation
-    mask_model = datamodels.RampModel(mask)
+    mask_model = datamodels.MaskRefModel(mask)
     assert mask_model.validate() is None
 
 
@@ -211,7 +211,7 @@ def test_make_readnoise():
     assert readnoise.data.dtype == np.float32
 
     # Test validation
-    readnoise_model = datamodels.RampModel(readnoise)
+    readnoise_model = datamodels.ReadnoiseRefModel(readnoise)
     assert readnoise_model.validate() is None
 
 


### PR DESCRIPTION
Update Ramp Pedestal Array to 2D. Fixed reference model casting in test_models.

Test failures are expected as RDM is behind RAD in updates.