### PR TITLE
RCAL-237 Changes to support new rad tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Updated utilities and test for change in dimensionality of err variable in ramp datamodel. [#82]
 
+- Add support for new ``rad`` schema tags. [#86]
+
 0.12.2 (2022-04-26)
 ===================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,7 @@ install_requires =
     numpy
     astropy>=5.0.4
     # rad>=0.13.0
-    # rad @ git+https://github.com/spacetelescope/rad.git@main
-    # Use updated rad schemas
-    rad @ git+https://github.com/WilliamJamieson/rad/@schemas/refactor_tags
+    rad @ git+https://github.com/spacetelescope/rad.git@main
     # Use asdf-standard master until next release
     asdf-standard @ git+https://github.com/asdf-format/asdf-standard@master
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,8 @@ install_requires =
     # rad @ git+https://github.com/spacetelescope/rad.git@main
     # Use updated rad schemas
     rad @ git+https://github.com/WilliamJamieson/rad/@schemas/refactor_tags
-    # Use asdf-standard bugfix
-    asdf-standard @ git+https://github.com/WilliamJamieson/asdf-standard@bugfix/archive
+    # Use asdf-standard master until next release
+    asdf-standard @ git+https://github.com/asdf-format/asdf-standard@master
 package_dir =
     =src
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,11 @@ install_requires =
     numpy
     astropy>=5.0.4
     # rad>=0.13.0
-    rad @ git+https://github.com/spacetelescope/rad.git@main
+    # rad @ git+https://github.com/spacetelescope/rad.git@main
+    # Use updated rad schemas
+    rad @ git+https://github.com/WilliamJamieson/rad/@schemas/refactor_tags
+    # Use asdf-standard bugfix
+    asdf-standard @ git+https://github.com/WilliamJamieson/asdf-standard@bugfix/archive
 package_dir =
     =src
 packages = find:

--- a/src/roman_datamodels/extensions.py
+++ b/src/roman_datamodels/extensions.py
@@ -1,10 +1,11 @@
 from asdf.extension import ManifestExtension
-from .stnode import TaggedListNodeConverter, TaggedObjectNodeConverter
+from .stnode import TaggedListNodeConverter, TaggedObjectNodeConverter, TaggedScalarNodeConverter
 
 
 DATAMODEL_CONVERTERS = [
     TaggedObjectNodeConverter(),
     TaggedListNodeConverter(),
+    TaggedScalarNodeConverter(),
 ]
 
 DATAMODEL_EXTENSIONS = [

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -171,7 +171,7 @@ class DNode(UserDict):
             if key == 'origin' and value != 'STSCI':
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
             elif key == 'telescope' and value != 'ROMAN':
-                raise jsonschema.ValidationError("origin must be 'ROMAN'")
+                raise jsonschema.ValidationError("telescope must be 'ROMAN'")
             value = self._convert_to_scalar(key, value)
             if key in self._data:
                 if validate:
@@ -490,7 +490,7 @@ class TaggedScalarNodeConverter(Converter):
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
         elif tag == Telescope._tag: # noqa
             if validate and node != 'ROMAN':
-                raise jsonschema.ValidationError("origin must be 'ROMAN'")
+                raise jsonschema.ValidationError("telescope must be 'ROMAN'")
 
         if tag == FileDate._tag:
             converter = ctx.extension_manager.get_converter_for_type(type(node))
@@ -506,7 +506,7 @@ class TaggedScalarNodeConverter(Converter):
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
         elif tag == Telescope._tag: # noqa
             if validate and node != 'ROMAN':
-                raise jsonschema.ValidationError("origin must be 'ROMAN'")
+                raise jsonschema.ValidationError("telescope must be 'ROMAN'")
 
         if tag == FileDate._tag:
             converter = ctx.extension_manager.get_converter_for_type(Time)

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -479,11 +479,24 @@ class TaggedScalarNodeConverter(Converter):
         node = obj.__class__.__bases__[0](obj)
 
         if tag == FileDate._tag:
-            node = {'time': node}
+            converter = ctx.extension_manager.get_converter_for_type(type(node))
+            node = converter.to_yaml_tree(node, tag, ctx)
+
+        # Move enum check to converter due to bug, see spacetelescope/rad#155
+        elif tag == Origin._tag:
+            assert node == 'STSCI'
+        elif tag == Telescope._tag:
+            assert node == 'ROMAN'
 
         return node
 
     def from_yaml_tree(self, node, tag, ctx):
+        # Move enum check to converter due to bug, see spacetelescope/rad#155
+        if tag == Origin._tag:
+            assert node == 'STSCI'
+        elif tag == Telescope._tag:
+            assert node == 'ROMAN'
+
         return _SCALAR_NODE_CLASSES_BY_TAG[tag](node)
 
 

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -137,6 +137,13 @@ class DNode(UserDict):
             DNode._ctx = asdf.AsdfFile()
         return self._ctx
 
+    @staticmethod
+    def _convert_to_scalar(key, value):
+        if key in _SCALAR_NODE_CLASSES_BY_KEY:
+            value = _SCALAR_NODE_CLASSES_BY_KEY[key](value)
+
+        return value
+
     def __getattr__(self, key):
         """
         Permit accessing dict keys as attributes, assuming they are legal Python
@@ -145,7 +152,7 @@ class DNode(UserDict):
         if key.startswith('_'):
             raise AttributeError('No attribute {0}'.format(key))
         if key in self._data:
-            value = self._data[key]
+            value = self._convert_to_scalar(key, self._data[key])
             if isinstance(value, dict):
                 return DNode(value, parent=self, name=key)
             elif isinstance(value, list):
@@ -225,6 +232,13 @@ class DNode(UserDict):
 
     def __asdf_traverse__(self):
         return dict(self)
+
+    def __setitem__(self, key, value):
+        value = self._convert_to_scalar(key, value)
+        if isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                value[sub_key] = self._convert_to_scalar(sub_key, sub_value)
+        super().__setitem__(key, value)
 
 
 class LNode(UserList):
@@ -320,6 +334,59 @@ class TaggedListNode(LNode, metaclass=TaggedListNodeMeta):
         return self._tag
 
 
+_SCALAR_NODE_CLASSES_BY_TAG = {}
+_SCALAR_NODE_CLASSES_BY_KEY = {}
+
+
+def _scalar_tag_to_key(tag):
+    return tag.split('/')[-1].split('-')[0]
+
+
+class TaggedScalarNodeMeta(ABCMeta):
+    """
+    Metaclass for TaggedScalarNode that maintains a registry
+    of subclasses.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.__name__ != "TaggedScalarNode":
+            if self._tag in _SCALAR_NODE_CLASSES_BY_TAG:
+                raise RuntimeError(
+                    f"TaggedScalarNode class for tag '{self._tag}' has been defined twice")
+            _SCALAR_NODE_CLASSES_BY_TAG[self._tag] = self
+            _SCALAR_NODE_CLASSES_BY_KEY[_scalar_tag_to_key(self._tag)] = self
+
+
+class TaggedScalarNode(metaclass=TaggedScalarNodeMeta):
+    _tag = None
+    _ctx = None
+
+    @property
+    def ctx(self):
+        if self._ctx is None:
+            TaggedScalarNode._ctx = asdf.AsdfFile()
+        return self._ctx
+    
+    def __asdf_traverse__(self):
+        return self
+    
+    @property
+    def tag(self):
+        return self._tag
+
+    @property
+    def key(self):
+        return _scalar_tag_to_key(self._tag)
+    
+    def get_schema(self):
+        extension_manager = self.ctx.extension_manager
+        tag_def = extension_manager.get_tag_definition(self.tag)
+        schema_uri = tag_def.schema_uris[0]
+        schema = asdf.schema.load_schema(schema_uri, resolve_references=True)
+        return schema
+
+
 class WfiMode(TaggedObjectNode):
     _tag = "asdf://stsci.edu/datamodels/roman/tags/wfi_mode-1.0.0"
 
@@ -344,40 +411,8 @@ class CalLogs(TaggedListNode):
     _tag = "asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.0.0"
 
 
-_DATAMODELS_MANIFEST_PATH = importlib_resources.files(
-    rad.resources) / "manifests" / "datamodels-1.0.yaml"
-_DATAMODELS_MANIFEST = yaml.safe_load(_DATAMODELS_MANIFEST_PATH.read_bytes())
-
-
-def _class_name_from_tag_uri(tag_uri):
-    tag_name = tag_uri.split("/")[-1].split("-")[0]
-    class_name = "".join([p.capitalize() for p in tag_name.split("_")])
-    if tag_uri.startswith("asdf://stsci.edu/datamodels/roman/tags/reference_files/"):
-        class_name += "Ref"
-    return class_name
-
-
-for tag in _DATAMODELS_MANIFEST["tags"]:
-    docstring = ""
-    if "description" in tag:
-        docstring = tag["description"] + "\n\n"
-    docstring = docstring + f"Class generated from tag '{tag['tag_uri']}'"
-
-    if tag["tag_uri"] in _OBJECT_NODE_CLASSES_BY_TAG:
-        _OBJECT_NODE_CLASSES_BY_TAG[tag["tag_uri"]].__doc__ = docstring
-    elif tag["tag_uri"] in _LIST_NODE_CLASSES_BY_TAG:
-        _LIST_NODE_CLASSES_BY_TAG[tag["tag_uri"]].__doc__ = docstring
-    else:
-        class_name = _class_name_from_tag_uri(tag["tag_uri"])
-
-        cls = type(
-            class_name,
-            (TaggedObjectNode,),
-            {"_tag": tag["tag_uri"],
-                "__module__": "roman_datamodels.stnode", "__doc__": docstring},
-        )
-        globals()[class_name] = cls
-        __all__.append(class_name)
+class FileDate(Time, TaggedScalarNode):
+    _tag = "asdf://stsci.edu/datamodels/roman/tags/file_date-1.0.0"
 
 
 class TaggedObjectNodeConverter(Converter):
@@ -424,6 +459,106 @@ class TaggedListNodeConverter(Converter):
         return _LIST_NODE_CLASSES_BY_TAG[tag](node)
 
 
+class TaggedScalarNodeConverter(Converter):
+    """
+    Converter for all subclasses of TaggedScalarNode.
+    """
+    @property
+    def tags(self):
+        return list(_SCALAR_NODE_CLASSES_BY_TAG.keys())
+
+    @property
+    def types(self):
+        return list(_SCALAR_NODE_CLASSES_BY_TAG.values())
+
+    def select_tag(self, obj, tags, ctx):
+        return obj.tag
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return obj
+
+    def from_yaml_tree(self, node, tag, ctx):
+        return _OBJECT_NODE_CLASSES_BY_TAG[tag](node)
+
+
+_DATAMODELS_MANIFEST_PATH = importlib_resources.files(
+    rad.resources) / "manifests" / "datamodels-1.0.yaml"
+_DATAMODELS_MANIFEST = yaml.safe_load(_DATAMODELS_MANIFEST_PATH.read_bytes())
+
+
+def _class_name_from_tag_uri(tag_uri):
+    tag_name = tag_uri.split("/")[-1].split("-")[0]
+    class_name = "".join([p.capitalize() for p in tag_name.split("_")])
+    if tag_uri.startswith("asdf://stsci.edu/datamodels/roman/tags/reference_files/"):
+        class_name += "Ref"
+    return class_name
+
+
+def _get_object_type(schema):
+    if "allOf" in schema:
+        for sub_schema in schema["allOf"]:
+            object_type = _get_object_type(sub_schema)
+            if object_type is not None:
+                return object_type
+    else:
+        return schema.get("type", None)
+
+
+def _create_class_from_tag_uri(tag_uri, schema_uri):
+    class_name = _class_name_from_tag_uri(tag_uri)
+
+    schema = asdf.schema.load_schema(schema_uri, resolve_references=True)
+    object_type = _get_object_type(schema)
+
+    if object_type == "object":
+        cls = type(
+            class_name,
+            (TaggedObjectNode,),
+            {"_tag": tag_uri,
+                "__module__": "roman_datamodels.stnode", "__doc__": docstring},
+        )
+    else:
+        if object_type == "string":
+            base_cls = str
+        elif object_type == "number":
+            base_cls = float
+        elif object_type == "integer":
+            base_cls = int
+        elif object_type == "boolean":
+            base_cls = bool
+        elif object_type == "null":
+            base_cls = None
+        else:
+            raise RuntimeError(f"Unsupported Scalar object type: {object_type}")
+
+        cls = type(
+            class_name,
+            (base_cls, TaggedScalarNode),
+            {"_tag": tag_uri,
+                "__module__": "roman_datamodels.stnode", "__doc__": docstring},
+        )
+
+    globals()[class_name] = cls
+    __all__.append(class_name)
+
+
+
+for tag in _DATAMODELS_MANIFEST["tags"]:
+    docstring = ""
+    if "description" in tag:
+        docstring = tag["description"] + "\n\n"
+    docstring = docstring + f"Class generated from tag '{tag['tag_uri']}'"
+
+    if tag["tag_uri"] in _OBJECT_NODE_CLASSES_BY_TAG:
+        _OBJECT_NODE_CLASSES_BY_TAG[tag["tag_uri"]].__doc__ = docstring
+    elif tag["tag_uri"] in _LIST_NODE_CLASSES_BY_TAG:
+        _LIST_NODE_CLASSES_BY_TAG[tag["tag_uri"]].__doc__ = docstring
+    elif tag["tag_uri"] in _SCALAR_NODE_CLASSES_BY_TAG:
+        _SCALAR_NODE_CLASSES_BY_TAG[tag["tag_uri"]].__doc__ = docstring
+    else:
+        _create_class_from_tag_uri(tag["tag_uri"], tag["schema_uri"])
+
+
 # List of node classes made available by this library.  This is part
 # of the public API.
-NODE_CLASSES = list(_OBJECT_NODE_CLASSES_BY_TAG.values()) + list(_LIST_NODE_CLASSES_BY_TAG.values())
+NODE_CLASSES = list(_OBJECT_NODE_CLASSES_BY_TAG.values()) + list(_LIST_NODE_CLASSES_BY_TAG.values()) + list(_SCALAR_NODE_CLASSES_BY_TAG.values())

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -483,26 +483,8 @@ class TaggedScalarNodeConverter(Converter):
     def to_yaml_tree(self, obj, tag, ctx):
         node = obj.__class__.__bases__[0](obj)
 
-        validate = asdf.get_config().validate_on_read
-
-        if tag == FileDate._tag:
-            converter = ctx.extension_manager.get_converter_for_type(type(node))
-            node = converter.to_yaml_tree(node, tag, ctx)
-
-        # Move enum check to converter due to bug, see spacetelescope/rad#155
-        elif tag == Origin._tag:
-            if validate and node != 'STSCI':
-                raise jsonschema.ValidationError("origin must be 'STSCI'")
-        elif tag == Telescope._tag:
-            if validate and node != 'ROMAN':
-                raise jsonschema.ValidationError("origin must be 'ROMAN'")
-
-        return node
-
-    def from_yaml_tree(self, node, tag, ctx):
         # Move enum check to converter due to bug, see spacetelescope/rad#155
         validate = asdf.get_config().validate_on_read
-
         if tag == Origin._tag:
             if validate and node != 'STSCI':
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
@@ -510,6 +492,26 @@ class TaggedScalarNodeConverter(Converter):
             if validate and node != 'ROMAN':
                 raise jsonschema.ValidationError("origin must be 'ROMAN'")
 
+        if tag == FileDate._tag:
+            converter = ctx.extension_manager.get_converter_for_type(type(node))
+            node = converter.to_yaml_tree(node, tag, ctx)
+
+        return node
+
+    def from_yaml_tree(self, node, tag, ctx):
+        # Move enum check to converter due to bug, see spacetelescope/rad#155
+        validate = asdf.get_config().validate_on_read
+        if tag == Origin._tag:
+            if validate and node != 'STSCI':
+                raise jsonschema.ValidationError("origin must be 'STSCI'")
+        elif tag == Telescope._tag:
+            if validate and node != 'ROMAN':
+                raise jsonschema.ValidationError("origin must be 'ROMAN'")
+
+        if tag == FileDate._tag:
+            converter = ctx.extension_manager.get_converter_for_type(Time)
+            node = converter.from_yaml_tree(node, tag, ctx)
+            
         return _SCALAR_NODE_CLASSES_BY_TAG[tag](node)
 
 

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -373,10 +373,10 @@ class TaggedScalarNode(metaclass=TaggedScalarNodeMeta):
         if self._ctx is None:
             TaggedScalarNode._ctx = asdf.AsdfFile()
         return self._ctx
-    
+
     def __asdf_traverse__(self):
         return self
-    
+
     @property
     def tag(self):
         return self._tag
@@ -384,7 +384,7 @@ class TaggedScalarNode(metaclass=TaggedScalarNodeMeta):
     @property
     def key(self):
         return _scalar_tag_to_key(self._tag)
-    
+
     def get_schema(self):
         extension_manager = self.ctx.extension_manager
         tag_def = extension_manager.get_tag_definition(self.tag)
@@ -485,10 +485,10 @@ class TaggedScalarNodeConverter(Converter):
 
         # Move enum check to converter due to bug, see spacetelescope/rad#155
         validate = asdf.get_config().validate_on_read
-        if tag == Origin._tag:
+        if tag == Origin._tag: # noqa
             if validate and node != 'STSCI':
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
-        elif tag == Telescope._tag:
+        elif tag == Telescope._tag: # noqa
             if validate and node != 'ROMAN':
                 raise jsonschema.ValidationError("origin must be 'ROMAN'")
 
@@ -501,17 +501,17 @@ class TaggedScalarNodeConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):
         # Move enum check to converter due to bug, see spacetelescope/rad#155
         validate = asdf.get_config().validate_on_read
-        if tag == Origin._tag:
+        if tag == Origin._tag: # noqa
             if validate and node != 'STSCI':
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
-        elif tag == Telescope._tag:
+        elif tag == Telescope._tag: # noqa
             if validate and node != 'ROMAN':
                 raise jsonschema.ValidationError("origin must be 'ROMAN'")
 
         if tag == FileDate._tag:
             converter = ctx.extension_manager.get_converter_for_type(Time)
             node = converter.from_yaml_tree(node, tag, ctx)
-            
+
         return _SCALAR_NODE_CLASSES_BY_TAG[tag](node)
 
 
@@ -568,4 +568,8 @@ for tag in _DATAMODELS_MANIFEST["tags"]:
 
 # List of node classes made available by this library.  This is part
 # of the public API.
-NODE_CLASSES = list(_OBJECT_NODE_CLASSES_BY_TAG.values()) + list(_LIST_NODE_CLASSES_BY_TAG.values()) + list(_SCALAR_NODE_CLASSES_BY_TAG.values())
+NODE_CLASSES = (
+    list(_OBJECT_NODE_CLASSES_BY_TAG.values()) +
+    list(_LIST_NODE_CLASSES_BY_TAG.values()) +
+    list(_SCALAR_NODE_CLASSES_BY_TAG.values())
+)

--- a/src/roman_datamodels/testing/assertions.py
+++ b/src/roman_datamodels/testing/assertions.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from astropy.modeling import Model
 
-from ..stnode import TaggedObjectNode, TaggedListNode
+from ..stnode import TaggedObjectNode, TaggedListNode, TaggedScalarNode
 
 
 def assert_node_equal(node1, node2):
@@ -37,12 +37,17 @@ def assert_node_equal(node1, node2):
 
         for value1, value2 in zip(node1, node2):
             _assert_value_equal(value1, value2)
+    elif isinstance(node1, TaggedScalarNode):
+        value1 = node1.__class__.__bases__[0](node1)
+        value2 = node2.__class__.__bases__[0](node2)
+
+        assert value1 == value2
     else:
         raise RuntimeError(f"Unhandled node class: {node1.__class__.__name__}")
 
 
 def _assert_value_equal(value1, value2):
-    if isinstance(value1, (TaggedObjectNode, TaggedListNode)):
+    if isinstance(value1, (TaggedObjectNode, TaggedListNode, TaggedScalarNode)):
         assert_node_equal(value1, value2)
     elif isinstance(value1, (np.ndarray, NDArrayType)):
         assert_array_equal(value1, value2)

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -409,7 +409,7 @@ def create_ref_meta(**kwargs):
         },
         "origin": "STScI",
         "pedigree": "DUMMY",
-        "telescope": "ROMAN",
+        "telescope": create_telescope(**kwargs),
         "useafter": _random_astropy_time(),
     }
     raw.update(kwargs)

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -26,6 +26,14 @@ __all__ = [
     "create_exposure",
     "create_flat_ref",
     "create_guidestar",
+    "create_file_date",
+    "create_calibration_software_version",
+    "create_filename",
+    "create_model_type",
+    "create_origin",
+    "create_prd_software_version",
+    "create_sdf_software_version",
+    "create_telescope",
     "create_meta",
     "create_node",
     "create_observation",
@@ -771,8 +779,39 @@ def create_guidestar(**kwargs):
 
     return stnode.Guidestar(raw)
 
+def create_file_date(**kwargs):
+    return stnode.FileDate(kwargs.get("file_date", _random_astropy_time()))
 
-def _create_basic_meta():
+
+def create_calibration_software_version(**kwargs):
+    return stnode.CalibrationSoftwareVersion(kwargs.get("calibration_sofware_version", _random_string("Version ", 120)))
+
+
+def create_filename(**kwargs):
+    return stnode.Filename(kwargs.get("filename", _random_string("Filename ", 120)))
+
+
+def create_model_type(**kwargs):
+    return stnode.ModelType(kwargs.get("model_type", _random_string("Model type ", 50)))
+
+
+def create_origin(**kwargs):
+    return stnode.Origin(kwargs.get("origin", "STSCI"))
+
+
+def create_prd_software_version(**kwargs):
+    return stnode.PrdSoftwareVersion(kwargs.get("prd_software_version", _random_string("S&OC PRD ", 120)))
+
+
+def create_sdf_software_version(**kwargs):
+    return stnode.SdfSoftwareVersion(kwargs.get("sdf_software_version", _random_software_version()))
+
+
+def create_telescope(**kwargs):
+    return stnode.Telescope(kwargs.get("telescope", "ROMAN"))
+
+
+def _create_basic_meta(**kwargs):
     """
     Create the metadata from the basic-1.0.0 schema, which is shared
     between references and datasets.
@@ -783,16 +822,16 @@ def _create_basic_meta():
     """
 
     return {
-        "calibration_software_version": _random_string("Version ", 120),
+        "calibration_software_version": create_calibration_software_version(**kwargs),
         "crds_context_used": "roman_{:04d}.pmap".format(_random_positive_int(9999)),
         "crds_software_version": _random_software_version(),
-        "filename": _random_string("Filename ", 120),
-        "file_date": _random_astropy_time(),
-        "model_type": _random_string("Model type ", 50),
-        "origin": "STSCI",
-        "prd_software_version": _random_string("S&OC PRD ", 120),
-        "sdf_software_version": _random_software_version(),
-        "telescope": "ROMAN",
+        "filename": create_filename(**kwargs),
+        "file_date": create_file_date(**kwargs),
+        "model_type": create_model_type(**kwargs),
+        "origin": create_origin(**kwargs),
+        "prd_software_version": create_prd_software_version(**kwargs),
+        "sdf_software_version": create_sdf_software_version(**kwargs),
+        "telescope": create_telescope(**kwargs),
     }
 
 
@@ -827,7 +866,7 @@ def create_meta(**kwargs):
         "visit": create_visit(),
         "wcsinfo": create_wcsinfo(),
     }
