### PR TITLE
RCAL-334: Clean attributes in schemas related to CRDS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
+0.12.3 (unreleased)
+===================
+
+- Removed CRDS version information from basic maker utility. [#80]
+
 0.12.2 (2022-04-26)
 ===================
 
-- Added function for model equality. [#79]
+- Added function for model equality. [#79]  
 
 0.12.1 (2022-04-26)
 ===================

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ install_requires =
     psutil>=5.7.2
     numpy>=1.21
     astropy>=5.0.4
-    rad>=0.13.0
+    # rad>=0.13.0
+    rad @ git+https://github.com/spacetelescope/rad.git@main
 package_dir =
     =src
 packages = find:

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -386,8 +386,6 @@ def mk_guidestar():
 def mk_basic_meta():
     meta = {}
     meta['calibration_software_version'] = '9.9.9'
-    meta['crds_software_version'] = '8.8.8'
-    meta['crds_context_used'] = '222'
     meta['sdf_software_version'] = '7.7.7'
     meta['filename'] = NOSTR
     meta['file_date'] = time.Time(


### PR DESCRIPTION
Removed CRDS version information from basic maker utility.