### PR TITLE
added asdf info method introspection for DNode an LNode classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 
 - Updated stnode tests to include all cal steps. [#60]
 
+- Fix bug with asdf 2.9.x due to change in private variable name. [#63]
 
 0.8.0 (2021-11-22)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@
 0.7.0 (2021-11-10)
 ==================
 
+- Modified DNode and LNode classes to provide asdf info method introspection
+  into the contents of the class. []
+
 - Modified open function to handle accepting model instances that are checked
   against a target datamodel class, whether supplied directly as a model instance,
   or obtained by the referenced ASDF file. [#52]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@
 ==================
 
 - Modified DNode and LNode classes to provide asdf info method introspection
-  into the contents of the class. []
+  into the contents of the class. [#61]
 
 - Modified open function to handle accepting model instances that are checked
   against a target datamodel class, whether supplied directly as a model instance,

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     jsonschema>=3.0.2
-    asdf>=2.8.0
+    asdf>=2.9.1
     psutil>=5.7.2
     numpy>=1.16
     astropy>=4.0

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -276,11 +276,11 @@ class DataModel:
         validate.value_change(self._instance, pass_invalid_values=False,
                               strict_validation=True)
 
-    # def __getitem__(self, key):
-    #   assert isinstance(key, str)
+    def info(self, *args, **kwargs):
+        return self._asdf.info(*args, **kwargs)
 
-    # def __setitem__(self, key, value):
-    #   pass
+    def search(self, *args, **kwargs):
+        return self._asdf.search(*args, **kwargs)
 
 
 class ImageModel(DataModel):

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -224,7 +224,7 @@ class DNode(UserDict):
             self._x_schema = subschema
 
     def __asdf_traverse__(self):
-        return list(self.items())
+        return dict(self)
 
 
 class LNode(UserList):
@@ -251,7 +251,7 @@ class LNode(UserList):
             return value
 
     def __asdf_traverse__(self):
-        return list(enumerate(self))
+        return list(self)
 
 
 _OBJECT_NODE_CLASSES_BY_TAG = {}

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -87,7 +87,6 @@ def _check_value(value, schema, validator_context):
                                          validator_callbacks,
                                          validator_resolver)
 
-    #value = yamlutil.custom_tree_to_tagged_tree(value, validator_context)
     validator.validate(value, _schema=temp_schema)
     validator_context.close()
 
@@ -223,11 +222,10 @@ class DNode(UserDict):
             # Extract the subschema corresponding to this node.
             subschema = _get_schema_for_property(parent_schema, self._name)
             self._x_schema = subschema
-    # def __getindex__(self, key):
-    #     return self.data[key]
 
-    # def __setindex__(self, key, value):
-    #     self.data[key] = value
+    def __asdf_traverse__(self):
+        return list(self.items())
+
 
 class LNode(UserList):
 
@@ -251,6 +249,9 @@ class LNode(UserList):
             return LNode(value)
         else:
             return value
+
+    def __asdf_traverse__(self):
+        return list(enumerate(self))
 
 
 _OBJECT_NODE_CLASSES_BY_TAG = {}

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -289,7 +289,7 @@ class TaggedObjectNode(DNode, metaclass=TaggedObjectNodeMeta):
         """Retrieve the schema associated with this tag"""
         extension_manager = self.ctx.extension_manager
         tag_def = extension_manager.get_tag_definition(self.tag)
-        schema_uri = tag_def.schema_uri
+        schema_uri = tag_def.schema_uris[0]
         schema = asdfschema.load_schema(schema_uri, resolve_references=True)
         return schema
 

--- a/src/roman_datamodels/util.py
+++ b/src/roman_datamodels/util.py
@@ -66,7 +66,7 @@ def get_schema_uri_from_converter(converter_class):
     rclass = locate(classname)
     tag = rclass._tag
     schema_uri = next(
-        t for t in DATAMODEL_EXTENSIONS[0].tags if t._tag_uri == tag)._schema_uri
+        t for t in DATAMODEL_EXTENSIONS[0].tags if t.tag_uri == tag).schema_uris[0]
     return schema_uri
 
 # def open(init=None, memmap=False, **kwargs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -459,4 +459,5 @@ def test_datamodel_info_search(capsys):
     assert "optical_element" in captured.out
     result = dm.search('optical_element')
     assert 'F062' in repr(result)
+    assert result.node == 'F062'
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -460,4 +460,3 @@ def test_datamodel_info_search(capsys):
     result = dm.search('optical_element')
     assert 'F062' in repr(result)
     assert result.node == 'F062'
-

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ def test_model_schemas():
     dmodels = datamodels.model_registry.keys()
     for model in dmodels:
         schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags
-                          if t._tag_uri == model._tag)._schema_uri
+                          if t._tag_uri == model._tag).schema_uris[0]
         asdf.schema.load_schema(schema_uri)
 
 # Testing core schema
@@ -125,9 +125,9 @@ def test_reference_file_model_base(tmp_path):
     # Set temporary asdf file
 
     # Get all reference file classes
-    tags = [t for t in DATAMODEL_EXTENSIONS[0].tags if "/reference_files/" in t._tag_uri]
+    tags = [t for t in DATAMODEL_EXTENSIONS[0].tags if "/reference_files/" in t.tag_uri]
     for tag in tags:
-        schema = asdf.schema.load_schema(tag._schema_uri)
+        schema = asdf.schema.load_schema(tag.schema_uris[0])
         # Check that schema references common reference schema
         allofs = schema['properties']['meta']['allOf']
         found_common = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -448,3 +448,15 @@ def test_opening_level2_image(tmp_path):
 
     assert wfi_image.meta.instrument.optical_element == 'F062'
     assert isinstance(wfi_image, datamodels.ImageModel)
+
+def test_datamodel_info_search(capsys):
+    wfi_science_raw = utils.mk_level1_science_raw()
+    af = asdf.AsdfFile()
+    af.tree = {'roman': wfi_science_raw}
+    dm = datamodels.open(af)
+    dm.info(max_rows=200)
+    captured = capsys.readouterr()
+    assert "optical_element" in captured.out
+    result = dm.search('optical_element')
+    assert 'F062' in repr(result)
+

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -50,3 +50,15 @@ def test_serialization(node_class, tmp_path):
 
     with asdf.open(file_path) as af:
         assert_node_equal(af["node"], node)
+
+
+def test_info(capsys):
+    node = stnode.WfiMode({"optical_element": "GRISM",
+                           "detector": "WFI18",
+                           "name": "WFI"})
+    tree = dict(wfimode=node)
+    af = asdf.AsdfFile(tree)
+    af.info()
+    captured = capsys.readouterr()
+    assert "optical_element" in captured.out
+    assert "GRISM" in captured.out


### PR DESCRIPTION
This PR allows the asdf `node` method to show the contents of Roman datafiles whereas previously it didn't since it would treat any tag class as opaque (the Roman tree structure is primarily made of tag classes unlike JWST tree structures). The referenced asdf PR is asdf-format/asdf#1052, and for this functionality to work, that PR must be installed.