### PR TITLE
RCAL-439: RDM: Add support for Reference File Quantities

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,7 @@ install_requires =
     astropy>=5.0.4
     #rad>=0.14.0
     # Temporary path for github PR tests
-    #rad @git+https://github.com/spacetelescope/rad.git@main
-    rad @git+https://github.com/PaulHuwe/rad.git@RAD-105_RefFileQuantities
+    rad @git+https://github.com/spacetelescope/rad.git@main
     asdf-standard>=1.0.3
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,8 @@ install_requires =
     astropy>=5.0.4
     #rad>=0.14.0
     # Temporary path for github PR tests
-    rad @git+https://github.com/spacetelescope/rad.git@main
+    #rad @git+https://github.com/spacetelescope/rad.git@main
+    rad @git+https://github.com/PaulHuwe/rad.git@RAD-105_RefFileQuantities
     asdf-standard>=1.0.3
 package_dir =
     =src

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -479,9 +479,9 @@ def create_dark_ref(**kwargs):
     roman_datamodels.stnode.DarkRef
     """
     raw = {
-        "data": _random_array_float32((2, 4096, 4096)),
+        "data": _random_array_float32((2, 4096, 4096), units=ru.DN),
         "dq": _random_array_uint32(),
-        "err": _random_array_float32((2, 4096, 4096)),
+        "err": _random_array_float32((2, 4096, 4096), units=ru.DN),
         "meta": create_ref_meta(reftype="DARK")
     }
     raw.update(kwargs)
@@ -532,7 +532,7 @@ def create_gain_ref(**kwargs):
     roman_datamodels.stnode.GainRef
     """
     raw = {
-        "data": _random_array_float32((4096, 4096)),
+        "data": _random_array_float32((4096, 4096), units=ru.electron / ru.DN),
         "meta": create_ref_meta(reftype="GAIN"),
     }
     raw.update(kwargs)
@@ -554,7 +554,7 @@ def create_linearity_ref(**kwargs):
     roman_datamodels.stnode.LinearityRef
     """
     raw = {
-        "coeffs": _random_array_float32((2, 4096, 4096)),
+        "coeffs": _random_array_float32((2, 4096, 4096), units=ru.DN),
         "dq": _random_array_uint32((4096, 4096)),
         "meta": create_ref_meta(reftype="LINEARITY"),
     }
@@ -626,7 +626,7 @@ def create_readnoise_ref(**kwargs):
     roman_datamodels.stnode.ReadnoiseRef
     """
     raw = {
-        "data": _random_array_float32((4096, 4096)),
+        "data": _random_array_float32((4096, 4096), units=ru.DN),
         "meta": create_ref_meta(reftype="READNOISE"),
     }
     raw.update(kwargs)
@@ -649,7 +649,7 @@ def create_saturation_ref(**kwargs):
     roman_datamodels.stnode.SaturationRef
     """
     raw = {
-        "data": _random_array_float32((4096, 4096)),
+        "data": _random_array_float32((4096, 4096), units=ru.DN),
         "dq": _random_array_uint32((4096, 4096)),
         "meta": create_ref_meta(reftype="SATURATION"),
     }

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -554,7 +554,7 @@ def create_linearity_ref(**kwargs):
     roman_datamodels.stnode.LinearityRef
     """
     raw = {
-        "coeffs": _random_array_float32((2, 4096, 4096), units=ru.DN),
+        "coeffs": _random_array_float32((2, 4096, 4096)),
         "dq": _random_array_uint32((4096, 4096)),
         "meta": create_ref_meta(reftype="LINEARITY"),
     }

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -560,6 +560,9 @@ def create_linearity_ref(**kwargs):
     }
     raw.update(kwargs)
 
+    raw['meta']['input_units'] = ru.DN
+    raw['meta']['output_units'] = ru.DN
+
     return stnode.LinearityRef(raw)
 
 

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -728,7 +728,7 @@ def mk_linearity(shape=None, filepath=None):
         shape = (2, 4096, 4096)
 
     linearityref['dq'] = np.zeros(shape[1:], dtype=np.uint32)
