### PR TITLE
update create_ref_file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Fixed format of exposure times factory functions, changed filter 'W146' to 'F146'. [#87]
 
+- Update create_ref_file() to match updated schema. [#89]
+
 0.12.2 (2022-04-26)
 ===================
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -1400,7 +1400,7 @@ def create_ref_file(**kwargs):
     """
     reftypes = ["dark", "distortion", "flat", "gain", "linearity", "mask", "readnoise",
                 "saturation", "photom" ]
-    val = {"name": "N/A"}
+    val = "N/A"
     raw = dict(zip(reftypes, [val] * len(reftypes)))
     raw["crds"] = {"sw_version": "12.1", "context_used": "781"}
     raw.update(kwargs)


### PR DESCRIPTION
update create_ref_file to be up to date with https://github.com/spacetelescope/rad/pull/157, where reference file names are no longer nested.