### PR TITLE
Rcal-386 Model Container

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,8 @@ install_requires =
     psutil>=5.7.2
     numpy
     astropy>=5.0.4
-    rad>=0.13.1
+    # rad>=0.13.1
+    rad @ git+https://github.com/PaulHuwe/rad.git@RAD-72_ModelContainer
     asdf-standard>=1.0.3
 package_dir =
     =src

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -296,6 +296,11 @@ class RampFitOutputModel(DataModel):
     pass
 
 
+class AssociationsModel(DataModel):
+    # Need an init to allow instantiation from a JSON file
+    pass
+
+
 class GuidewindowModel(DataModel):
     pass
 
@@ -427,6 +432,7 @@ model_registry = {
     stnode.WfiScienceRaw: ScienceRawModel,
     stnode.Ramp: RampModel,
     stnode.RampFitOutput: RampFitOutputModel,
+    stnode.Associations: AssociationsModel,
     stnode.Guidewindow: GuidewindowModel,
     stnode.FlatRef: FlatRefModel,
     stnode.DarkRef: DarkRefModel,

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -300,6 +300,9 @@ class AssociationsModel(DataModel):
     # Need an init to allow instantiation from a JSON file
     pass
 
+class ModelContainerModel(DataModel):
+    # Needs a number of methods to properly handle the contents
+    pass
 
 class GuidewindowModel(DataModel):
     pass
@@ -433,6 +436,7 @@ model_registry = {
     stnode.Ramp: RampModel,
     stnode.RampFitOutput: RampFitOutputModel,
     stnode.Associations: AssociationsModel,
+    stnode.ModelContainer: ModelContainerModel,
     stnode.Guidewindow: GuidewindowModel,
     stnode.FlatRef: FlatRefModel,
     stnode.DarkRef: DarkRefModel,

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -1082,6 +1082,91 @@ def create_ramp_fit_output(**kwargs):
     return stnode.RampFitOutput(raw)
 
 
+def create_associations(**kwargs):
+    """
+    Create a dummy Association table instance (or file) with table and valid values for attributes
+    required by the schema.
+
+    Parameters
+    ----------
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    roman_datamodels.stnode.Associations
+    """
+
+    raw = {
+#        "meta": create_meta(),
+    }
+    raw.update(kwargs)
+
+    raw["asn_type"] = "image"
+    raw["asn_rule"] = "candidate_Asn_Lv2Image_i2d"
+    raw["version_id"] = "null"
+    raw["code_version"] = "0.16.2.dev16+g640b0b79"
+    raw["degraded_status"] = "No known degraded exposures in association."
+    raw['program'] = 1
+    raw['constraints'] = "DMSAttrConstraint({'name': 'program', 'sources': ['program'], " \
+                         "'value': '001'})\nConstraint_TargetAcq({'name': 'target_acq', 'value': " \
+                         "'target_acquisition'})\nDMSAttrConstraint({'name': 'science', " \
+                         "'DMSAttrConstraint({'name': 'asn_candidate','sources': " \
+                         "['asn_candidate'], 'value': \"\\\\('o036',\\\\ 'observation'\\\\)\"})"
+    raw['asn_id'] = "o036"
+    raw['asn_pool'] = "r00001_20200530t023154_pool"
+    raw['target'] = 16
+
+    length = 7
+
+    exptypes = random.choices(['SCIENCE', 'CALIBRATION', 'ENGINEERING'], k=length)
+    exposerr = ["null"] * length
+    expname = ["file_" + str(x) + ".asdf" for x in range(length)]
+
+    raw['products'] = []
+    raw['products'].append({
+        'name' : "product0",
+        'members' : [{
+            "expname" : expname[0],
+            "exposerr" : exposerr[0],
+            "exptype" : exptypes[0]
+        },
+        {
+            "expname": expname[1],
+            "exposerr": exposerr[1],
+            "exptype": exptypes[1]
+        }]
+    })
+    raw['products'].append({
+        'name': "product1",
+        'members': [{
+            "expname": expname[2],
+            "exposerr": exposerr[2],
+            "exptype": exptypes[2]
+        }]
+    })
+    raw['products'].append({
+        'name': "product1",
+        'members': [{
+            "expname" : expname[3],
+            "exposerr" : exposerr[3],
+            "exptype" : exptypes[3]
+        },
+        {
+            "expname": expname[4],
+            "exposerr": exposerr[4],
+            "exptype": exptypes[4]
+        },
+        {
+            "expname": expname[5],
+            "exposerr": exposerr[5],
+            "exptype": exptypes[5]
+        }]
+    })
+
+    return stnode.Associations(raw)
+
+
 def create_guidewindow(**kwargs):
     """
     Create a dummy Guide Window instance with valid values for attributes

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -1167,6 +1167,68 @@ def create_associations(**kwargs):
     return stnode.Associations(raw)
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def create_model_container(**kwargs):
+    """
+    Create a dummy Model Container instance with valid values for attributes
+    in the schema.
+
+    Parameters
+    ----------
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    roman_datamodels.stnode.ModelContainer
+    """
+
+    raw = {
+        #"meta": create_meta(),
+    }
+    raw.update(kwargs)
+
+    raw["asn_exptypes"] = "image"
+    raw["asn_rule"] = "candidate_Asn_Lv2Image_i2d"
+    raw["asn_table_name"] = "null"
+    raw["asn_pool_name"] = "0.16.2.dev16+g640b0b79"
+    raw["asn_table"] = create_associations()
+    raw['asn_n_members'] = 1
+
+    return stnode.ModelContainer(raw)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def create_guidewindow(**kwargs):
     """
     Create a dummy Guide Window instance with valid values for attributes

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -3,9 +3,11 @@ import astropy.time as time
 import numpy as np
 from astropy import units as u
 from astropy.modeling import models
+from random import choices
 
 from .factories import _random_positive_int, _random_string
 from .. import stnode
+
 
 NONUM = -999999
 NOSTR = "dummy value"
@@ -1017,6 +1019,73 @@ def mk_rampfitoutput(shape=None, filepath=None):
         af.write_to(filepath)
     else:
         return rampfitoutput
+
+def mk_associations(shape=None, filepath=None):
+    """
+    Create a dummy Association table instance (or file) with table and valid values for attributes
+    required by the schema.
+
+    Parameters
+    ----------
+    shape
+        (optional) The shape of the member elements of products.
+
+    filepath
+        (optional) File name and path to write model to.
+
+    Returns
+    -------
+    roman_datamodels.stnode.AssociationsModel
+    """
+
+    associations = stnode.Associations()
+
+    associations["asn_type"] = "image"
+    associations["asn_rule"] = "candidate_Asn_Lv2Image_i2d"
+    associations["version_id"] = "null"
+    associations["code_version"] = "0.16.2.dev16+g640b0b79"
+    associations["degraded_status"] = "No known degraded exposures in association."
+    associations['program'] = 1
+    associations['constraints'] = "DMSAttrConstraint({'name': 'program', 'sources': ['program'], " \
+                         "'value': '001'})\nConstraint_TargetAcq({'name': 'target_acq', 'value': " \
+                         "'target_acquisition'})\nDMSAttrConstraint({'name': 'science', " \
+                         "'DMSAttrConstraint({'name': 'asn_candidate','sources': " \
+                         "['asn_candidate'], 'value': \"\\\\('o036',\\\\ 'observation'\\\\)\"})"
+    associations['asn_id'] = "o036"
+    associations['asn_pool'] = "r00001_20200530t023154_pool"
+    associations['target'] = 16
+
+    if not shape:
+        shape = (2, 3, 1)
+
+    file_idx = 0
+    associations['products'] = []
+    for product_idx in range(len(shape)):
+        exptypes = choices(['SCIENCE', 'CALIBRATION', 'ENGINEERING'], k=shape[product_idx])
+        members_lst = []
+        for member_idx in range(shape[product_idx]):
+            members_lst.append(
+                {
+                    "expname": "file_" + str(file_idx) + ".asdf",
+                    "exposerr": "null",
+                    "exptype": exptypes[member_idx]
+                }
+            )
+            file_idx += 1
+        associations['products'].append(
+            {
+                "name" : "product" + str(product_idx),
+                "members" : members_lst
+            }
+        )
+
+    if filepath:
+        af = asdf.AsdfFile()
+        af.tree = {'roman': associations}
+        af.write_to(filepath)
+    else:
+        return associations
+
 
 def mk_guidewindow(shape=None, filepath=None):
     """

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -7,7 +7,7 @@ from random import choices
 
 from .factories import _random_positive_int, _random_string
 from .. import stnode
-
+from .. import datamodels
 
 NONUM = -999999
 NOSTR = "dummy value"
@@ -1085,6 +1085,87 @@ def mk_associations(shape=None, filepath=None):
         af.write_to(filepath)
     else:
         return associations
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+def mk_model_container(shape=None, hasmodels=True, filepath=None):
+    """
+    Create a dummy Model Container instance (or file) with alid values for attributes required by
+    the schema.
+
+    Parameters
+    ----------
+    shape
+        (optional) The shape of the member elements of products.
+
+    filepath
+        (optional) File name and path to write model to.
+
+    Returns
+    -------
+    roman_datamodels.stnode.AssociationsModel
+    """
+
+    model_container = stnode.Associations()
+
+    model_container["asn_exptypes"] = "image"
+
+    model_container["asn_table_name"] = "asn.json"
+    model_container["asn_pool_name"] = "r00001_20200530t023154_pool"
+    model_container["degraded_status"] = "No known degraded exposures in association."
+
+    if not shape:
+        shape = (2, 3, 1)
+
+    model_container["asn_n_members"] = len(shape)
+
+    model_container["asn_table_name"] = mk_associations(shape=shape)
+
+    model_container["asn_table_name"] = []
+    if hasmodels:
+        for product_group in model_container["asn_table_name"]["products"]:
+            for member in product_group["members"]:
+                model_obj = datamodels.open(member["expname"])
+
+
+
+
+
+    if filepath:
+        af = asdf.AsdfFile()
+        af.tree = {'roman': model_container}
+        af.write_to(filepath)
+    else:
+        return model_container
+
+
+
+
+
+
+
+
+
+
+
 
 
 def mk_guidewindow(shape=None, filepath=None):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,6 +166,47 @@ def test_opening_association_ref(tmp_path):
     assert isinstance(association, datamodels.AssociationsModel)
 
 
+
+
+
+
+
+
+# Model Container tests
+def test_make_model_container():
+    member_shapes = (3, 8, 5, 2)
+    association = utils.mk_associations(shape=member_shapes)
+
+    print("XXX association.products = "+str(association.products))
+
+    assert association.asn_type == "image"
+    assert len(association.products) == len(member_shapes)
+
+    for prod_idx in range(len(member_shapes)):
+        assert association.products[prod_idx].name == "product" + str(prod_idx)
+        assert len(association.products[prod_idx].members) == member_shapes[prod_idx]
+        assert association.products[prod_idx].members[-1].expname == "file_" + str(sum(member_shapes[0:prod_idx+1])-1) + ".asdf"
+        assert association.products[prod_idx].members[-1].exposerr == "null"
+        assert association.products[prod_idx].members[-1].exptype in \
+               ['SCIENCE', 'CALIBRATION', 'ENGINEERING']
+
+    # Test validation
+    association_model = datamodels.AssociationsModel(association)
+    assert association_model.validate() is None
+
+
+def test_opening_model_container_ref(tmp_path):
+    # First make test reference file
+    file_path = tmp_path / 'testassociations.asdf'
+    utils.mk_associations(filepath=file_path)
+    association = datamodels.open(file_path)
+    assert association.program == 1
+    assert isinstance(association, datamodels.AssociationsModel)
+
+
+
+
+
 # Guide Window tests
 def test_make_guidewindow():
     guidewindow = utils.mk_guidewindow(shape=(2, 8, 16, 32, 32))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,6 +134,38 @@ def test_opening_rampfitoutput_ref(tmp_path):
     assert isinstance(rampfitoutput, datamodels.RampFitOutputModel)
 
 
+# Association tests
+def test_make_association():
+    member_shapes = (3, 8, 5, 2)
+    association = utils.mk_associations(shape=member_shapes)
+
+    print("XXX association.products = "+str(association.products))
+
+    assert association.asn_type == "image"
+    assert len(association.products) == len(member_shapes)
+
+    for prod_idx in range(len(member_shapes)):
+        assert association.products[prod_idx].name == "product" + str(prod_idx)
+        assert len(association.products[prod_idx].members) == member_shapes[prod_idx]
+        assert association.products[prod_idx].members[-1].expname == "file_" + str(sum(member_shapes[0:prod_idx+1])-1) + ".asdf"
+        assert association.products[prod_idx].members[-1].exposerr == "null"
+        assert association.products[prod_idx].members[-1].exptype in \
+               ['SCIENCE', 'CALIBRATION', 'ENGINEERING']
+
+    # Test validation
+    association_model = datamodels.AssociationsModel(association)
+    assert association_model.validate() is None
+
+
+def test_opening_association_ref(tmp_path):
+    # First make test reference file
+    file_path = tmp_path / 'testassociations.asdf'
+    utils.mk_associations(filepath=file_path)
+    association = datamodels.open(file_path)
+    assert association.program == 1
+    assert isinstance(association, datamodels.AssociationsModel)
+
+
 # Guide Window tests
 def test_make_guidewindow():
     guidewindow = utils.mk_guidewindow(shape=(2, 8, 16, 32, 32))


### PR DESCRIPTION
This is just an initial stab at creating the model container datamodel in romandatamodels. Please focus on the maker utility (mk_model_container in testing/utils.py) and the test of the model (test_make_model_container in tests/test_models.py) for comments. There is a great deal of code in the model definition (methods) in JWST which has not been ported yet, like the details of JSON interfacing, management of the models in the list, etc.