### PR TITLE
properly handle string input to `filetype.check()`

### DIFF
--- a/src/roman_datamodels/filetype.py
+++ b/src/roman_datamodels/filetype.py
@@ -21,7 +21,7 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
 
     supported = ('asdf', 'json')
 
-    if isinstance(init, (os.PathLike, Path)):
+    if isinstance(init, (str, os.PathLike, Path)):
         path, ext = os.path.splitext(init)
         ext = ext.strip('.')
 
@@ -39,8 +39,7 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
             return 'asn'
 
         return ext
-
-    if hasattr(init, "read") and hasattr(init, "seek"):
+    elif hasattr(init, "read") and hasattr(init, "seek"):
         magic = init.read(5)
         init.seek(0, 0)
 
@@ -51,5 +50,5 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
             return "asdf"
 
         return "asn"
-
-    raise ValueError(f"Cannot get file type of {str(init)}")
+    else:
+        raise ValueError(f"Cannot get file type of {str(init)}")

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -16,6 +16,7 @@ def test_filetype():
     file_6 = filetype.check(open(DATA_DIRECTORY / 'pluto.asdf', 'rb'))
     file_7 = filetype.check(DATA_DIRECTORY / 'fake.asdf')
     file_8 = filetype.check(open(DATA_DIRECTORY / 'fake.asdf'))
+    file_9 = filetype.check(str(DATA_DIRECTORY / 'pluto.asdf'))
 
     assert file_1 == 'asn'
     assert file_2 == 'asn'
@@ -26,6 +27,7 @@ def test_filetype():
     assert file_6 == 'asdf'
     assert file_7 == 'asdf'
     assert file_8 == 'asn'
+    assert file_9 == 'asdf'
 
     with pytest.raises(ValueError):
         filetype.check(DATA_DIRECTORY / 'empty.txt')


### PR DESCRIPTION
The `check` function as modified in https://github.com/spacetelescope/roman_datamodels/pull/99 only checked `os.PathLike` and `pathlib.Path`. This fixes that issue and adds a test for the case of string input.