### PR TITLE
Fix times, change W146 to F146, move 'gw_function_start/end' end and 'gw_acq_exec_stat' from guidestar to guidewindow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Add support for new ``rad`` schema tags. [#86]
 
+- Fixed format of exposure times factory functions, changed filter 'W146' to 'F146'. [#87]
+
 0.12.2 (2022-04-26)
 ===================
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -95,8 +95,15 @@ def _random_string_time():
     return datetime.utcfromtimestamp(_random_utc_timestamp()).strftime("%H:%M:%S.%f")[0:12]
 
 
-def _random_astropy_time():
-    return Time(_random_utc_timestamp(), format="unix")
+def _random_astropy_time(time_format='unix'):
+    timeobj =  Time(_random_utc_timestamp(), format="unix")
+
+    if time_format == 'unix':
+        return timeobj
+    else:
+        time_str = timeobj.to_value(format=time_format)
+        timeobj = Time(time_str, format=time_format)
+        return timeobj
 
 
 def _random_int(min=None, max=None):
@@ -200,7 +207,7 @@ def _random_optical_element():
         "F087",
         "F106",
         "F129",
-        "W146",
+        "F146",
         "F158",
         "F184",
         "F213",
@@ -347,7 +354,7 @@ def create_exposure(**kwargs):
         "duration": _random_positive_float(),
         "effective_exposure_time": _random_positive_float(),
         "elapsed_exposure_time": _random_positive_float(),
-        "end_time": _random_astropy_time(),
+        "end_time": _random_astropy_time(time_format='isot'),
         "end_time_mjd": _random_mjd_timestamp(),
         "end_time_tdb": _random_mjd_timestamp(),
         "exposure_time": _random_positive_float(),
@@ -358,13 +365,13 @@ def create_exposure(**kwargs):
         "groupgap": 0,
         "id": _random_positive_int(),
         "integration_time": _random_positive_float(),
-        "mid_time": _random_astropy_time(),
+        "mid_time": _random_astropy_time(time_format='isot'),
         "mid_time_mjd": _random_mjd_timestamp(),
         "mid_time_tdb": _random_mjd_timestamp(),
         "nframes": 8,
         "ngroups": 6,
         "sca_number": _random_positive_int(),
-        "start_time": _random_astropy_time(),
+        "start_time": _random_astropy_time(time_format='isot'),
         "start_time_mjd": _random_mjd_timestamp(),
         "start_time_tdb": _random_mjd_timestamp(),
         "type": _random_exposure_type(),
@@ -690,7 +697,7 @@ def create_wfi_img_photom_ref(**kwargs):
             {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
              "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
              "pixelareasr": 1.0e-13 * u.steradian},
-        "W146":
+        "F146":
             {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
              "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
              "pixelareasr": 1.0e-13 * u.steradian},
@@ -760,10 +767,7 @@ def create_guidestar(**kwargs):
         "gs_udec": _random_positive_float(),
         "gs_umag": _random_positive_float(),
         "gs_ura": _random_positive_float(),
-        "gw_acq_exec_stat": _random_string("Status ", 15),
         "gw_id": _random_string("ID ", 20),
-        "gw_function_end_time": _random_astropy_time(),
-        "gw_function_start_time": _random_astropy_time(),
         "gw_fgs_mode": "WSM-ACQ-2",
         "gw_start_time": _random_astropy_time(),
         "gw_stop_time": _random_astropy_time(),
@@ -1108,6 +1112,8 @@ def create_guidewindow(**kwargs):
     raw["meta"]["file_creation_time"] = _random_astropy_time()
     raw["meta"]["gw_start_time"] = _random_astropy_time()
     raw["meta"]["gw_end_time"] = _random_astropy_time()
+    raw["meta"]["gw_function_start_time"] = _random_astropy_time()
+    raw["meta"]["gw_function_end_time"] = _random_astropy_time()
     raw['meta']['gw_frame_readout_time'] = _random_float()
     raw['meta']['pedestal_resultant_exp_time'] = _random_float()
     raw['meta']['signal_resultant_exp_time'] = _random_float()
@@ -1119,6 +1125,7 @@ def create_guidewindow(**kwargs):
     raw['meta']['gw_window_ystop'] = raw['meta']["gw_window_ystart"] + 16.0
     raw['meta']['gw_window_xsize'] = 16.0
     raw['meta']['gw_window_ysize'] = 16.0
+    raw['meta']['gw_acq_exec_stat'] = _random_string("Status ", 15)
 
     return stnode.Guidewindow(raw)
 

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy import units as u
 from astropy.modeling import models
 
-from .factories import _random_positive_int
+from .factories import _random_positive_int, _random_string
 from .. import stnode
 
 NONUM = -999999
@@ -364,10 +364,6 @@ def mk_guidestar():
     guide['gs_mag'] = NONUM
     guide['gs_umag'] = NONUM
     guide['gw_fgs_mode'] = "WSM-ACQ-2"
-    guide['gw_function_start_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    guide['gw_function_end_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
     guide['data_start'] = NONUM
     guide['data_end'] = NONUM
     guide['gw_acq_exec_stat'] = NOSTR
@@ -847,7 +843,7 @@ def mk_wfi_img_photom(filepath=None):
             {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
              "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
              "pixelareasr": 1.0e-13 * u.steradian},
-        "W146":
+        "F146":
             {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
              "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
              "pixelareasr": 1.0e-13 * u.steradian},
@@ -1054,6 +1050,10 @@ def mk_guidewindow(shape=None, filepath=None):
         '2020-01-01T00:00:00.0', format='isot', scale='utc')
     guidewindow['meta']['gw_end_time'] = time.Time(
         '2020-01-01T10:00:00.0', format='isot', scale='utc')
+    guidewindow['meta']['gw_function_start_time'] = time.Time(
+        '2020-01-01T00:00:00.0', format='isot', scale='utc')
+    guidewindow['meta']['gw_function_end_time'] = time.Time(
+        '2020-01-01T00:00:00.0', format='isot', scale='utc')
     guidewindow['meta']['gw_frame_readout_time'] = NONUM
     guidewindow['meta']['pedestal_resultant_exp_time'] = NONUM
     guidewindow['meta']['signal_resultant_exp_time'] = NONUM
@@ -1065,6 +1065,7 @@ def mk_guidewindow(shape=None, filepath=None):
     guidewindow['meta']['gw_window_ystop'] = guidewindow['meta']['gw_window_ystart'] + 16.0
     guidewindow['meta']['gw_window_xsize'] = 16.0
     guidewindow['meta']['gw_window_ysize'] = 16.0
+    guidewindow['meta']['gw_acq_exec_stat'] = _random_string("Status ", 15)
 
     if not shape:
         shape = (2, 8, 16, 32, 32)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -432,12 +432,12 @@ def test_make_wfi_img_photom():
     wfi_img_photom = utils.mk_wfi_img_photom()
 
     assert wfi_img_photom.meta.reftype == 'PHOTOM'
-    assert isinstance(wfi_img_photom.phot_table.W146.photmjsr, u.Quantity)
+    assert isinstance(wfi_img_photom.phot_table.F146.photmjsr, u.Quantity)
     assert isinstance(wfi_img_photom.phot_table.F184.photmjsr, u.Quantity)
-    assert isinstance(wfi_img_photom.phot_table.W146.uncertainty, u.Quantity)
+    assert isinstance(wfi_img_photom.phot_table.F146.uncertainty, u.Quantity)
     assert isinstance(wfi_img_photom.phot_table.F184.uncertainty, u.Quantity)
     assert isinstance(wfi_img_photom.phot_table.F184.pixelareasr, u.Quantity)
-    assert isinstance(wfi_img_photom.phot_table.W146.pixelareasr, u.Quantity)
+    assert isinstance(wfi_img_photom.phot_table.F146.pixelareasr, u.Quantity)
     assert wfi_img_photom.phot_table.PRISM.photmjsr is None
     assert wfi_img_photom.phot_table.PRISM.uncertainty is None
     assert isinstance(wfi_img_photom.phot_table.PRISM.pixelareasr, u.Quantity)


### PR DESCRIPTION
This PR has a few changes:

- The factory function for creating 'exposure' was setting the exposure start and end times as floats because they were never converted from 'unix' format to 'isot'. There are several other instances where this is happening (when the `_random_astropy_time` function is called), for example in the 'useafter' value, I'm not sure which ones need to be changed so I just fixed the instances in exposure for now.

- Changed filter name from W146 to F146.

- Moved 'gw_function_start', 'gw_function_end,' and 'gw_acq_exec_stat' from factory functions for guidestar to guidewindow ( see https://github.com/spacetelescope/rad/pull/154/).