### PR TITLE
Modify open function to allow target argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 - Modified open function to handle accepting model instances that are checked
   against a target datamodel class, whether supplied directly as a model instance,
-  or obtained by the referenced ASDF file. [xxx]
+  or obtained by the referenced ASDF file. [#52]
 
 - Created maker utility and tests for ramp_fit_output files. [#50]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Added ability to add attributes to datamodels [#33]
 
+- Added check to ensure opening a Roman file with datamodel class
+  that doesn't match the class implied by the tag raises an exception.
+
 0.5.2 (2021-08-26)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 0.7.0 (unreleased)
 ==================
 
+- Modified open function to handle accepting model instances that are checked
+  against a target datamodel class, whether supplied directly as a model instance,
+  or obtained by the referenced ASDF file. [xxx]
+
 - Created maker utility and tests for ramp_fit_output files. [#50]
 
 0.6.0 (2021-10-26)

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -364,7 +364,7 @@ def open(init, memmap=False, target=None, **kwargs):
             - AsdfFile instance
             - string indicating the path to an ASDF file
             - Roman data model instance
-    memmap : bool 
+    memmap : bool
         Open ASDF file binary data using memmap (default: False)
     target : DataModel class
         If not None value, the DataModel implied by the init argument

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -40,7 +40,7 @@ class DataModel:
             asdffile = self.open_asdf(init, **kwargs)
             if not self.check_type(asdffile):
                 raise ValueError(
-                    f'ASDF file is not of the type expected. Expected {self.__class__.___name__}')
+                    f'ASDF file is not of the type expected. Expected {self.__class__.__name__}')
             self._instance = asdffile.tree['roman']
         elif isinstance(init, asdf.AsdfFile):
             asdffile = init
@@ -59,6 +59,18 @@ class DataModel:
         '''
         Subclass is expected to check for proper type of node
         '''
+        if 'roman' not in asdffile_instance.tree:
+            raise ValueError(
+                'ASDF file does not have expected "roman" attribute')
+        topnode = asdffile_instance.tree['roman']
+        if model_registry[topnode.__class__] != self.__class__:
+            # First check to see if there is a casting function
+            if topnode.__class__ not in casting_registry:
+                return False
+            casting_functions = casting_registry[topnode.__class__]
+            if self.__class__ not in casting_functions:
+                return False
+            casting_functions[self.__class__](self)
         return True
 
     @property
@@ -348,4 +360,13 @@ model_registry = {
     stnode.MaskRef: MaskRefModel,
     stnode.ReadnoiseRef: ReadnoiseRefModel,
     stnode.WfiImgPhotomRef: WfiImgPhotomRefModel,
+}
+
+
+def scienceraw_to_ramp(scienceraw_instance):
+    pass
+
+
+casting_registry = {
+    stnode.WfiScienceRaw: {RampModel: scienceraw_to_ramp}
 }

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -310,6 +310,7 @@ class DarkRefModel(DataModel):
 class GainRefModel(DataModel):
     pass
 
+
 class LinearityRefModel(DataModel):
     def get_primary_array_name(self):
         """
@@ -319,6 +320,7 @@ class LinearityRefModel(DataModel):
         primary array's name is not "data".
         """
         return 'coeffs'
+
 
 class MaskRefModel(DataModel):
     def get_primary_array_name(self):
@@ -330,29 +332,66 @@ class MaskRefModel(DataModel):
         """
         return 'dq'
 
+
 class PixelareaRefModel(DataModel):
     pass
+
 
 class ReadnoiseRefModel(DataModel):
     pass
 
+
 class SuperbiasRefModel(DataModel):
     pass
 
+
 class SaturationRefModel(DataModel):
     pass
+
 
 class WfiImgPhotomRefModel(DataModel):
     pass
 
 
-def open(init, memmap=False, **kwargs):
+def open(init, memmap=False, target=None, **kwargs):
+    """
+    Data model factory function
+
+    Parameters
+    ----------
+    init :
+        May be any one of the following types:
+            - AsdfFile instance
+            - string indicating the path to an ASDF file
+            - Roman data model instance
+    memmap : bool 
+        Open ASDF file binary data using memmap (default: False)
+    target : DataModel class
+        If not None value, the DataModel implied by the init argument
+        must be an instance of the target class. If the init value
+        is already a data model, and matches the target, the init
+        value is returned, not copied, as opposed to the case where
+        the init value is a data model, and target is not supplied,
+        and the returned value is a copy of the init value.
+
+    Returns
+    -------
+    Roman DataModel instance
+    """
+    if target is not None:
+        if not issubclass(target, DataModel):
+            raise ValueError("Target must be a subclass of DataModel")
     # Temp fix to catch JWST args defore being passed to asdf open
     if "asn_n_members" in kwargs:
         del kwargs["asn_n_members"]
     if isinstance(init, asdf.AsdfFile):
         asdffile = init
     elif isinstance(init, DataModel):
+        if target is not None:
+            if not isinstance(init, target):
+                raise ValueError("First argument is not an instance of target")
+            else:
+                return init
         # Copy the object so it knows not to close here
         return init.copy()
     else:
@@ -367,7 +406,13 @@ def open(init, memmap=False, **kwargs):
                 "Roman datamodels does not accept FITS files or objects")
     modeltype = type(asdffile.tree['roman'])
     if modeltype in model_registry:
-        return model_registry[modeltype](asdffile, **kwargs)
+        rmodel = model_registry[modeltype](asdffile, **kwargs)
+        if target is not None:
+            if not issubclass(rmodel.__class__, target):
+                raise ValueError(
+                    "Referenced ASDF file model type is not subclass of target")
+        else:
+            return rmodel
     else:
         return DataModel(asdffile, **kwargs)
 

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -64,13 +64,7 @@ class DataModel:
                 'ASDF file does not have expected "roman" attribute')
         topnode = asdffile_instance.tree['roman']
         if model_registry[topnode.__class__] != self.__class__:
-            # First check to see if there is a casting function
-            if topnode.__class__ not in casting_registry:
-                return False
-            casting_functions = casting_registry[topnode.__class__]
-            if self.__class__ not in casting_functions:
-                return False
-            casting_functions[self.__class__](self)
+            return False
         return True
 
     @property
@@ -363,13 +357,4 @@ model_registry = {
     stnode.MaskRef: MaskRefModel,
     stnode.ReadnoiseRef: ReadnoiseRefModel,
     stnode.WfiImgPhotomRef: WfiImgPhotomRefModel,
-}
-
-
-def scienceraw_to_ramp(scienceraw_instance):
-    pass
-
-
-casting_registry = {
-    stnode.WfiScienceRaw: {RampModel: scienceraw_to_ramp}
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -233,3 +233,14 @@ def test_add_model_attribute(tmp_path):
     assert readnoise.new_attribute == 77
     with pytest.raises(ValueError):
         readnoise['_underscore'] = 'bad'
+
+
+def test_open_with_model_class(tmp_path):
+    # First make test reference file
+    file_path = tmp_path / 'testreadnoise.asdf'
+    utils.mk_readnoise(filepath=file_path)
+    rnmod = datamodels.ReadnoiseRefModel(file_path)
+    assert rnmod.meta.reftype == "READNOISE"
+    assert rnmod.data.shape == (4096, 4224)
+    with pytest.raises(ValueError):
+        wrongmod = datamodels.RampModel(file_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -399,3 +399,20 @@ def test_open_with_model_class(tmp_path):
     assert rnmod.data.shape == (4096, 4224)
     with pytest.raises(ValueError):
         datamodels.RampModel(file_path)
+
+
+def test_open_with_target(tmp_path):
+    file_path = tmp_path / 'testreadnoise.asdf'
+    utils.mk_readnoise(filepath=file_path)
+    rnmod = datamodels.ReadnoiseRefModel(file_path)
+    rnmod2 = datamodels.open(rnmod, target=datamodels.ReadnoiseRefModel)
+    assert rnmod is rnmod2
+    rnmod3 = datamodels.open(rnmod)
+    assert rnmod3 is not rnmod
+    with pytest.raises(ValueError):
+        rnmod4 = datamodels.open(rnmod, target=datamodels.WfiImgPhotomRefModel)
+    with pytest.raises(ValueError):
+        rnmod5 = datamodels.open(
+            file_path, target=datamodels.WfiImgPhotomRefModel)
+    with pytest.raises((ValueError, TypeError)):
+        rnmod6 = datamodels.open(file_path, target='bullseye')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -410,9 +410,9 @@ def test_open_with_target(tmp_path):
     rnmod3 = datamodels.open(rnmod)
     assert rnmod3 is not rnmod
     with pytest.raises(ValueError):
-        rnmod4 = datamodels.open(rnmod, target=datamodels.WfiImgPhotomRefModel)
+        datamodels.open(rnmod, target=datamodels.WfiImgPhotomRefModel)
     with pytest.raises(ValueError):
-        rnmod5 = datamodels.open(
+        datamodels.open(
             file_path, target=datamodels.WfiImgPhotomRefModel)
     with pytest.raises((ValueError, TypeError)):
-        rnmod6 = datamodels.open(file_path, target='bullseye')
+        datamodels.open(file_path, target='bullseye')


### PR DESCRIPTION
This addresses #51.

Instead of changing the constructor behavior, it was deemed much simpler to add this functionality to the `open` function, by use of the `target` argument. When a value is present, it is expected to be a `DataModel` class (not instance) and when provided a `DataModel` instance, it checks to see that instance is an instance of the target class. If a file path is provided, it opens the ASDF file and then checks to see if the `DataModel` corresponding to the ASDF file matches that of the target. In the case of the first argument being a `DataModel` instance, that instance is returned, rather than copied (unlike what happens when the constructor for that class is provided an instance, in which case a copy is made).

Also, the `open` function now has a more standard docstring.