### PR TITLE
RCAL-347: Update roman_datamodels util ramp error array creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Removed CRDS version information from basic maker utility. [#80]
 
+- Updated utilities and test for change in dimensionality of err variable in ramp datamodel. [#82]
+
 0.12.2 (2022-04-26)
 ===================
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -992,7 +992,7 @@ def create_ramp(**kwargs):
         "data": _random_array_float32((2, 4096, 4096)),
         "pixeldq": _random_array_uint32((4096, 4096)),
         "groupdq": _random_array_uint8((2, 4096, 4096)),
-        "err": _random_array_float32(min=0.0),
+        "err": _random_array_float32(size=(2, 4096, 4096),min=0.0),
         "amp33": _random_array_uint16((2, 4096, 128)),
         "border_ref_pix_right": _random_array_float32((2, 4096, 4)),
         "border_ref_pix_left": _random_array_float32((2, 4096, 4)),

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -977,7 +977,7 @@ def mk_ramp(shape=None, n_ints=None, filepath=None):
     ramp['data'] = np.full(shape, 1.0, dtype=np.float32)
     ramp['pixeldq'] = np.zeros(shape[1:], dtype=np.uint32)
     ramp['groupdq'] = np.zeros(shape, dtype=np.uint8)
-    ramp['err'] = np.zeros(shape[1:], dtype=np.float32)
+    ramp['err'] = np.zeros(shape, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -75,7 +75,7 @@ def test_make_ramp():
     assert ramp.pixeldq.shape == (20, 20)
     assert ramp.groupdq.dtype == np.uint8
     assert ramp.err.dtype == np.float32
-    assert ramp.err.shape == (20, 20)
+    assert ramp.err.shape == (2, 20, 20)
 
     # Test validation
     ramp = datamodels.RampModel(ramp)


### PR DESCRIPTION
Updated utilities and test for change in dimensionality of err variable in ramp datamodel.