### PR TITLE
RCAL-314: Update roman_datamodels to include ma_table_number

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@
 
 - Corrected photom units to megajanskies. [#73]
 
+- Moved ma_table_name and ma_table_number from observation to exposure groups. [#74]
+
 0.10.0 (2022-02-15)
 ===================
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -360,6 +360,8 @@ def create_exposure(**kwargs):
         "start_time_mjd": _random_mjd_timestamp(),
         "start_time_tdb": _random_mjd_timestamp(),
         "type": _random_exposure_type(),
+        "ma_table_name": _random_string("MA table "),
+        "ma_table_number": _random_positive_int(max=998) + 1,
         "level0_compressed": True,
     }
     raw.update(kwargs)
@@ -388,16 +390,14 @@ def create_ref_meta(**kwargs):
             "type" : "WFI_IMAGE",
             "ngroups" : 6,
             "nframes" : 8,
-            "groupgap" : 0
+            "groupgap" : 0,
+            "ma_table_name": _random_string("MA table "),
+            "ma_table_number": _random_positive_int(max=998) + 1,
         },
         "instrument": {
             "name": "WFI",
             "detector": _random_detector(),
             "optical_element": _random_optical_element(),
-        },
-        "observation": {
-            "ma_table_name": _random_string("MA table "),
-            "ma_table_number":  _random_positive_int(max=998) + 1,
         },
         "origin": "STScI",
         "pedigree": "DUMMY",
@@ -850,8 +850,6 @@ def create_observation(**kwargs):
         "end_time": _random_astropy_time(),
         "execution_plan": _random_positive_int(),
         "exposure": _random_positive_int(),
-        "ma_table_name": _random_string("MA table "),
-        "ma_table_number": _random_positive_int(max=998) + 1,
         "obs_id": _random_string("Obs ID ", 26),
         "observation": _random_positive_int(),
         "observation_label": _random_string("Observation label "),

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -57,6 +57,8 @@ def mk_exposure():
     exp['duration'] = NONUM
     exp['nresets_at_start'] = NONUM
     exp['datamode'] = NONUM
+    exp['ma_table_name'] = NOSTR
+    exp['ma_table_number'] = NONUM
     exp['level0_compressed'] = True
     return exp
 
@@ -124,8 +126,6 @@ def mk_observation():
     obs['exposure'] = NONUM
     obs['template'] = NOSTR
     obs['observation_label'] = NOSTR
-    obs['ma_table_name'] = NOSTR
-    obs['ma_table_number'] = NONUM
     obs['survey'] = 'N/A'
     return obs
 
@@ -609,16 +609,14 @@ def mk_dark(shape=None, filepath=None):
     darkref = stnode.DarkRef()
     meta['reftype'] = 'DARK'
     darkref['meta'] = meta
-    observation = {}
-    observation['ma_table_name']= NOSTR
-    observation['ma_table_number'] = NONUM
-    darkref['meta']['observation'] = observation
     exposure = {}
     exposure['ngroups'] = 6
     exposure['nframes'] = 8
     exposure['groupgap'] = 0
     exposure['type'] = 'WFI_IMAGE'
     exposure['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
+    exposure['ma_table_name'] = NOSTR
+    exposure['ma_table_number'] = NONUM
     darkref['meta']['exposure'] = exposure
 
     if not shape:


### PR DESCRIPTION
Moved ma_table_name and ma_table_number from observation to exposure groups.