### PR TITLE
Add IPAC/SSC origin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - pin ``asdf`` above ``2.12.1`` to fix issues with unit and regression tests [#91]
 - Add ability to access information stored in ``rad`` schemas relative to the information stored in the datamodel. [#93]
+- Add ``IPAC/SSC`` as valid ``origin`` values. [#95]
 
 0.12.3 (2022-08-09)
 ===================

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -40,6 +40,10 @@ __all__ = [
 validate = True
 strict_validation = True
 
+# Needed due to enum bug with ASDF
+_VALID_ORIGIN = ["STSCI", "IPAC/SSC"]
+_VALID_TELESCOPE = ["ROMAN"]
+
 
 def set_validate(value):
     global validate
@@ -168,9 +172,9 @@ class DNode(UserDict):
         Permit assigning dict keys as attributes.
         """
         if key[0] != '_':
-            if key == 'origin' and value != 'STSCI':
+            if key == 'origin' and value not in _VALID_ORIGIN:
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
-            elif key == 'telescope' and value != 'ROMAN':
+            elif key == 'telescope' and value not in _VALID_TELESCOPE:
                 raise jsonschema.ValidationError("telescope must be 'ROMAN'")
             value = self._convert_to_scalar(key, value)
             if key in self._data:
@@ -486,10 +490,10 @@ class TaggedScalarNodeConverter(Converter):
         # Move enum check to converter due to bug, see spacetelescope/rad#155
         validate = asdf.get_config().validate_on_read
         if tag == Origin._tag: # noqa
-            if validate and node != 'STSCI':
+            if validate and node not in _VALID_ORIGIN:
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
         elif tag == Telescope._tag: # noqa
-            if validate and node != 'ROMAN':
+            if validate and node not in _VALID_TELESCOPE:
                 raise jsonschema.ValidationError("telescope must be 'ROMAN'")
 
         if tag == FileDate._tag:
@@ -502,10 +506,10 @@ class TaggedScalarNodeConverter(Converter):
         # Move enum check to converter due to bug, see spacetelescope/rad#155
         validate = asdf.get_config().validate_on_read
         if tag == Origin._tag: # noqa
-            if validate and node != 'STSCI':
+            if validate and node not in _VALID_ORIGIN:
                 raise jsonschema.ValidationError("origin must be 'STSCI'")
         elif tag == Telescope._tag: # noqa
-            if validate and node != 'ROMAN':
+            if validate and node not in _VALID_TELESCOPE:
                 raise jsonschema.ValidationError("telescope must be 'ROMAN'")
 
         if tag == FileDate._tag:

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -173,9 +173,9 @@ class DNode(UserDict):
         """
         if key[0] != '_':
             if key == 'origin' and value not in _VALID_ORIGIN:
-                raise jsonschema.ValidationError("origin must be 'STSCI'")
+                raise jsonschema.ValidationError(f"origin must be one of {_VALID_ORIGIN}")
             elif key == 'telescope' and value not in _VALID_TELESCOPE:
-                raise jsonschema.ValidationError("telescope must be 'ROMAN'")
+                raise jsonschema.ValidationError(f"telescope must be one of {_VALID_TELESCOPE}'")
             value = self._convert_to_scalar(key, value)
             if key in self._data:
                 if validate:
@@ -491,10 +491,10 @@ class TaggedScalarNodeConverter(Converter):
         validate = asdf.get_config().validate_on_read
         if tag == Origin._tag: # noqa
             if validate and node not in _VALID_ORIGIN:
-                raise jsonschema.ValidationError("origin must be 'STSCI'")
+                raise jsonschema.ValidationError(f"origin must be one of {_VALID_ORIGIN}")
         elif tag == Telescope._tag: # noqa
             if validate and node not in _VALID_TELESCOPE:
-                raise jsonschema.ValidationError("telescope must be 'ROMAN'")
+                raise jsonschema.ValidationError(f"telescope must be one of {_VALID_TELESCOPE}'")
 
         if tag == FileDate._tag:
             converter = ctx.extension_manager.get_converter_for_type(type(node))
@@ -507,10 +507,10 @@ class TaggedScalarNodeConverter(Converter):
         validate = asdf.get_config().validate_on_read
         if tag == Origin._tag: # noqa
             if validate and node not in _VALID_ORIGIN:
-                raise jsonschema.ValidationError("origin must be 'STSCI'")
+                raise jsonschema.ValidationError(f"origin must be one of {_VALID_ORIGIN}")
         elif tag == Telescope._tag: # noqa
             if validate and node not in _VALID_TELESCOPE:
-                raise jsonschema.ValidationError("telescope must be 'ROMAN'")
+                raise jsonschema.ValidationError(f"telescope must be one of {_VALID_TELESCOPE}'")
 
         if tag == FileDate._tag:
             converter = ctx.extension_manager.get_converter_for_type(Time)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,12 +41,24 @@ def test_core_schema(tmp_path):
     wfi_image = utils.mk_level2_image(shape=(10, 10))
     with asdf.AsdfFile() as af:
         af.tree = {'roman': wfi_image}
+
+        # Test telescope name
         with pytest.raises(ValidationError):
             af.tree['roman'].meta.telescope = 'NOTROMAN'
         af.tree['roman'].meta['telescope'] = 'NOTROMAN'
         with pytest.raises(ValidationError):
             af.write_to(file_path)
         af.tree['roman'].meta.telescope = 'ROMAN'
+
+        # Test origin name
+        with pytest.raises(ValidationError):
+            af.tree['roman'].meta.origin = 'NOTSTSCI'
+        af.tree['roman'].meta['origin'] = 'NOTIPAC/SSC'
+        with pytest.raises(ValidationError):
+            af.write_to(file_path)
+        af.tree['roman'].meta.origin = 'IPAC/SSC'
+        af.tree['roman'].meta.origin = 'STSCI'
+
         af.write_to(file_path)
     # Now mangle the file
     with open(file_path, 'rb') as fp:


### PR DESCRIPTION
Due to a known bug, we have to enforce `enum` constraints on tagged objects through the ASDF converters. This PR adds `IPAC/SSC` to the list of `origin` keywords accepted.