### PR TITLE
Fix bug with asdf 2.9.x due to change in private variable name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 
 - Updated stnode tests to include all cal steps. [#60]
 
+- Fix bug with asdf 2.9.x due to change in private variable name. [#63]
 
 0.8.0 (2021-11-22)
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     jsonschema>=3.0.2
-    asdf>=2.8.0
+    asdf>=2.9.1
     psutil>=5.7.2
     numpy>=1.16
     astropy>=4.0

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -289,7 +289,7 @@ class TaggedObjectNode(DNode, metaclass=TaggedObjectNodeMeta):
         """Retrieve the schema associated with this tag"""
         extension_manager = self.ctx.extension_manager
         tag_def = extension_manager.get_tag_definition(self.tag)
-        schema_uri = tag_def.schema_uri
+        schema_uri = tag_def.schema_uris[0]
         schema = asdfschema.load_schema(schema_uri, resolve_references=True)
         return schema
 

--- a/src/roman_datamodels/util.py
+++ b/src/roman_datamodels/util.py
@@ -66,7 +66,7 @@ def get_schema_uri_from_converter(converter_class):
     rclass = locate(classname)
     tag = rclass._tag
     schema_uri = next(
-        t for t in DATAMODEL_EXTENSIONS[0].tags if t._tag_uri == tag)._schema_uri
+        t for t in DATAMODEL_EXTENSIONS[0].tags if t.tag_uri == tag).schema_uris[0]
     return schema_uri
 
 # def open(init=None, memmap=False, **kwargs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ def test_model_schemas():
     dmodels = datamodels.model_registry.keys()
     for model in dmodels:
         schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags
-                          if t._tag_uri == model._tag)._schema_uri
+                          if t._tag_uri == model._tag).schema_uris[0]
         asdf.schema.load_schema(schema_uri)
 
 # Testing core schema
@@ -125,9 +125,9 @@ def test_reference_file_model_base(tmp_path):
     # Set temporary asdf file
 
     # Get all reference file classes
-    tags = [t for t in DATAMODEL_EXTENSIONS[0].tags if "/reference_files/" in t._tag_uri]
+    tags = [t for t in DATAMODEL_EXTENSIONS[0].tags if "/reference_files/" in t.tag_uri]
     for tag in tags:
-        schema = asdf.schema.load_schema(tag._schema_uri)
+        schema = asdf.schema.load_schema(tag.schema_uris[0])
         # Check that schema references common reference schema
         allofs = schema['properties']['meta']['allOf']
         found_common = False


### PR DESCRIPTION
The `TagDefinition._schema_uri` variable changed to `TagDefinition._schema_uris`.  This updates roman_datamodels to use the public property instead of the unreliable private variable.