-    linearityref['coeffs'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    linearityref['coeffs'] = np.zeros(shape, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -724,6 +724,9 @@ def mk_linearity(shape=None, filepath=None):
     meta['reftype'] = 'LINEARITY'
     linearityref['meta'] = meta
 
+    linearityref['meta']['input_units'] = ru.DN
+    linearityref['meta']['output_units'] = ru.DN
+
     if not shape:
         shape = (2, 4096, 4096)
 

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -619,9 +619,9 @@ def mk_dark(shape=None, filepath=None):
     if not shape:
         shape = (2, 4096, 4096)
 
-    darkref['data'] = np.zeros(shape, dtype=np.float32)
+    darkref['data'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
     darkref['dq'] = np.zeros(shape[1:], dtype=np.uint32)
-    darkref['err'] = np.zeros(shape, dtype=np.float32)
+    darkref['err'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -692,7 +692,7 @@ def mk_gain(shape=None, filepath=None):
     if not shape:
         shape = (4096, 4096)
 
-    gainref['data'] = np.zeros(shape, dtype=np.float32)
+    gainref['data'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -727,8 +727,8 @@ def mk_linearity(shape=None, filepath=None):
     if not shape:
         shape = (2, 4096, 4096)
 
-    linearityref['coeffs'] = np.zeros(shape, dtype=np.float32)
     linearityref['dq'] = np.zeros(shape[1:], dtype=np.uint32)
+    linearityref['coeffs'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -918,7 +918,7 @@ def mk_readnoise(shape=None, filepath=None):
     if not shape:
         shape = (4096, 4096)
 
-    readnoiseref['data'] = np.zeros(shape, dtype=np.float32)
+    readnoiseref['data'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -1131,8 +1131,8 @@ def mk_saturation(shape=None, filepath=None):
     if not shape:
         shape = (4096, 4096)
 
-    saturationref['data'] = np.zeros(shape, dtype=np.float32)
     saturationref['dq'] = np.zeros(shape, dtype=np.uint32)
+    saturationref['data'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -315,7 +315,6 @@ def test_make_linearity():
     linearity = utils.mk_linearity(shape=(2, 20, 20))
     assert linearity.meta.reftype == 'LINEARITY'
     assert linearity.coeffs.dtype == np.float32
-    assert linearity.coeffs.unit == ru.DN
     assert linearity.dq.dtype == np.uint32
 
     # Test validation

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@ import warnings
 
 from jsonschema import ValidationError
 from astropy import units as u
+from roman_datamodels import units as ru
 import asdf
 from astropy.modeling import Model
 import numpy as np
@@ -83,11 +84,13 @@ def test_make_ramp():
 
     assert ramp.meta.exposure.type == 'WFI_IMAGE'
     assert ramp.data.dtype == np.float32
+    assert ramp.data.unit == ru.DN
     assert ramp.pixeldq.dtype == np.uint32
     assert ramp.pixeldq.shape == (20, 20)
     assert ramp.groupdq.dtype == np.uint8
     assert ramp.err.dtype == np.float32
     assert ramp.err.shape == (2, 20, 20)
+    assert ramp.err.unit == ru.DN
 
     # Test validation
     ramp = datamodels.RampModel(ramp)
@@ -109,14 +112,22 @@ def test_make_rampfitoutput():
 
     assert rampfitoutput.meta.exposure.type == 'WFI_IMAGE'
     assert rampfitoutput.slope.dtype == np.float32
+    assert rampfitoutput.slope.unit == ru.electron / u.s
     assert rampfitoutput.sigslope.dtype == np.float32
+    assert rampfitoutput.sigslope.unit == ru.electron / u.s
     assert rampfitoutput.yint.dtype == np.float32
+    assert rampfitoutput.yint.unit == ru.electron
     assert rampfitoutput.sigyint.dtype == np.float32
+    assert rampfitoutput.sigyint.unit == ru.electron
     assert rampfitoutput.pedestal.dtype == np.float32
+    assert rampfitoutput.pedestal.unit == ru.electron
     assert rampfitoutput.weights.dtype == np.float32
     assert rampfitoutput.crmag.dtype == np.float32
+    assert rampfitoutput.crmag.unit == ru.electron
     assert rampfitoutput.var_poisson.dtype == np.float32
+    assert rampfitoutput.var_poisson.unit == ru.electron**2 / u.s**2
     assert rampfitoutput.var_rnoise.dtype == np.float32
+    assert rampfitoutput.var_rnoise.unit == ru.electron**2 / u.s**2
     assert rampfitoutput.var_poisson.shape == (2, 20, 20)
     assert rampfitoutput.pedestal.shape == (20, 20)
 
@@ -140,8 +151,11 @@ def test_make_guidewindow():
 
     assert guidewindow.meta.exposure.type == 'WFI_IMAGE'
     assert guidewindow.pedestal_frames.dtype == np.uint16
+    assert guidewindow.pedestal_frames.unit == ru.DN
     assert guidewindow.signal_frames.dtype == np.uint16
+    assert guidewindow.signal_frames.unit == ru.DN
     assert guidewindow.amp33.dtype == np.uint16
+    assert guidewindow.amp33.unit == ru.DN
     assert guidewindow.pedestal_frames.shape == (2, 8, 16, 32, 32)
     assert guidewindow.signal_frames.shape == (2, 8, 16, 32, 32)
     assert guidewindow.amp33.shape == (2, 8, 16, 32, 32)
@@ -236,6 +250,7 @@ def test_make_dark():
     assert dark.dq.dtype == np.uint32
     assert dark.dq.shape == (20, 20)
     assert dark.err.dtype == np.float32
+    assert dark.data.unit == ru.DN
 
     # Test validation
     dark_model = datamodels.DarkRefModel(dark)
@@ -279,6 +294,7 @@ def test_make_gain():
     gain = utils.mk_gain(shape=(20, 20))
     assert gain.meta.reftype == 'GAIN'
     assert gain.data.dtype == np.float32
+    assert gain.data.unit == ru.electron / ru.DN
 
     # Test validation
     gain_model = datamodels.GainRefModel(gain)
@@ -299,6 +315,7 @@ def test_make_linearity():
     linearity = utils.mk_linearity(shape=(2, 20, 20))
     assert linearity.meta.reftype == 'LINEARITY'
     assert linearity.coeffs.dtype == np.float32
+    assert linearity.coeffs.unit == ru.DN
     assert linearity.dq.dtype == np.uint32
 
     # Test validation
@@ -362,6 +379,7 @@ def test_make_readnoise():
     readnoise = utils.mk_readnoise(shape=(20, 20))
     assert readnoise.meta.reftype == 'READNOISE'
     assert readnoise.data.dtype == np.float32
+    assert readnoise.data.unit == ru.DN
 
     # Test validation
     readnoise_model = datamodels.ReadnoiseRefModel(readnoise)
@@ -401,6 +419,8 @@ def test_make_saturation():
     saturation = utils.mk_saturation(shape=(20, 20))
     assert saturation.meta.reftype == 'SATURATION'
     assert saturation.dq.dtype == np.uint32
+    assert saturation.data.dtype == np.float32
+    assert saturation.data.unit == ru.DN
 
     # Test validation
     saturation_model = datamodels.SaturationRefModel(saturation)
@@ -445,11 +465,17 @@ def test_make_wfi_img_photom():
 
     assert wfi_img_photom.meta.reftype == 'PHOTOM'
     assert isinstance(wfi_img_photom.phot_table.F146.photmjsr, u.Quantity)
+    assert wfi_img_photom.phot_table.F146.photmjsr.unit == u.megajansky / u.steradian
     assert isinstance(wfi_img_photom.phot_table.F184.photmjsr, u.Quantity)
+
     assert isinstance(wfi_img_photom.phot_table.F146.uncertainty, u.Quantity)
     assert isinstance(wfi_img_photom.phot_table.F184.uncertainty, u.Quantity)
+    assert wfi_img_photom.phot_table.F184.uncertainty.unit == u.megajansky / u.steradian
+
     assert isinstance(wfi_img_photom.phot_table.F184.pixelareasr, u.Quantity)
     assert isinstance(wfi_img_photom.phot_table.F146.pixelareasr, u.Quantity)
+    assert wfi_img_photom.phot_table.GRISM.pixelareasr.unit == u.steradian
+
     assert wfi_img_photom.phot_table.PRISM.photmjsr is None
     assert wfi_img_photom.phot_table.PRISM.uncertainty is None
     assert isinstance(wfi_img_photom.phot_table.PRISM.pixelareasr, u.Quantity)
@@ -474,6 +500,7 @@ def test_level1_science_raw():
     wfi_science_raw = utils.mk_level1_science_raw()
 
     assert wfi_science_raw.data.dtype == np.uint16
+    assert wfi_science_raw.data.unit == ru.DN
 
     # Test validation
     wfi_science_raw_model = datamodels.ScienceRawModel(wfi_science_raw)
@@ -495,10 +522,14 @@ def test_level2_image():
     wfi_image = utils.mk_level2_image()
 
     assert wfi_image.data.dtype == np.float32
+    assert wfi_image.data.unit == ru.electron / u.s
     assert wfi_image.dq.dtype == np.uint32
     assert wfi_image.err.dtype == np.float32
+    assert wfi_image.err.unit == ru.electron / u.s
     assert wfi_image.var_poisson.dtype == np.float32
+    assert wfi_image.var_poisson.unit == ru.electron**2 / u.s**2
     assert wfi_image.var_rnoise.dtype == np.float32
+    assert wfi_image.var_rnoise.unit == ru.electron ** 2 / u.s ** 2
     assert wfi_image.var_flat.dtype == np.float32
     assert type(wfi_image.cal_logs[0]) == str
 


### PR DESCRIPTION
Update factory, maker utils, and tests to support reference file data arrays changed to quantities in RAD.

Also added unit tests for data science quantities.

NOTE: setup.cfg is temporarily pointing to the RAD branch needed for tests to pass. I will update this when the RAD PR is merged.