### PR TITLE
fix style errors

### DIFF
--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -24,7 +24,6 @@ import rad.resources
 from .stuserdict import STUserDict as UserDict
 from .units import Unit, CompositeUnit
 
-from roman_datamodels.units import Unit, CompositeUnit, force_roman_unit
 
 if sys.version_info < (3, 9):
     import importlib_resources

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,12 @@ commands=
     coverage run --source=roman_datamodels -m pytest
     coverage report -m
     codecov -e TOXENV
-passenv= TOXENV CI TRAVIS TRAVIS_* CODECOV_* DISPLAY HOME
+passenv=
+    TOXENV
+    CI
+    CODECOV_*
+    HOME
+    CRDS_*
 
 [testenv:bandit]
 deps=


### PR DESCRIPTION
#111 introduced style errors into `main` by importing functions twice. This attempts to fix them.