### PR TITLE
Changes to models testing functions to bring them in sync with schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "*"
     tags:
       - '*'
   pull_request:
@@ -33,11 +34,6 @@ jobs:
             runs-on: ubuntu-latest
             python-version: 3.8
             toxenv: py38
-
-          - name: Python 3.7
-            runs-on: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37
 
           - name: Coverage
             runs-on: ubuntu-latest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.10.0 (unreleased)
 ===================
 
+- Updated maker utilities for level 1, level 2, and ramp models to reflect changes in reference pixels. [#65]
+
 0.9.0 (2022-02-04)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,16 +17,16 @@ classifiers =
 
 [options]
 zip_safe = True
-python_requires = >=3.6
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =
     jsonschema>=3.0.2
-    asdf>=2.9.1
+    asdf>=2.9.2
     psutil>=5.7.2
-    numpy>=1.16
-    astropy>=4.0
-    romanad>=0.8.0
+    numpy>=1.21
+    astropy>=5.0
+    romanad @ git+https://github.com/Spacetelescope/rad.git@main
 
 package_dir =
     =src

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -912,6 +912,15 @@ def create_ramp(**kwargs):
         "pixeldq": _random_array_uint32(),
         "groupdq": _random_array_uint8((2, 4096, 4096)),
         "err": _random_array_float32(min=0.0),
+        "amp33": _random_array_float32((2, 4096, 128)),
+        "border_ref_pix_right": _random_array_float32((2, 4096, 4)),
+        "border_ref_pix_left": _random_array_float32((2, 4096, 4)),
+        "border_ref_pix_top": _random_array_float32((2, 4, 4096)),
+        "border_ref_pix_bottom": _random_array_float32((2, 4, 4096)),
+        "dq_border_ref_pix_right": _random_array_uint32((2, 4096, 4)),
+        "dq_border_ref_pix_left": _random_array_uint32((2, 4096, 4)),
+        "dq_border_ref_pix_top": _random_array_uint32((2, 4, 4096)),
+        "dq_border_ref_pix_bottom": _random_array_uint32((2, 4, 4096))
     }
     raw.update(kwargs)
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -1111,14 +1111,23 @@ def create_wfi_image(**kwargs):
     roman_datamodels.stnode.WfiImage
     """
     raw = {
-        "area": _random_array_float32(),
-        "data": _random_array_float32(),
-        "dq": _random_array_uint32(),
-        "err": _random_array_float32(min=0.0),
+        "area": _random_array_float32((2, 4088, 4088)),
+        "data": _random_array_float32((2, 4088, 4088)),
+        "dq": _random_array_uint32((2, 4088, 4088)),
+        "err": _random_array_float32((2, 4088, 4088), min=0.0),
         "meta": create_meta(),
-        "var_flat": _random_array_float32(),
-        "var_poisson": _random_array_float32(),
-        "var_rnoise": _random_array_float32(),
+        "var_flat": _random_array_float32((2, 4088, 4088)),
+        "var_poisson": _random_array_float32((2, 4088, 4088)),
+        "var_rnoise": _random_array_float32((2, 4088, 4088)),
+        "amp33": _random_array_float32((2, 4096, 128)),
+        "border_ref_pix_right": _random_array_float32((2, 4096, 4)),
+        "border_ref_pix_left": _random_array_float32((2, 4096, 4)),
+        "border_ref_pix_top": _random_array_float32((2, 4, 4096)),
+        "border_ref_pix_bottom": _random_array_float32((2, 4, 4096)),
+        "dq_border_ref_pix_right": _random_array_uint32((4096, 4)),
+        "dq_border_ref_pix_left": _random_array_uint32((4096, 4)),
+        "dq_border_ref_pix_top": _random_array_uint32((4, 4096)),
+        "dq_border_ref_pix_bottom": _random_array_uint32((4, 4096))
         "cal_logs": create_cal_logs(),
     }
     raw.update(kwargs)
@@ -1167,6 +1176,7 @@ def create_wfi_science_raw(**kwargs):
     raw = {
         # TODO: What should this shape be?
         "data": _random_array_uint16((2, 4096, 4096)),
+        "amp33": _random_array_float32((2, 4096, 128)),
         "meta": create_meta(),
     }
     raw.update(kwargs)

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -917,10 +917,10 @@ def create_ramp(**kwargs):
         "border_ref_pix_left": _random_array_float32((2, 4096, 4)),
         "border_ref_pix_top": _random_array_float32((2, 4, 4096)),
         "border_ref_pix_bottom": _random_array_float32((2, 4, 4096)),
-        "dq_border_ref_pix_right": _random_array_uint32((2, 4096, 4)),
-        "dq_border_ref_pix_left": _random_array_uint32((2, 4096, 4)),
-        "dq_border_ref_pix_top": _random_array_uint32((2, 4, 4096)),
-        "dq_border_ref_pix_bottom": _random_array_uint32((2, 4, 4096))
+        "dq_border_ref_pix_right": _random_array_uint32((4096, 4)),
+        "dq_border_ref_pix_left": _random_array_uint32((4096, 4)),
+        "dq_border_ref_pix_top": _random_array_uint32((4, 4096)),
+        "dq_border_ref_pix_bottom": _random_array_uint32((4, 4096))
     }
     raw.update(kwargs)
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -10,6 +10,7 @@ import secrets
 import sys
 
 from astropy.time import Time
+from astropy import units as u
 import numpy as np
 
 from .. import stnode
@@ -356,6 +357,7 @@ def create_exposure(**kwargs):
         "start_time_mjd": _random_mjd_timestamp(),
         "start_time_tdb": _random_mjd_timestamp(),
         "type": _random_exposure_type(),
+        "level0_compressed": True,
     }
     raw.update(kwargs)
 
@@ -443,9 +445,10 @@ def create_dark_ref(**kwargs):
         "data": _random_array_float32((2, 4096, 4096)),
         "dq": _random_array_uint32(),
         "err": _random_array_float32((2, 4096, 4096)),
-        "meta": create_ref_meta(reftype="DARK"),
+        "meta": create_ref_meta(reftype="DARK")
     }
     raw.update(kwargs)
+    raw['meta']['exposure']['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
 
     return stnode.DarkRef(raw)
 
@@ -537,8 +540,8 @@ def create_pixelarea_ref(**kwargs):
         "meta": create_ref_meta(reftype="AREA"),
     }
     raw['meta']['photometry'] = {
-        'pixelarea_steradians': _random_positive_float(),
-        'pixelarea_arcsecsq': _random_positive_float(),
+        'pixelarea_steradians': _random_positive_float() * u.sr,
+        'pixelarea_arcsecsq': _random_positive_float() * u.arcsec ** 2,
     }
     raw.update(kwargs)
 
@@ -563,6 +566,7 @@ def create_readnoise_ref(**kwargs):
         "meta": create_ref_meta(reftype="READNOISE"),
     }
     raw.update(kwargs)
+    raw['meta']['exposure']['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
 
     return stnode.ReadnoiseRef(raw)
 
@@ -629,11 +633,17 @@ def create_wfi_img_photom_ref(**kwargs):
     """
     raw_dict = {
         "W146":
-             {"photmjsr":(10 * np.random.random()),
-              "uncertainty":np.random.random()},
+             {"photmjsr": (10 * np.random.random() * u.MJy / u.sr),
+              "uncertainty": np.random.random() * u.MJy / u.sr,
+              "pixelareasr": .2 * u.sr},
         "F184":
-            {"photmjsr": (10 * np.random.random()),
-             "uncertainty": np.random.random()}
+            {"photmjsr": (10 * np.random.random() * u.MJy / u.sr),
+             "uncertainty": np.random.random() * u.MJy / u.sr,
+             "pixelareasr": .2 * u.sr},
+        "PRISM":
+             {"photmjsr": None,
+              "uncertainty": None,
+              "pixelareasr": None},
     }
 
     raw = {
@@ -680,7 +690,7 @@ def create_guidestar(**kwargs):
         "gw_id": _random_string("ID ", 20),
         "gw_function_end_time": _random_astropy_time(),
         "gw_function_start_time": _random_astropy_time(),
-        "gw_pcs_mode": _random_string("PCS ", 10),
+        "gw_fgs_mode": "WSM-ACQ-2",
         "gw_start_time": _random_astropy_time(),
         "gw_stop_time": _random_astropy_time(),
         "gw_window_xsize": _random_positive_float(),
@@ -740,7 +750,6 @@ def create_meta(**kwargs):
         "guidestar": create_guidestar(),
         "instrument": create_wfi_mode(),
         "observation": create_observation(),
-        "photometry": create_photometry(),
         "pointing": create_pointing(),
         "program": create_program(),
         "target": create_target(),
@@ -808,10 +817,12 @@ def create_photometry(**kwargs):
     roman_datamodels.stnode.Photometry
     """
     raw = {
-        "conversion_megajanskys": _random_positive_float(),
-        "conversion_microjanskys": _random_positive_float(),
-        "pixelarea_arcsecsq": _random_positive_float(),
-        "pixelarea_steradians": _random_positive_float(),
+        "conversion_megajanskys": _random_positive_float() * u.MJy / u.sr,
+        "conversion_microjanskys": _random_positive_float() * u.uJy / u.sr,
+        "pixelarea_arcsecsq": _random_positive_float() * u.arcsec ** 2,
+        "pixelarea_steradians": _random_positive_float() * u.sr,
+        "conversion_megajanskys_uncertainty": _random_positive_float() * u.MJy / u.sr,
+        "conversion_microjanskys_uncertainty": _random_positive_float() * u.uJy / u.sr
     }
     raw.update(kwargs)
 
@@ -836,6 +847,9 @@ def create_pixelarea(**kwargs):
         "area": _random_array_float32(min=0.0),
     }
     raw.update(kwargs)
+    raw["meta"] = {}
+    raw["meta"]["photometry"] = {'pixelarea_steradians': .3 * u.sr,
+                                 'pixelarea_arcsecsq': .3 * u.arcsec ** 2}
 
     return stnode.Pixelarea(raw)
 
@@ -909,10 +923,10 @@ def create_ramp(**kwargs):
     raw = {
         "meta": create_meta(),
         "data": _random_array_float32((2, 4096, 4096)),
-        "pixeldq": _random_array_uint32(),
+        "pixeldq": _random_array_uint32((4096, 4096)),
         "groupdq": _random_array_uint8((2, 4096, 4096)),
         "err": _random_array_float32(min=0.0),
-        "amp33": _random_array_float32((2, 4096, 128)),
+        "amp33": _random_array_uint16((2, 4096, 128)),
         "border_ref_pix_right": _random_array_float32((2, 4096, 4)),
         "border_ref_pix_left": _random_array_float32((2, 4096, 4)),
         "border_ref_pix_top": _random_array_float32((2, 4, 4096)),
@@ -1110,16 +1124,16 @@ def create_wfi_image(**kwargs):
     -------
     roman_datamodels.stnode.WfiImage
     """
+
     raw = {
-        "area": _random_array_float32((2, 4088, 4088)),
-        "data": _random_array_float32((2, 4088, 4088)),
-        "dq": _random_array_uint32((2, 4088, 4088)),
-        "err": _random_array_float32((2, 4088, 4088), min=0.0),
+        "data": _random_array_float32((4088, 4088)),
+        "dq": _random_array_uint32((4088, 4088)),
+        "err": _random_array_float32((4088, 4088), min=0.0),
         "meta": create_meta(),
-        "var_flat": _random_array_float32((2, 4088, 4088)),
-        "var_poisson": _random_array_float32((2, 4088, 4088)),
-        "var_rnoise": _random_array_float32((2, 4088, 4088)),
-        "amp33": _random_array_float32((2, 4096, 128)),
+        "var_flat": _random_array_float32((4088, 4088)),
+        "var_poisson": _random_array_float32((4088, 4088)),
+        "var_rnoise": _random_array_float32((4088, 4088)),
+        "amp33": _random_array_uint16((2, 4096, 128)),
         "border_ref_pix_right": _random_array_float32((2, 4096, 4)),
         "border_ref_pix_left": _random_array_float32((2, 4096, 4)),
         "border_ref_pix_top": _random_array_float32((2, 4, 4096)),
@@ -1127,10 +1141,11 @@ def create_wfi_image(**kwargs):
         "dq_border_ref_pix_right": _random_array_uint32((4096, 4)),
         "dq_border_ref_pix_left": _random_array_uint32((4096, 4)),
         "dq_border_ref_pix_top": _random_array_uint32((4, 4096)),
-        "dq_border_ref_pix_bottom": _random_array_uint32((4, 4096))
+        "dq_border_ref_pix_bottom": _random_array_uint32((4, 4096)),
         "cal_logs": create_cal_logs(),
     }
     raw.update(kwargs)
+    raw["meta"]["photometry"] = create_photometry()
 
     return stnode.WfiImage(raw)
 
@@ -1176,7 +1191,7 @@ def create_wfi_science_raw(**kwargs):
     raw = {
         # TODO: What should this shape be?
         "data": _random_array_uint16((2, 4096, 4096)),
-        "amp33": _random_array_float32((2, 4096, 128)),
+        "amp33": _random_array_uint16((2, 4096, 128)),
         "meta": create_meta(),
     }
     raw.update(kwargs)

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -513,20 +513,24 @@ def mk_level2_image(shape=None, n_ints=None, filepath=None):
     rl_shape_3d = (n_ints, shape[0] + 8, 4) # for right, left ref pix arrays
 
     # add border reference pixel arrays
-    wfi_image['border_ref_pix_left'] = np.zeros(rl_shape_3d, dtype=np.float32)
-    wfi_image['border_ref_pix_right'] = np.zeros(rl_shape_3d, dtype=np.float32)
-    wfi_image['border_ref_pix_top'] = np.zeros(tb_shape_3d, dtype=np.float32)
-    wfi_image['border_ref_pix_bottom'] = np.zeros(tb_shape_3d, dtype=np.float32)
+    wfi_image['border_ref_pix_left'] = np.zeros((n_ints, shape[0] + 8, 4),
+                                                dtype=np.float32)
+    wfi_image['border_ref_pix_right'] = np.zeros((n_ints, shape[0] + 8, 4),
+                                                dtype=np.float32)
+    wfi_image['border_ref_pix_top'] = np.zeros((n_ints, 4, shape[1] + 8),
+                                                dtype=np.float32)
+    wfi_image['border_ref_pix_bottom'] = np.zeros((n_ints, 4, shape[1] + 8),
+                                                  dtype=np.float32)
 
     # and their dq arrays
-    wfi_image['dq_border_ref_pix_left'] = np.zeros(rl_shape_3d, dtype=np.uint32)
-    wfi_image['dq_border_ref_pix_right'] = np.zeros(rl_shape_3d, dtype=np.uint32)
-    wfi_image['dq_border_ref_pix_top'] = np.zeros(tb_shape_3d, dtype=np.uint32)
-    wfi_image['dq_border_ref_pix_top'] = np.zeros(tb_shape_3d, dtype=np.uint32)
+    wfi_image['dq_border_ref_pix_left'] = np.zeros((shape[0] + 8, 4), dtype=np.uint32)
+    wfi_image['dq_border_ref_pix_right'] = np.zeros((shape[0] + 8, 4), dtype=np.uint32)
+    wfi_image['dq_border_ref_pix_top'] = np.zeros((4, shape[1] + 8), dtype=np.uint32)
+    wfi_image['dq_border_ref_pix_bottom'] = np.zeros((4, shape[1] + 8), dtype=np.uint32)
 
     # add amp 33 ref pixel array
     amp33_size = (n_ints, 4096, 128)
-    wfi_image['amp33'] = np.zeros(amp33_size, dtype=np.float32)
+    wfi_image['amp33'] = np.zeros(amp33_size, dtype=np.uint16)
 
     wfi_image['data'] = np.zeros(shape, dtype=np.float32)
     wfi_image['dq'] = np.zeros(shape, dtype=np.uint32)
@@ -882,20 +886,24 @@ def mk_ramp(shape=None, n_ints=None, filepath=None):
     rl_shape_3d = (shape[0], shape[1], 4) # for right, left ref pix arrays
 
     # add border reference pixel arrays
-    ramp['border_ref_pix_left'] = np.zeros(rl_shape_3d, dtype=np.float32)
-    ramp['border_ref_pix_right'] = np.zeros(rl_shape_3d, dtype=np.float32)
-    ramp['border_ref_pix_top'] = np.zeros(tb_shape_3d, dtype=np.float32)
-    ramp['border_ref_pix_bottom'] = np.zeros(tb_shape_3d, dtype=np.float32)
+    ramp['border_ref_pix_left'] = np.zeros((shape[0], shape[1], 4),
+                                           dtype=np.float32)
+    ramp['border_ref_pix_right'] = np.zeros((shape[0], shape[1], 4),
+                                            dtype=np.float32)
+    ramp['border_ref_pix_top'] = np.zeros((shape[0], 4, shape[2]),
+                                           dtype=np.float32)
+    ramp['border_ref_pix_bottom'] = np.zeros((shape[0], 4, shape[2]),
+                                              dtype=np.float32)
 
     # and their dq arrays
-    ramp['dq_border_ref_pix_left'] = np.zeros(rl_shape_3d, dtype=np.uint32)
-    ramp['dq_border_ref_pix_right'] = np.zeros(rl_shape_3d, dtype=np.uint32)
-    ramp['dq_border_ref_pix_top'] = np.zeros(tb_shape_3d, dtype=np.uint32)
-    ramp['dq_border_ref_pix_top'] = np.zeros(tb_shape_3d, dtype=np.uint32)
+    ramp['dq_border_ref_pix_left'] = np.zeros((shape[1], 4), dtype=np.uint32)
+    ramp['dq_border_ref_pix_right'] = np.zeros((shape[1], 4), dtype=np.uint32)
+    ramp['dq_border_ref_pix_top'] = np.zeros((4, shape[2]), dtype=np.uint32)
+    ramp['dq_border_ref_pix_bottom'] = np.zeros((4, shape[2]), dtype=np.uint32)
 
     # add amp 33 ref pixel array
     amp33_size = (shape[0], 4096, 128)
-    ramp['amp33'] = np.zeros(amp33_size, dtype=np.float32)
+    ramp['amp33'] = np.zeros(amp33_size, dtype=np.uint16)
 
     ramp['data'] = np.full(shape, 1.0, dtype=np.float32)
     ramp['pixeldq'] = np.zeros(shape[1:], dtype=np.uint32)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 
 from jsonschema import ValidationError
+from astropy import units as u
 import asdf
 import numpy as np
 
@@ -276,8 +277,8 @@ def test_opening_mask_ref(tmp_path):
 def test_make_pixelarea():
     pixearea = utils.mk_pixelarea(shape=(20, 20))
     assert pixearea.meta.reftype == 'AREA'
-    assert type(pixearea.meta.photometry.pixelarea_steradians) == float
-    assert type(pixearea.meta.photometry.pixelarea_arcsecsq) == float
+    assert type(pixearea.meta.photometry.pixelarea_steradians) == u.Quantity
+    assert type(pixearea.meta.photometry.pixelarea_arcsecsq) == u.Quantity
     assert pixearea.data.dtype == np.float32
 
     # Test validation
@@ -381,10 +382,15 @@ def test_make_wfi_img_photom():
     wfi_img_photom = utils.mk_wfi_img_photom()
 
     assert wfi_img_photom.meta.reftype == 'PHOTOM'
-    assert type(wfi_img_photom.phot_table.W146.photmjsr) == float
-    assert type(wfi_img_photom.phot_table.F184.photmjsr) == float
-    assert type(wfi_img_photom.phot_table.W146.uncertainty) == float
-    assert type(wfi_img_photom.phot_table.F184.uncertainty) == float
+    assert isinstance(wfi_img_photom.phot_table.W146.photmjsr, u.Quantity)
+    assert isinstance(wfi_img_photom.phot_table.F184.photmjsr, u.Quantity)
+    assert isinstance(wfi_img_photom.phot_table.W146.uncertainty, u.Quantity)
+    assert isinstance(wfi_img_photom.phot_table.F184.uncertainty, u.Quantity)
+    assert isinstance(wfi_img_photom.phot_table.F184.pixelareasr, u.Quantity)
+    assert isinstance(wfi_img_photom.phot_table.W146.pixelareasr, u.Quantity)
+    assert wfi_img_photom.phot_table.PRISM.photmjsr is None
+    assert wfi_img_photom.phot_table.PRISM.uncertainty is None
+    assert wfi_img_photom.phot_table.PRISM.pixelareasr is None
 
     # Test validation
     wfi_img_photom_model = datamodels.WfiImgPhotomRefModel(wfi_img_photom)
@@ -432,7 +438,6 @@ def test_level2_image():
     assert wfi_image.var_poisson.dtype == np.float32
     assert wfi_image.var_rnoise.dtype == np.float32
     assert wfi_image.var_flat.dtype == np.float32
-    assert wfi_image.area.dtype == np.float32
     assert type(wfi_image.cal_logs[0]) == str
 
     # Test validation


### PR DESCRIPTION
The changes in schemas include
- photometry changes - spacetelescope/rad#114
- making photometry an optional property - spacetelescope/rad#115
- adding `p_keywords` - spacetelescope/rad#105
- adding `level0_compression` attribute - spacetelescope/rad#104
- adding `gw_fgs_mode` to `guide_star` - spacetelescope/rad#103

This PR also updates versioons of some dependencies in setup.cfg and points to rad/main