### PR TITLE
RCAL-321: Remove exptype and p_keywords from Distortion DataModel Utilities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Added distortion data model, utilities, and tests. [#70]
 
+- Removed exptype and p_keyword from Distortion maker utility and factory. [#71]
+
 0.10.0 (2022-02-15)
 ===================
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -480,7 +480,6 @@ def create_distortion_ref(**kwargs):
 
     raw['meta']['input_units'] = u.pixel
     raw['meta']['output_units'] = u.arcsec
-    raw['meta']['exposure']['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
 
     return stnode.DistortionRef(raw)
 

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -654,10 +654,6 @@ def mk_distortion(filepath=None):
     distortionref = stnode.DistortionRef()
     meta['reftype'] = 'DISTORTION'
     distortionref['meta'] = meta
-    exposure = {}
-    exposure['type'] = 'WFI_IMAGE'
-    exposure['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
-    distortionref['meta']['exposure'] = exposure
 
     distortionref['meta']['input_units'] = u.pixel
     distortionref['meta']['output_units'] = u.arcsec


### PR DESCRIPTION
Removed exptype and p_keyword from Distortion maker utility and factory.