### PR TITLE
Remove observation.time and observation.date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+0.12.1 (Unreleased)
+===================
+- Removed ``observation.date`` and ``observation.time`` from CRDS parameters. [#78]
+
 0.12.0 (2022-04-25)
 ==================
 

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -262,12 +262,6 @@ class DataModel:
             key: val for key, val in self.to_flat_dict(include_arrays=False).items()
             if isinstance(val, (str, int, float, complex, bool))
         }
-        # We need to add two distinct time and date entries derived from the start time
-        # since that is what CRDS expects.
-        time = self.meta.observation.start_time
-        date, time = time.isot.split('T')
-        crds_header['roman.meta.observation.date'] = date
-        crds_header['roman.meta.observation.time'] = time
         return crds_header
 
     def validate(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 from jsonschema import ValidationError
 from astropy import units as u
@@ -208,7 +209,7 @@ def test_flat_model(tmp_path):
 
         # Test that asdf file opens properly
         with datamodels.open(file_path) as model:
-            with pytest.warns(None):
+            with warnings.catch_warnings():
                 model.validate()
 
             # Confirm that asdf file is opened as flat file model
@@ -514,3 +515,12 @@ def test_datamodel_info_search(capsys):
     result = dm.search('optical_element')
     assert 'F062' in repr(result)
     assert result.node == 'F062'
+
+
+def test_crds_parameters(tmp_path):
+    file_path = tmp_path / 'testwfi_image.asdf'
+    utils.mk_level2_image(filepath=file_path)
+    wfi_image = datamodels.open(file_path)
+
+    crds_pars = wfi_image.get_crds_parameters()
+    assert 'roman.meta.exposure.start_time' in crds_pars

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -518,7 +518,7 @@ def test_datamodel_info_search(capsys):
 
 
 def test_crds_parameters(tmp_path):
-    # CRDS uses meta.exposure.sstart_time to compare to USEAFTER
+    # CRDS uses meta.exposure.start_time to compare to USEAFTER
     file_path = tmp_path / 'testwfi_image.asdf'
     utils.mk_level2_image(filepath=file_path)
     wfi_image = datamodels.open(file_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -529,5 +529,5 @@ def test_crds_parameters(tmp_path):
     utils.mk_ramp(filepath=file_path)
     ramp = datamodels.open(file_path)
 
-    crds_pars = wfi_image.get_crds_parameters()
+    crds_pars = ramp.get_crds_parameters()
     assert 'roman.meta.exposure.start_time' in crds_pars

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -518,9 +518,16 @@ def test_datamodel_info_search(capsys):
 
 
 def test_crds_parameters(tmp_path):
+    # CRDS uses meta.exposure.sstart_time to compare to USEAFTER
     file_path = tmp_path / 'testwfi_image.asdf'
     utils.mk_level2_image(filepath=file_path)
     wfi_image = datamodels.open(file_path)
+
+    crds_pars = wfi_image.get_crds_parameters()
+    assert 'roman.meta.exposure.start_time' in crds_pars
+
+    utils.mk_ramp(filepath=file_path)
+    ramp = datamodels.open(file_path)
 
     crds_pars = wfi_image.get_crds_parameters()
     assert 'roman.meta.exposure.start_time' in crds_pars


### PR DESCRIPTION
roman_datamodels.datamodels was "decomposing" `observation.start_time` into `obsertvation.date` and observation.time` when passing parameters to CRDS. Since these are removed from the schema now, the code in datamodels was removed too.