### PR TITLE
First version of models.rst of roman_datamodels docs (RCAL-262)

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,0 +1,290 @@
+.. _datamodels:
+
+About models
+============
+
+The purpose of the data model is to abstract away the peculiarities of
+the underlying file format.  The same data model may be used for data
+created from scratch in memory, or loaded from ASDF files.
+
+
+Hierarchy of models
+-------------------
+
+There are different data model classes for different kinds of data.
+
+One model instance, many arrays
+-------------------------------
+
+Each model instance generally has many arrays that are associated with
+it.  For example, the `ImageModel` class has the following arrays
+associated with it:
+
+    - `data`: The science data
+    - `pixeldq`: The 2D data quality array
+    - `grpupdq`: The 3D data quality array
+    - `err`: The error array
+
+The shape of these arrays must be broadcast-compatible.  If you try to
+assign an array to one of these members that is not
+broadcast-compatible with the data array, an exception is raised.
+
+Working with models
+===================
+
+Creating a data model from scratch
+----------------------------------
+
+To create a new `WfiImageModel`, just call its constructor. Then populate
+arrays of the new model:
+ 
+    import roman_datamodels.stnode as rds
+    wfi_image = rds.WfiImage()    
+    wfi_image['data'] = np.ones((4096, 4096), dtype=np.float32)
+    wfi_image['dq'] = np.zeros((4096, 4096), dtype=np.uint32)
+    ...
+
+The meta attributes can also be populated:
+
+    meta = {}
+    meta['filename'] = "test.asdf" 
+    ...
+
+The meta attributes can be attached to the new model:
+
+    wfi_image['meta'] = meta
+    
+	
+Creating a data model from a file
+---------------------------------
+The `roman_datamodels.datamodels.open` function is a convenient way to create a
+model from a file on disk, by passing it a path to an ASDF file.    
+
+The file will be opened, and based on the nature of the data in the
+file, the correct data model class will be returned.  For example, if
+the file contains 3-dimensional data, a `RampModel` instance will be
+returned.  You will generally want to instantiate a model using a
+`with` statement so that the file will be closed automatically when
+exiting the `with` block.
+
+    with roman_datamodels.open("myimage.asdf") as im:
+        assert isinstance(im, rdd.RampModel)
+
+If you know the type of data stored in the file, or you want to ensure that
+what is being loaded is of a particular type, use the constructor of the
+desired concrete class. For example, if you want to ensure that the file being
+opened contains 3-dimensional image data:
+
+    from roman_datamodels.datmodels import RampModel
+    with RampModel("myimage.asdf") as im:
+        # raisese exception if myimage.asdf is not a ramp input file
+        pass
+
+This will raise an exception if the file contains data of the wrong shape.
+
+
+Saving a data model to a file
+-----------------------------
+
+Simply call the `save` method on the model instance.  The format to
+save into will either be deduced from the filename (if provided) or
+the `format` keyword argument::
+
+    im.save("myimage.asdf")
+
+.. note::
+
+   Unlike ``astropy.io.fits``, `save` always clobbers the output file.
+
+
+Copying a model
+---------------
+
+To create a new model based on another model, simply use its `copy`
+method.  This will perform a deep-copy: that is, no changes to the
+original model will propagate to the new model::
+
+    new_model = old_model.copy()
+
+
+Looking at the contents of a model
+----------------------------------
+
+Use ``model.info()`` to look at the contents of a data model. It renders
+the underlying ASDF tree starting at the root or a specified ``node``.
+The number of displayed rows is controlled by the ``max_rows`` argument::
+
+  im.info()
+  root.tree (AsdfObject)
+  ├─asdf_library (Software)
+  │ ├─author (str): Space Telescope Science Institute
+  │ ├─homepage (str): http://github.com/spacetelescope/asdf
+  │ ├─name (str): asdf
+  │ └─version (str): 2.5.2a1.dev12+g12aa460
+  ├─history (dict)
+  │ └─extensions (list) ...
+  ├─data (ndarray): shape=(2048, 2048), dtype=float32
+  ├─dq (ndarray): shape=(2048, 2048), dtype=uint32
+  ├─err (ndarray): shape=(2048, 2048), dtype=float32
+  ├─meta (dict)
+  │ ├─aperture (dict) ...
+  │ ├─bunit_data (str): DN/s
+  │ ├─bunit_err (str): DN/s
+  │ ├─cal_step (dict) ...
+  │ ├─calibration_software_revision (str): 3bfd782b
+  │ ├─calibration_software_version (str): 0.14.3a1.dev133+g3bfd782b.d20200216
+  │ ├─coordinates (dict) ...
+  │ └─28 not shown
+  ├─var_poisson (ndarray): shape=(2048, 2048), dtype=float32
+  ├─var_rnoise (ndarray): shape=(2048, 2048), dtype=float32
+  └─extra_fits (dict) ...
+  Some nodes not shown.
+
+
+Searching a model
+-----------------
+
+``model.search()`` can be used to search the ASDF tree by ``key`` or
+``value``::
+
+  im.search(key='optical_element')
+
+  root.tree (AsdfObject)
+  └─meta (dict)
+  └─instrument (dict)
+    └─optical_element (str): F158
+
+
+  im.search(value='ROMAN')
+
+  root (AsdfObject)
+  └─meta (dict)
+    └─telescope (str): ROMAN
+
+
+Converting from ``astropy.io.fits``  # This section still TBD
+===================================
+
+This section describes how to port code that uses ``astropy.io.fits``
+to use `roman.roman_datamodels`.
+
+Opening a file  # This section still TBD
+--------------
+
+Instead of::
+
+    astropy.io.fits.open("myfile.fits")
+
+use::
+
+    from jwst.datamodels import ImageModel
+    with ImageModel("myfile.fits") as model:
+        ...
+
+In place of `ImageModel`, use the type of data one expects to find in
+the file.  For example, if spectrographic data is expected, use
+`SpecModel`.  If it doesn't matter (perhaps the application is only
+sorting FITS files into categories) use the base class `DataModel`.
+
+An alternative is to use::
+
+    from jwst import datamodels
+    with datamodels.open("myfile.fits") as model:
+        ...
+
+The `datamodels.open()` method checks if the `DATAMODL` FITS keyword has
+been set, which records the DataModel that was used to create the file.
+If the keyword is not set, then `datamodels.open()` does its best to
+guess the best DataModel to use.
+
+    
+Accessing data
+--------------
+
+Data should be accessed through one of the pre-defined data members on
+the model (`data`, `dq`, `err`), such as ::
+
+    model.data
+
+Accessing keywords
+------------------
+
+The data model hides direct access to metadata attributes.
+
+There is a convenience method, `find_fits_keyword` to find where a
+the attribute is used in the metadata tree, use::
+
+    print(model.meta.exposure.mid_time)
+
+
+Extra FITS keywords  # This section still TBD
+-------------------
+
+When loading arbitrary FITS files, there may be keywords that are not
+listed in the schema for that data model.  These "extra" FITS keywords
+are put under the model in the `_extra_fits` namespace.
+
+Under the `_extra_fits` namespace is a section for each header data
+unit, and under those are the extra FITS keywords.  For example, if
+the FITS file contains a keyword `FOO` in the primary header, its
+value can be obtained using::
+
+    model._extra_fits.PRIMARY.FOO
+
+This feature is useful to retain any extra keywords from input files
+to output products.
+
+To get a list of everything in `_extra_fits`::
+
+    model._extra_fits._instance
+
+returns a dictionary of of the instance at the model._extra_fits node.
+
+`_instance` can be used at any node in the tree to return a dictionary
+of rest of the tree structure at that node.
+   
+
+Environmental Variables
+-----------------------
+
+There are a number of environmental variables that affect how models are read.
+
+PASS_INVALID_VALUES
+  Used by `~roman.roman_datamodels.DataModel` when instantiating
+  a model from a file. If ``True``, values that do not validate the schema will
+  still be added to the metadata. If ``False``, they will be set to ``None``.
+  Default is ``False``.
+
+STRICT_VALIDATION
+  Used by `~roman.roman_datamodels.DataModel` when instantiating a model from a file.
+  If ``True``, schema validation errors will generate an exception.
+  If ``False``, they will generate a warning.
+  Default is ``False``.
+
+SKIP_FITS_UPDATE
+  Used by `~roman.roman_datamodels.DataModel` when instantiating a
+  model from a FITS file. When ``False``, models opened from FITS files will
+  proceed and load the FITS header values into the model. When ``True`` and the
+  FITS file has an ASDF extension, the loading/validation of the FITS header
+  will be skipped, loading the model only from the ASDF extension. If not
+  defined, the instantiation routines will determine whether the loading/validation
+  of the FITS header can be skipped or not.
+
+VALIDATE_ON_ASSIGNMENT
+  Used by `~roman.roman_datamodels.DataModel` when instantiating a model from a file.
+  If 'True', attribute assignments are validated at the time of assignment.
+  Validation errors generate warnings and values will be set to `None`.
+  If 'False', schema validation occurs only once at the time of write.
+  If `None`, value will be taken from the environmental VALIDATE_ON_ASSIGNMENT,
+  defaulting to 'True' if  no environment variable is set.     
+  Validation errors generate warnings. Default is 'None'.
+
+  
+For flag or boolean variables, any value in ``('true', 't', 'yes', 'y')`` or a
+non-zero number, will evaluate as ``True``. Any value in ``('false', 'f', 'no',
+'n', '0')`` will evaluate as ``False``. The values are case-insensitive.
+
+All of the environmental variables have equivalent function arguments in the API
+for the relevant code. The environment variables are used only if explicit
+values had not been used in a script. In other words, values in code override
+environmental variables.


### PR DESCRIPTION
First version of models.rst - 1 of the 6 rst files for the roman_datamodels doc (epic RCAL-248). 