### PR TITLE
RCAL-206 Implement Nonlinearity RDM Support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Update Ramp Pedestal Array to 2D. Fixed reference model casting in test_models. [#38]
 
+- Implemented support and tests for linearity reference model. Corrected dimension order in factories. Added primary array definition to MaskRefModel. [#39]
+
+  
 0.5.2 (2021-08-26)
 ==================
 

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -304,9 +304,25 @@ class DarkRefModel(DataModel):
 class GainRefModel(DataModel):
     pass
 
+class LinearityRefModel(DataModel):
+    def get_primary_array_name(self):
+        """
+        Returns the name "primary" array for this model, which
+        controls the size of other arrays that are implicitly created.
+        This is intended to be overridden in the subclasses if the
+        primary array's name is not "data".
+        """
+        return 'coeffs'
 
 class MaskRefModel(DataModel):
-    pass
+    def get_primary_array_name(self):
+        """
+        Returns the name "primary" array for this model, which
+        controls the size of other arrays that are implicitly created.
+        This is intended to be overridden in the subclasses if the
+        primary array's name is not "data".
+        """
+        return 'dq'
 
 
 class ReadnoiseRefModel(DataModel):
@@ -350,6 +366,7 @@ model_registry = {
     stnode.FlatRef: FlatRefModel,
     stnode.DarkRef: DarkRefModel,
     stnode.GainRef: GainRefModel,
+    stnode.LinearityRef: LinearityRefModel,
     stnode.MaskRef: MaskRefModel,
     stnode.ReadnoiseRef: ReadnoiseRefModel,
     stnode.SaturationRef: SaturationRefModel,

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -428,9 +428,9 @@ def create_dark_ref(**kwargs):
     roman_datamodels.stnode.DarkRef
     """
     raw = {
-        "data": _random_array_float32((4096, 4096, 1)),
+        "data": _random_array_float32((2, 4096, 4096)),
         "dq": _random_array_uint32(),
-        "err": _random_array_float32((4096, 4096, 1)),
+        "err": _random_array_float32((2, 4096, 4096)),
         "meta": create_ref_meta(reftype="DARK"),
     }
     raw.update(kwargs)
@@ -459,6 +459,29 @@ def create_gain_ref(**kwargs):
     raw.update(kwargs)
 
     return stnode.GainRef(raw)
+
+def create_linearity_ref(**kwargs):
+    """
+    Create a dummy LinearityRef instance with valid values for attributes
+    required by the schema.
+
+    Parameters
+    ----------
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    roman_datamodels.stnode.LinearityRef
+    """
+    raw = {
+        "coeffs": _random_array_float32((2, 4096, 4096)),
+        "dq": _random_array_uint32((4096, 4096)),
+        "meta": create_ref_meta(reftype="LINEARITY"),
+    }
+    raw.update(kwargs)
+
+    return stnode.LinearityRef(raw)
 
 
 def create_mask_ref(**kwargs):
@@ -824,9 +847,9 @@ def create_ramp(**kwargs):
 
     raw = {
         "meta": create_meta(),
-        "data": _random_array_float32((4096, 4096, 8)),
+        "data": _random_array_float32((2, 4096, 4096)),
         "pixeldq": _random_array_uint32(),
-        "groupdq": _random_array_uint8((4096, 4096, 8)),
+        "groupdq": _random_array_uint8((2, 4096, 4096)),
         "err": _random_array_float32(min=0.0),
     }
     raw.update(kwargs)
@@ -848,7 +871,7 @@ def create_ramp_fit_output(**kwargs):
     roman_datamodels.stnode.RampFitOutput
     """
 
-    seg_shape = (4, 4096, 4096)
+    seg_shape = (2, 4096, 4096)
 
     raw = {
         "meta": create_meta(),
@@ -1055,7 +1078,7 @@ def create_wfi_science_raw(**kwargs):
     """
     raw = {
         # TODO: What should this shape be?
-        "data": _random_array_uint16((8, 4096, 4096)),
+        "data": _random_array_uint16((2, 4096, 4096)),
         "meta": create_meta(),
     }
     raw.update(kwargs)

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -395,6 +395,27 @@ def mk_gain(shape=None, filepath=None):
     else:
         return gainref
 
+def mk_linearity(shape=None, filepath=None):
+    meta = {}
+    add_ref_common(meta)
+    linearityref = stnode.LinearityRef()
+    meta['reftype'] = 'LINEARITY'
+    linearityref['meta'] = meta
+
+    if shape:
+        linearityref['coeffs'] = np.zeros(shape, dtype=np.float32)
+        linearityref['dq'] = np.zeros(shape[1:], dtype=np.uint32)
+    else:
+        linearityref['coeffs'] = np.zeros((2, 4096, 4224), dtype=np.float32)
+        linearityref['dq'] = np.zeros((4096, 4096), dtype=np.uint32)
+
+    if filepath:
+        af = asdf.AsdfFile()
+        af.tree = {'roman': linearityref}
+        af.write_to(filepath)
+    else:
+        return linearityref
+
 
 def mk_mask(shape=None, filepath=None):
     meta = {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -163,8 +163,6 @@ def test_opening_dark_ref(tmp_path):
     assert isinstance(dark, datamodels.DarkRefModel)
 
 # Gain tests
-
-
 def test_make_gain():
     gain = utils.mk_gain(shape=(20, 20))
     assert gain.meta.reftype == 'GAIN'
@@ -182,6 +180,28 @@ def test_opening_gain_ref(tmp_path):
     gain = datamodels.open(file_path)
     assert gain.meta.instrument.optical_element == 'F158'
     assert isinstance(gain, datamodels.GainRefModel)
+
+
+# Linearity tests
+def test_make_linearity():
+    linearity = utils.mk_linearity(shape=(2, 20, 20))
+    assert linearity.meta.reftype == 'LINEARITY'
+    assert linearity.coeffs.dtype == np.float32
+    assert linearity.dq.dtype == np.uint32
+
+    # Test validation
+    linearity_model = datamodels.LinearityRefModel(linearity)
+    assert linearity_model.validate() is None
+
+
+def test_opening_linearity_ref(tmp_path):
+    # First make test reference file
+    file_path = tmp_path / 'testlinearity.asdf'
+    utils.mk_linearity(filepath=file_path)
+    linearity = datamodels.open(file_path)
+    assert linearity.meta.instrument.optical_element == 'F158'
+    assert isinstance(linearity, datamodels.LinearityRefModel)
+
 
 
 # Mask tests


### PR DESCRIPTION
Implemented support and tests for linearity reference model. 
Corrected dimension order in factories. 
Added primary array definition to MaskRefModel.

NOTE: Test fails are expected as RDM is behind RAD in developments. 