### PR TITLE
Add `gwcs` as a dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.14.0 (unreleased)
 ===================
 
--
+- Explicitly add ``gwcs`` to the list of dependencies. [#108]
 
 0.13.0 (2022-08-23)
 ===================

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ setup_requires =
 install_requires =
     asdf>=2.13.0
     asdf-astropy>=0.2.0
+    gwcs>=0.18.1
     psutil>=5.7.2
     numpy
     astropy>=5.0.4


### PR DESCRIPTION
As stated in #107, once cannot read L2 files using `roman_datamodels` only. This is because they include `gwcs` information. Since `roman_datamodels` provides the ASDF file read/write for support for all the data models used by Roman installing it should require all of the ASDF file read/write support libraries for the objects which are contained with the data models themselves which are written to the files.

Fixes #107