### PR TITLE
freeze action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,12 @@ jobs:
           - python: '3.10'
             numpy: '1.20.*'
     steps:
-      - uses: actions/checkout@v3.0.2
-      - uses: actions/setup-python@v4.1.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         id: python
         with:
           python-version: ${{ matrix.python }}
-      - uses: actions/cache@v3.0.5
+      - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
           key: test-numpy${{ matrix.numpy }}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,12 +116,12 @@ jobs:
           - python: '3.10'
             numpy: '1.20.*'
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-python@main
+      - uses: actions/checkout@v3.0.2
+      - uses: actions/setup-python@v4.1.0
         id: python
         with:
           python-version: ${{ matrix.python }}
-      - uses: actions/cache@main
+      - uses: actions/cache@v3.0.5
         with:
           path: ${{ env.pythonLocation }}
           key: test-numpy${{ matrix.numpy }}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}


### PR DESCRIPTION
freezes the versions of actions used in the GitHub Actions workflow, to ensure that API changes don't break the unit tests