-    raw.update(_create_basic_meta())
+    raw.update(_create_basic_meta(**kwargs))
     raw.update(kwargs)
 
     return raw

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -10,7 +10,7 @@ def test_generated_node_classes(manifest):
         class_name = stnode._class_name_from_tag_uri(tag["tag_uri"])
         node_class = getattr(stnode, class_name)
 
-        assert issubclass(node_class, (stnode.TaggedObjectNode, stnode.TaggedListNode))
+        assert issubclass(node_class, (stnode.TaggedObjectNode, stnode.TaggedListNode, stnode.TaggedScalarNode))
         assert node_class._tag == tag["tag_uri"]
         assert tag["description"] in node_class.__doc__
         assert tag["tag_uri"] in node_class.__doc__


### PR DESCRIPTION
These are the changes to the datamodels in order to support PR spacetelescope/rad#153.

The reason for these changes is to enable recovery of the information stored in the schemas for `archive_catalog` and `sdf` from an open data model. If this data is located as a primary key of a tagged schema or under the properties of that schema, then ASDF can easily retrieve this data, to see this note that now more things in the `model.info()` have title comments.

Note that in order to function, currently these have been selected in the `setup.cfg` file which should be updated once the below have been merged

- It will need `rad` with PR spacetelescope/rad#153 merged.
- It will need `asdf-standard` with PR asdf-format/asdf-standard#323