### PR TITLE
pin `asdf` to newest patch version to fix dependency for newest `jsonschema` release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.3.0 (unreleased)
 ==================
 
+- pin ``asdf`` above ``2.12.1`` to fix issues with unit and regression tests [#91]
+
 0.12.3 (2022-08-09)
 ===================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     jsonschema>=3.0.2
-    asdf>=2.9.2
+    asdf>=2.12.1
     asdf-astropy>=0.2.0
     psutil>=5.7.2
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =
-    jsonschema>=3.0.2
     asdf>=2.12.1
     asdf-astropy>=0.2.0
     psutil>=5.7.2


### PR DESCRIPTION
related to https://github.com/asdf-format/asdf/pull/1171; when `asdf 2.12.1` is released, this PR can be merged