### PR TITLE
RCAL-203 Implement Pixel Area RDM Support

### DIFF
--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -324,6 +324,8 @@ class MaskRefModel(DataModel):
         """
         return 'dq'
 
+class PixelareaRefModel(DataModel):
+    pass
 
 class ReadnoiseRefModel(DataModel):
     pass
@@ -368,6 +370,7 @@ model_registry = {
     stnode.GainRef: GainRefModel,
     stnode.LinearityRef: LinearityRefModel,
     stnode.MaskRef: MaskRefModel,
+    stnode.PixelareaRef: PixelareaRefModel,
     stnode.ReadnoiseRef: ReadnoiseRefModel,
     stnode.SaturationRef: SaturationRefModel,
     stnode.WfiImgPhotomRef: WfiImgPhotomRefModel,

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -512,6 +512,31 @@ def create_mask_ref(**kwargs):
 
     return stnode.MaskRef(raw)
 
+def create_pixelarea_ref(**kwargs):
+    """
+    Create a dummy PixelareaRef instance with valid values for attributes
+    required by the schema.
+
+    Parameters
+    ----------
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    roman_datamodels.stnode.PixelareaRef
+    """
+    raw = {
+        "data": _random_array_float32((4096, 4096)),
+        "meta": create_ref_meta(reftype="AREA"),
+    }
+    raw['meta']['photometry'] = {
+        'pixelarea_steradians': _random_positive_float(),
+        'pixelarea_arcsecsq': _random_positive_float(),
+    }
+    raw.update(kwargs)
+
+    return stnode.PixelareaRef(raw)
 
 def create_readnoise_ref(**kwargs):
     """

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -439,6 +439,28 @@ def mk_mask(shape=None, filepath=None):
     else:
         return maskref
 
+def mk_pixelarea(shape=None, filepath=None):
+    meta = {}
+    add_ref_common(meta)
+    pixelarearef = stnode.PixelareaRef()
+    meta['reftype'] = 'AREA'
+    meta['photometry'] = {
+        'pixelarea_steradians': float(NONUM),
+        'pixelarea_arcsecsq': float(NONUM),
+    }
+    pixelarearef['meta'] = meta
+
+    if shape:
+        pixelarearef['data'] = np.zeros(shape, dtype=np.float32)
+    else:
+        pixelarearef['data'] = np.zeros((4096, 4096), dtype=np.float32)
+
+    if filepath:
+        af = asdf.AsdfFile()
+        af.tree = {'roman': pixelarearef}
+        af.write_to(filepath)
+    else:
+        return pixelarearef
 
 def mk_readnoise(shape=None, filepath=None):
     meta = {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -223,6 +223,26 @@ def test_opening_mask_ref(tmp_path):
     assert mask.meta.instrument.optical_element == 'F158'
     assert isinstance(mask, datamodels.MaskRefModel)
 
+# Pixel Area tests
+def test_make_pixelarea():
+    pixearea = utils.mk_pixelarea(shape=(20, 20))
+    assert pixearea.meta.reftype == 'AREA'
+    assert type(pixearea.meta.photometry.pixelarea_steradians) == float
+    assert type(pixearea.meta.photometry.pixelarea_arcsecsq) == float
+    assert pixearea.data.dtype == np.float32
+
+    # Test validation
+    pixearea_model = datamodels.PixelareaRefModel(pixearea)
+    assert pixearea_model.validate() is None
+
+
+def test_opening_pixelarea_ref(tmp_path):
+    # First make test reference file
+    file_path = tmp_path / 'testpixelarea.asdf'
+    utils.mk_pixelarea(filepath=file_path)
+    pixelarea = datamodels.open(file_path)
+    assert pixelarea.meta.instrument.optical_element == 'F158'
+    assert isinstance(pixelarea, datamodels.PixelareaRefModel)
 
 # Read Noise tests
 def test_make_readnoise():


### PR DESCRIPTION
Implemented datamodel support for pixel area reference files in roman_datamodels. 

Created maker utility for the data model.

Created tests for the maker utility.

Test failures are expected until RDM catches up to RAD.