### PR TITLE
Start using code-formatters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,11 @@ repos:
   hooks:
     - id: isort
 
+- repo: https://github.com/psf/black
+  rev: 22.12.0
+  hooks:
+    - id: black
+
 - repo: https://github.com/pycqa/flake8
   rev: '6.0.0'
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,11 +33,15 @@ repos:
     - id: pyupgrade
       args: ["--py38-plus"]
 
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+
 - repo: https://github.com/pycqa/flake8
   rev: '6.0.0'
   hooks:
   -   id: flake8
-
 
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Move metadata to ``pyproject.toml`` in accordance with PEP621 [#100]
 - Cleanup ``enum`` validation code. [#112]
 - Add ``pre-commit`` support. [#119]
+- Apply ``isort`` and ``black`` code formatters to all files. [#120]
 
 0.14.0 (2022-11-14)
 ===================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,18 +32,18 @@ def setup(app):
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../'))
-sys.path.insert(0, os.path.abspath('roman_datamodels/'))
+sys.path.insert(0, os.path.abspath("../"))
+sys.path.insert(0, os.path.abspath("roman_datamodels/"))
 
 # -- General configuration ------------------------------------------------
 with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:
     conf = tomli.load(configuration_file)
-setup_cfg = conf['project']
+setup_cfg = conf["project"]
 
 # If your documentation needs a minimal Sphinx version, state it here.
 # needs_sphinx = '1.3'
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 
 def check_sphinx_version(expected_version):
@@ -51,64 +51,60 @@ def check_sphinx_version(expected_version):
     expected_version = LooseVersion(expected_version)
     if sphinx_version < expected_version:
         raise RuntimeError(
-            f"At least Sphinx version {expected_version} is required to build this "
-            f"documentation.  Found {sphinx_version}.")
+            f"At least Sphinx version {expected_version} is required to build this documentation.  Found {sphinx_version}."
+        )
 
 
 # Configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/',
-               (None, 'http://data.astropy.org/intersphinx/python3.inv')),
-    'numpy': ('https://numpy.org/doc/stable/',
-              (None, 'http://data.astropy.org/intersphinx/numpy.inv')),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/',
-              (None, 'http://data.astropy.org/intersphinx/scipy.inv')),
-    'matplotlib': ('https://matplotlib.org/stable/',
-                   (None, 'http://data.astropy.org/intersphinx/matplotlib.inv')),
-    'astropy': ('https://docs.astropy.org/en/stable/', None),
-    'asdf': ('https://asdf.readthedocs.io/en/stable/', None),
-    'psutil': ('https://psutil.readthedocs.io/en/stable/', None),
+    "python": ("https://docs.python.org/3/", (None, "http://data.astropy.org/intersphinx/python3.inv")),
+    "numpy": ("https://numpy.org/doc/stable/", (None, "http://data.astropy.org/intersphinx/numpy.inv")),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", (None, "http://data.astropy.org/intersphinx/scipy.inv")),
+    "matplotlib": ("https://matplotlib.org/stable/", (None, "http://data.astropy.org/intersphinx/matplotlib.inv")),
+    "astropy": ("https://docs.astropy.org/en/stable/", None),
+    "asdf": ("https://asdf.readthedocs.io/en/stable/", None),
+    "psutil": ("https://psutil.readthedocs.io/en/stable/", None),
 }
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'pytest_doctestplus.sphinx.doctestplus',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.napoleon',
-    'sphinx_automodapi.automodapi',
-    'sphinx_automodapi.automodsumm',
-    'sphinx_automodapi.autodoc_enhancements',
-    'sphinx_automodapi.smart_resolver',
-    'sphinx_asdf',
+    "pytest_doctestplus.sphinx.doctestplus",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.inheritance_diagram",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx_automodapi.automodapi",
+    "sphinx_automodapi.automodsumm",
+    "sphinx_automodapi.autodoc_enhancements",
+    "sphinx_automodapi.smart_resolver",
+    "sphinx_asdf",
 ]
 
 if on_rtd:
-    extensions.append('sphinx.ext.mathjax')
+    extensions.append("sphinx.ext.mathjax")
 
-elif LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
-    extensions.append('sphinx.ext.pngmath')
+elif LooseVersion(sphinx.__version__) < LooseVersion("1.4"):
+    extensions.append("sphinx.ext.pngmath")
 else:
-    extensions.append('sphinx.ext.imgmath')
+    extensions.append("sphinx.ext.imgmath")
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # A list of warning types to suppress arbitrary warning messages. We mean to
 # override directives in astropy_helpers.sphinx.ext.autodoc_enhancements,
@@ -116,13 +112,15 @@ master_doc = 'index'
 # released in upstream Sphinx (https://github.com/sphinx-doc/sphinx/pull/1843).
 # Suppress the warnings requires Sphinx v1.4.2
 
-suppress_warnings = ['app.add_directive', ]
+suppress_warnings = [
+    "app.add_directive",
+]
 
 # General information about the project
-project = setup_cfg['name']
+project = setup_cfg["name"]
 primary_author = setup_cfg["authors"][0]
 author = f'{primary_author["name"]} <{primary_author["email"]}>'
-copyright = f'{datetime.datetime.now().year}, {author}'
+copyright = f"{datetime.datetime.now().year}, {author}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -131,12 +129,12 @@ copyright = f'{datetime.datetime.now().year}, {author}'
 # The short X.Y version.
 package = importlib.import_module(project)
 try:
-    version = package.__version__.split('-', 1)[0]
+    version = package.__version__.split("-", 1)[0]
     # The full version, including alpha/beta/rc tags.
     release = package.__version__
 except AttributeError:
-    version = 'dev'
-    release = 'dev'
+    version = "dev"
+    release = "dev"
 
 # The language for content autogenerated by Sphinx. Refer to documentation
 # for a list of supported languages.
@@ -150,7 +148,7 @@ except AttributeError:
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
@@ -158,7 +156,7 @@ rst_epilog = """.. _roman_datamodels: high-level_API.html"""
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-default_role = 'obj'
+default_role = "obj"
 
 # Don't show summaries of the members in each class along with the
 # class' docstring
@@ -166,7 +164,7 @@ numpydoc_show_class_members = False
 
 autosummary_generate = True
 
-automodapi_toctreedirnm = 'api'
+automodapi_toctreedirnm = "api"
 
 # Class documentation should contain *both* the class docstring and
 # the __init__ docstring
@@ -176,12 +174,12 @@ autoclass_content = "both"
 graphviz_output_format = "svg"
 
 graphviz_dot_args = [
-    '-Nfontsize=10',
-    '-Nfontname=Helvetica Neue, Helvetica, Arial, sans-serif',
-    '-Efontsize=10',
-    '-Efontname=Helvetica Neue, Helvetica, Arial, sans-serif',
-    '-Gfontsize=10',
-    '-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif'
+    "-Nfontsize=10",
+    "-Nfontname=Helvetica Neue, Helvetica, Arial, sans-serif",
+    "-Efontsize=10",
+    "-Efontname=Helvetica Neue, Helvetica, Arial, sans-serif",
+    "-Gfontsize=10",
+    "-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif",
 ]
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
@@ -196,7 +194,7 @@ graphviz_dot_args = [
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'default'
+pygments_style = "default"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -206,22 +204,19 @@ pygments_style = 'default'
 
 # Mapping for links to the ASDF Standard in ASDF schema documentation
 asdf_schema_reference_mappings = [
-    ('tag:stsci.edu:asdf',
-     'http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/'),
+    ("tag:stsci.edu:asdf", "http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/"),
 ]
 
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'stsci_rtd_theme'
+html_theme = "stsci_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    "collapse_navigation": True
-}
+html_theme_options = {"collapse_navigation": True}
 #        "nosidebar": "false",
 #        "sidebarbgcolor": "#4db8ff",
 #        "sidebartextcolor": "black",
@@ -259,14 +254,14 @@ html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = "%b %d, %Y"
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 # html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'**': ['globaltoc.html', 'relations.html', 'searchbox.html']}
+html_sidebars = {"**": ["globaltoc.html", "relations.html", "searchbox.html"]}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
@@ -299,7 +294,7 @@ html_use_index = True
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'roman_datamodelsdoc'
+htmlhelp_basename = "roman_datamodelsdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -345,10 +340,7 @@ htmlhelp_basename = 'roman_datamodelsdoc'
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ('index', 'roman_datamodels', 'Roman Datamodels Documentation',
-     ['roman_datamodels'], 1)
-]
+man_pages = [("index", "roman_datamodels", "Roman Datamodels Documentation", ["roman_datamodels"], 1)]
 
 # If true, show URL addresses after external links.
 man_show_urls = True
@@ -359,9 +351,15 @@ man_show_urls = True
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'roman_datamodels', 'Roman Datamodels Documentation',
-     'roman_datamodels', 'roman_datamodels', 'Roman Datamodels Documentation',
-     'Miscellaneous'),
+    (
+        "index",
+        "roman_datamodels",
+        "Roman Datamodels Documentation",
+        "roman_datamodels",
+        "roman_datamodels",
+        "Roman Datamodels Documentation",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
@@ -371,7 +369,7 @@ texinfo_documents = [
 texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-texinfo_show_urls = 'inline'
+texinfo_show_urls = "inline"
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
@@ -380,10 +378,10 @@ texinfo_show_urls = 'inline'
 # -- Options for Epub output ----------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = 'Roman'
-epub_author = 'STSCI'
-epub_publisher = 'STSCI'
-epub_copyright = '2017, AURA'
+epub_title = "Roman"
+epub_author = "STSCI"
+epub_publisher = "STSCI"
+epub_copyright = "2017, AURA"
 
 # The basename for the epub file. It defaults to the project name.
 # epub_basename = u'Roman'
@@ -392,7 +390,7 @@ epub_copyright = '2017, AURA'
 # optimized for small screen space, using the same theme for HTML and
 # epub output is usually not wise. This defaults to 'epub', a theme designed
 # to save visual space.
-epub_theme = 'epub'
+epub_theme = "epub"
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.
@@ -423,7 +421,7 @@ epub_theme = 'epub'
 # epub_post_files = []
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+epub_exclude_files = ["search.html"]
 
 # The depth of the table of contents in toc.ncx.
 # epub_tocdepth = 3
@@ -449,5 +447,5 @@ epub_exclude_files = ['search.html']
 # Enable nitpicky mode - which ensures that all references in the docs resolve.
 nitpicky = True
 nitpick_ignore = [
-    ('py:class', '_io.FileIO'),
+    ("py:class", "_io.FileIO"),
 ]

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -7,7 +7,7 @@ def _docdir(request):
     # Trigger ONLY for doctestplus.
     doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
     if isinstance(request.node.parent, doctest_plugin._doctest_textfile_item_cls):
-        tmpdir = request.getfixturevalue('tmpdir')
+        tmpdir = request.getfixturevalue("tmpdir")
         with tmpdir.as_cwd():
             yield
     else:

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture(autouse=True)
 def _docdir(request):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,8 @@ exclude_lines = [
     'def main\(.*\):',
     'if __name__ == \(.*\):',
 ]
+
+[tool.isort]
+profile = "black"
+filter_files = true
+line_length = 130

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,16 @@ exclude_lines = [
 profile = "black"
 filter_files = true
 line_length = 130
+
+[tool.black]
+line-length = 130
+force-exclude = '''
+^/(
+  (
+      \.eggs
+    | \.git
+    | \.pytest_cache
+    | \.tox
+  )/
+)
+'''

--- a/scripts/insert_next_release
+++ b/scripts/insert_next_release
@@ -3,9 +3,8 @@
 Insert the next release's changelog header.  Prints the version, which
 our GitHub Actions workflow uses to generate a commit message.
 """
-from pathlib import Path
 import re
-
+from pathlib import Path
 
 RELEASED_VERSION_RE = re.compile(r"\A(?P<major>[0-9]+)\.(?P<minor>[0-9])+\.[0-9]+ \([0-9]{4}-[0-9]{2}-[0-9]{2}\)$", re.MULTILINE)
 

--- a/scripts/insert_next_release
+++ b/scripts/insert_next_release
@@ -29,5 +29,6 @@ def main():
 
     print(version, end=None)
 
+
 if __name__ == "__main__":
     main()

--- a/scripts/set_release_date
+++ b/scripts/set_release_date
@@ -4,10 +4,9 @@ Set the (latest and unreleased) changelog header release date to today.
 Prints the version, which our GitHub Actions workflow uses to
 generate a commit message and release tag.
 """
+import re
 from datetime import date
 from pathlib import Path
-import re
-
 
 UNRELEASED_VERSION_RE = re.compile(r"\A(?P<version>[0-9]+\.[0-9]+\.[0-9]+) \(unreleased\)$", re.MULTILINE)
 

--- a/scripts/set_release_date
+++ b/scripts/set_release_date
@@ -28,5 +28,6 @@ def main():
 
     print(version, end=None)
 
+
 if __name__ == "__main__":
     main()

--- a/src/roman_datamodels/__init__.py
+++ b/src/roman_datamodels/__init__.py
@@ -2,4 +2,4 @@
 from ._version import version as __version__
 from .datamodels import DataModel, open
 
-__all__ = ['open', 'DataModel', '__version__']
+__all__ = ["open", "DataModel", "__version__"]

--- a/src/roman_datamodels/__init__.py
+++ b/src/roman_datamodels/__init__.py
@@ -1,6 +1,5 @@
 # from .util import open
-from .datamodels import DataModel, open
 from ._version import version as __version__
-
+from .datamodels import DataModel, open
 
 __all__ = ['open', 'DataModel', '__version__']

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -6,20 +6,20 @@ keep consistency with the JWST data model version.
 
 It is to be subclassed by the various types of data model variants for products
 '''
-from pathlib import PurePath
+import copy
 import datetime
-import sys
-import asdf
 import os
 import os.path
-import copy
-import numpy as np
-from astropy.time import Time
-from asdf.fits_embed import AsdfInFits
-from . import stnode
-from . import validate
-from . extensions import DATAMODEL_EXTENSIONS
+import sys
+from pathlib import PurePath
 
+import asdf
+import numpy as np
+from asdf.fits_embed import AsdfInFits
+from astropy.time import Time
+
+from . import stnode, validate
+from .extensions import DATAMODEL_EXTENSIONS
 
 __all__ = [
     'DataModel',

--- a/src/roman_datamodels/extensions.py
+++ b/src/roman_datamodels/extensions.py
@@ -1,6 +1,6 @@
 from asdf.extension import ManifestExtension
-from .stnode import TaggedListNodeConverter, TaggedObjectNodeConverter, TaggedScalarNodeConverter, UnitConverter
 
+from .stnode import TaggedListNodeConverter, TaggedObjectNodeConverter, TaggedScalarNodeConverter, UnitConverter
 
 DATAMODEL_CONVERTERS = [
     TaggedObjectNodeConverter(),

--- a/src/roman_datamodels/extensions.py
+++ b/src/roman_datamodels/extensions.py
@@ -10,7 +10,5 @@ DATAMODEL_CONVERTERS = [
 ]
 
 DATAMODEL_EXTENSIONS = [
-    ManifestExtension.from_uri(
-        "asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0",
-        converters=DATAMODEL_CONVERTERS)
+    ManifestExtension.from_uri("asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0", converters=DATAMODEL_CONVERTERS)
 ]

--- a/src/roman_datamodels/filetype.py
+++ b/src/roman_datamodels/filetype.py
@@ -21,24 +21,24 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
 
     """
 
-    supported = ('asdf', 'json')
+    supported = ("asdf", "json")
 
     if isinstance(init, (str, os.PathLike, Path)):
         path, ext = os.path.splitext(init)
-        ext = ext.strip('.')
+        ext = ext.strip(".")
 
         if not ext:
-            raise ValueError(f'Input file path does not have an extension: {init}')
+            raise ValueError(f"Input file path does not have an extension: {init}")
 
         if ext not in supported:  # Could be the file is zipped; try splitting again
             path, ext = os.path.splitext(path)
-            ext = ext.strip('.')
+            ext = ext.strip(".")
 
             if ext not in supported:
-                raise ValueError(f'Unrecognized file type for: {init}')
+                raise ValueError(f"Unrecognized file type for: {init}")
 
-        if ext == 'json':  # Assume json input is an association
-            return 'asn'
+        if ext == "json":  # Assume json input is an association
+            return "asn"
 
         return ext
     elif hasattr(init, "read") and hasattr(init, "seek"):
@@ -48,7 +48,7 @@ def check(init: Union[os.PathLike, Path, io.FileIO]) -> str:
         if not magic or len(magic) < 5:
             raise ValueError(f"Cannot get file type of {str(init)}")
 
-        if magic == b'#ASDF':
+        if magic == b"#ASDF":
             return "asdf"
 
         return "asn"

--- a/src/roman_datamodels/integration.py
+++ b/src/roman_datamodels/integration.py
@@ -9,4 +9,5 @@ def get_extensions():
     List[`asdf.extension.Extension`]
     """
     from . import extensions
+
     return extensions.DATAMODEL_EXTENSIONS

--- a/src/roman_datamodels/mktest.py
+++ b/src/roman_datamodels/mktest.py
@@ -10,175 +10,175 @@ NOSTR = "dummy value"
 
 
 def mk_level2_image(filepath, outfilepath):
-    '''
+    """
     Read in the tentative l2 image file that doesn't use tags
     and cast into a tagged version.
-    '''
+    """
     afin = asdf.open(filepath)
-    imeta = afin.tree['meta']
+    imeta = afin.tree["meta"]
     exp = stnode.Exposure()
-    exp['count'] = NONUM
-    exp['type'] = NONUM
-    exp['start_time'] = NOSTR
-    exp['mid_time'] = NOSTR
-    exp['end_time'] = NOSTR
-    exp['start_time_mjd'] = NONUM
-    exp['mid_time_mjd'] = NONUM
-    exp['end_time_mjd'] = NONUM
-    exp['start_time_tdb'] = NONUM
-    exp['mid_time_tdb'] = NONUM
-    exp['end_time_tdb'] = NONUM
-    exp['start_time_eng'] = NOSTR
-    exp['ngroups'] = NONUM
-    exp['nframes'] = NONUM
-    exp['data_problem'] = False
-    exp['gain_factor'] = NONUM
-    exp['integration_time'] = NONUM
-    exp['elapsed_exposure_time'] = NONUM
-    exp['nints'] = NONUM
-    exp['integration_start'] = NONUM
-    exp['integration_end'] = NONUM
-    exp['frame_divisor'] = NONUM
-    exp['groupgap'] = NONUM
-    exp['nsamples'] = NONUM
-    exp['sample_time'] = NONUM
-    exp['frame_time'] = NONUM
-    exp['group_time'] = NONUM
-    exp['exposure_time'] = NONUM
-    exp['effective_exposure_time'] = NONUM
-    exp['duration'] = NONUM
-    exp['nresets_at_start'] = NONUM
+    exp["count"] = NONUM
+    exp["type"] = NONUM
+    exp["start_time"] = NOSTR
+    exp["mid_time"] = NOSTR
+    exp["end_time"] = NOSTR
+    exp["start_time_mjd"] = NONUM
+    exp["mid_time_mjd"] = NONUM
+    exp["end_time_mjd"] = NONUM
+    exp["start_time_tdb"] = NONUM
+    exp["mid_time_tdb"] = NONUM
+    exp["end_time_tdb"] = NONUM
+    exp["start_time_eng"] = NOSTR
+    exp["ngroups"] = NONUM
+    exp["nframes"] = NONUM
+    exp["data_problem"] = False
+    exp["gain_factor"] = NONUM
+    exp["integration_time"] = NONUM
+    exp["elapsed_exposure_time"] = NONUM
+    exp["nints"] = NONUM
+    exp["integration_start"] = NONUM
+    exp["integration_end"] = NONUM
+    exp["frame_divisor"] = NONUM
+    exp["groupgap"] = NONUM
+    exp["nsamples"] = NONUM
+    exp["sample_time"] = NONUM
+    exp["frame_time"] = NONUM
+    exp["group_time"] = NONUM
+    exp["exposure_time"] = NONUM
+    exp["effective_exposure_time"] = NONUM
+    exp["duration"] = NONUM
+    exp["nresets_at_start"] = NONUM
     # Fill from file
-    for key in imeta['exposure'].keys():
-        exp[key] = imeta['exposure'][key]
+    for key in imeta["exposure"].keys():
+        exp[key] = imeta["exposure"][key]
 
     mode = stnode.WfiMode()
-    mode['name'] = NOSTR
-    mode['detector'] = NOSTR
-    mode['optical_element'] = NOSTR
-    for key in imeta['instrument'].keys():
-        mode[key] = imeta['instrument'][key]
+    mode["name"] = NOSTR
+    mode["detector"] = NOSTR
+    mode["optical_element"] = NOSTR
+    for key in imeta["instrument"].keys():
+        mode[key] = imeta["instrument"][key]
 
     prog = stnode.Program()
-    prog['title'] = NOSTR
-    prog['pi_name'] = NOSTR
-    prog['category'] = NOSTR
-    prog['sub_category'] = NOSTR
-    prog['science_category'] = NOSTR
-    prog['continuation_id'] = NONUM
-    for key in imeta['program'].keys():
-        prog[key] = imeta['program'][key]
+    prog["title"] = NOSTR
+    prog["pi_name"] = NOSTR
+    prog["category"] = NOSTR
+    prog["sub_category"] = NOSTR
+    prog["science_category"] = NOSTR
+    prog["continuation_id"] = NONUM
+    for key in imeta["program"].keys():
+        prog[key] = imeta["program"][key]
 
     obs = stnode.Observation()
-    obs['date'] = NOSTR
-    obs['time'] = NOSTR
-    obs['date_beg'] = NOSTR
-    obs['date_end'] = NOSTR
-    obs['obs_id'] = NOSTR
-    obs['visit_id'] = NOSTR
-    obs['program_number'] = NOSTR
-    obs['execution_plan_number'] = NOSTR
-    obs['pass_number'] = NOSTR
-    obs['leg_number'] = NOSTR
-    obs['observation_number'] = NOSTR
-    obs['visit_number'] = NOSTR
-    obs['visit_group'] = NOSTR
-    obs['activity_id'] = NOSTR
-    obs['exposure_number'] = NOSTR
-    obs['template'] = NOSTR
-    obs['observation_label'] = NOSTR
-    obs['observation_folder'] = NOSTR
-    obs['ma_table_name'] = NOSTR
-    for key in imeta['observation'].keys():
-        obs[key] = imeta['observation'][key]
+    obs["date"] = NOSTR
+    obs["time"] = NOSTR
+    obs["date_beg"] = NOSTR
+    obs["date_end"] = NOSTR
+    obs["obs_id"] = NOSTR
+    obs["visit_id"] = NOSTR
+    obs["program_number"] = NOSTR
+    obs["execution_plan_number"] = NOSTR
+    obs["pass_number"] = NOSTR
+    obs["leg_number"] = NOSTR
+    obs["observation_number"] = NOSTR
+    obs["visit_number"] = NOSTR
+    obs["visit_group"] = NOSTR
+    obs["activity_id"] = NOSTR
+    obs["exposure_number"] = NOSTR
+    obs["template"] = NOSTR
+    obs["observation_label"] = NOSTR
+    obs["observation_folder"] = NOSTR
+    obs["ma_table_name"] = NOSTR
+    for key in imeta["observation"].keys():
+        obs[key] = imeta["observation"][key]
 
     ephem = stnode.Ephemeris()
-    ephem['earth_angle'] = NONUM
-    ephem['moon_angle'] = NONUM
-    ephem['sun_angle'] = NONUM
-    ephem['type'] = NOSTR
-    ephem['time'] = NONUM
-    ephem['spatial_x'] = NONUM
-    ephem['spatial_y'] = NONUM
-    ephem['spatial_z'] = NONUM
-    ephem['velocity_x'] = NONUM
-    ephem['velocity_y'] = NONUM
-    ephem['velocity_z'] = NONUM
-    for key in imeta['ephemeris'].keys():
-        ephem[key] = imeta['ephemeris'][key]
+    ephem["earth_angle"] = NONUM
+    ephem["moon_angle"] = NONUM
+    ephem["sun_angle"] = NONUM
+    ephem["type"] = NOSTR
+    ephem["time"] = NONUM
+    ephem["spatial_x"] = NONUM
+    ephem["spatial_y"] = NONUM
+    ephem["spatial_z"] = NONUM
+    ephem["velocity_x"] = NONUM
+    ephem["velocity_y"] = NONUM
+    ephem["velocity_z"] = NONUM
+    for key in imeta["ephemeris"].keys():
+        ephem[key] = imeta["ephemeris"][key]
 
     visit = stnode.Visit()
-    visit['engineering_quality'] = 'OK'  # qqqq
-    visit['pointing_engdb_quality'] = 'CALCULATED'  # qqqq
-    visit['type'] = NOSTR
-    visit['start_time'] = NOSTR
-    visit['end_time'] = NOSTR
-    visit['status'] = NOSTR
-    visit['total_exposures'] = NONUM
-    visit['internal_target'] = False
-    for key in imeta['visit'].keys():
-        visit[key] = imeta['visit'][key]
+    visit["engineering_quality"] = "OK"  # qqqq
+    visit["pointing_engdb_quality"] = "CALCULATED"  # qqqq
+    visit["type"] = NOSTR
+    visit["start_time"] = NOSTR
+    visit["end_time"] = NOSTR
+    visit["status"] = NOSTR
+    visit["total_exposures"] = NONUM
+    visit["internal_target"] = False
+    for key in imeta["visit"].keys():
+        visit[key] = imeta["visit"][key]
 
     phot = stnode.Photometry()
-    phot['conversion_megajanskys'] = NONUM
-    phot['conversion_microjanskys'] = NONUM
-    phot['pixelarea_steradians'] = NONUM
-    phot['pixelarea_arcsecsq'] = NONUM
-    for key in imeta['photometry'].keys():
-        phot[key] = imeta['photometry'][key]
+    phot["conversion_megajanskys"] = NONUM
+    phot["conversion_microjanskys"] = NONUM
+    phot["pixelarea_steradians"] = NONUM
+    phot["pixelarea_arcsecsq"] = NONUM
+    for key in imeta["photometry"].keys():
+        phot[key] = imeta["photometry"][key]
 
     coord = stnode.Coordinates()
-    coord['reference_frame'] = NOSTR
-    for key in imeta['coordinates'].keys():
-        coord[key] = imeta['coordinates'][key]
+    coord["reference_frame"] = NOSTR
+    for key in imeta["coordinates"].keys():
+        coord[key] = imeta["coordinates"][key]
 
     aper = stnode.Aperture()
     aperlist = []
-    aper['name'] = NOSTR
-    aper['position_angle'] = NONUM
+    aper["name"] = NOSTR
+    aper["position_angle"] = NONUM
     for key in aperlist:
-        aper[key] = imeta['aperture'][key]
+        aper[key] = imeta["aperture"][key]
 
     point = stnode.Pointing()
-    point['ra_v1'] = NONUM
-    point['dec_v1'] = NONUM
-    point['pa_v3'] = NONUM
-    for key in imeta['pointing'].keys():
-        point[key] = imeta['pointing'][key]
+    point["ra_v1"] = NONUM
+    point["dec_v1"] = NONUM
+    point["pa_v3"] = NONUM
+    for key in imeta["pointing"].keys():
+        point[key] = imeta["pointing"][key]
 
     targ = stnode.Target()
-    targ['proposer_name'] = NOSTR
-    targ['catalog_name'] = NOSTR
-    targ['type'] = NOSTR
-    targ['ra'] = NONUM
-    targ['dec'] = NONUM
-    targ['ra_uncertainty'] = NONUM
-    targ['dec_uncertainty'] = NONUM
-    targ['proper_motion_ra'] = NONUM
-    targ['proper_motion_dec'] = NONUM
-    targ['proper_motion_epoch'] = NOSTR
-    targ['proposer_ra'] = NONUM
-    targ['proposer_dec'] = NONUM
-    targ['source_type_apt'] = 'POINT'  # qqqq
-    targ['source_type'] = 'POINT'  # qqqq
-    for key in imeta['target'].keys():
-        targ[key] = imeta['target'][key]
+    targ["proposer_name"] = NOSTR
+    targ["catalog_name"] = NOSTR
+    targ["type"] = NOSTR
+    targ["ra"] = NONUM
+    targ["dec"] = NONUM
+    targ["ra_uncertainty"] = NONUM
+    targ["dec_uncertainty"] = NONUM
+    targ["proper_motion_ra"] = NONUM
+    targ["proper_motion_dec"] = NONUM
+    targ["proper_motion_epoch"] = NOSTR
+    targ["proposer_ra"] = NONUM
+    targ["proposer_dec"] = NONUM
+    targ["source_type_apt"] = "POINT"  # qqqq
+    targ["source_type"] = "POINT"  # qqqq
+    for key in imeta["target"].keys():
+        targ[key] = imeta["target"][key]
 
     vab = stnode.VelocityAberration()
-    vab['ra_offset'] = NONUM
-    vab['dec_offset'] = NONUM
-    vab['scale_factor'] = NONUM
-    for key in imeta['velocity_aberration'].keys():
-        vab[key] = imeta['velocity_aberration'][key]
+    vab["ra_offset"] = NONUM
+    vab["dec_offset"] = NONUM
+    vab["scale_factor"] = NONUM
+    for key in imeta["velocity_aberration"].keys():
+        vab[key] = imeta["velocity_aberration"][key]
 
     wcsi = stnode.Wcsinfo()
-    wcsi['v2_ref'] = NONUM
-    wcsi['v3_ref'] = NONUM
-    wcsi['vparity'] = NONUM
-    wcsi['v3yangle'] = NONUM
-    wcsi['ra_ref'] = NONUM
-    wcsi['dec_ref'] = NONUM
-    wcsi['roll_ref'] = NONUM
+    wcsi["v2_ref"] = NONUM
+    wcsi["v3_ref"] = NONUM
+    wcsi["vparity"] = NONUM
+    wcsi["v3yangle"] = NONUM
+    wcsi["ra_ref"] = NONUM
+    wcsi["dec_ref"] = NONUM
+    wcsi["roll_ref"] = NONUM
 
     # guide = stnode.Guidestar()
     # guide['gs_start_time'] = NOSTR
@@ -212,38 +212,38 @@ def mk_level2_image(filepath, outfilepath):
     #   guide[key] = imeta['guidestar'][key]
 
     cstep = stnode.CalStep()
-    cstep['flat_field'] = 'INCOMPLETE'
+    cstep["flat_field"] = "INCOMPLETE"
 
     meta = {}
-    meta['filename'] = os.path.basename(outfilepath)
-    meta['date'] = time.Time(imeta['date'], format='isot', scale='utc')
-    meta['exposure'] = exp
-    meta['instrument'] = mode
-    meta['observation'] = obs
-    meta['program'] = prog
-    meta['ephemeris'] = ephem
-    meta['visit'] = visit
-    meta['photometry'] = phot
-    meta['coordinates'] = coord
-    meta['aperture'] = aper
-    meta['pointing'] = point
-    meta['target'] = targ
-    meta['velocity_aberration'] = vab
-    meta['wcsinfo'] = wcsi
-    #meta['guidestar'] = guide
-    meta['cal_step'] = cstep
+    meta["filename"] = os.path.basename(outfilepath)
+    meta["date"] = time.Time(imeta["date"], format="isot", scale="utc")
+    meta["exposure"] = exp
+    meta["instrument"] = mode
+    meta["observation"] = obs
+    meta["program"] = prog
+    meta["ephemeris"] = ephem
+    meta["visit"] = visit
+    meta["photometry"] = phot
+    meta["coordinates"] = coord
+    meta["aperture"] = aper
+    meta["pointing"] = point
+    meta["target"] = targ
+    meta["velocity_aberration"] = vab
+    meta["wcsinfo"] = wcsi
+    # meta['guidestar'] = guide
+    meta["cal_step"] = cstep
     wfi_image = stnode.WfiImage()
-    wfi_image['meta'] = meta
-    wfi_image['data'] = afin.tree['data']
-    wfi_image['dq'] = afin.tree['dq']
-    wfi_image['err'] = afin.tree['err']
-    wfi_image['var_poisson'] = afin.tree['var_poisson']
-    wfi_image['var_rnoise'] = afin.tree['var_rnoise']
-    wfi_image['var_flat'] = afin.tree['var_rnoise'] * 0
-    wfi_image['area'] = afin.tree['area']
-    wfi_image['cal_logs'] = stnode.CalLogs()
+    wfi_image["meta"] = meta
+    wfi_image["data"] = afin.tree["data"]
+    wfi_image["dq"] = afin.tree["dq"]
+    wfi_image["err"] = afin.tree["err"]
+    wfi_image["var_poisson"] = afin.tree["var_poisson"]
+    wfi_image["var_rnoise"] = afin.tree["var_rnoise"]
+    wfi_image["var_flat"] = afin.tree["var_rnoise"] * 0
+    wfi_image["area"] = afin.tree["area"]
+    wfi_image["cal_logs"] = stnode.CalLogs()
     afout = asdf.AsdfFile()
-    afout.tree = {'roman': wfi_image}
+    afout.tree = {"roman": wfi_image}
     afout.write_to(outfilepath)
 
 
@@ -252,23 +252,23 @@ def mk_flat(outfilepath):
     afoldref = asdf.open(oldref)
     afot = afoldref.tree
     wfimode = stnode.WfiMode()
-    wfimode['name'] = 'WFI'
-    wfimode['detector'] = 'WFI01'
-    wfimode['optical_element'] = 'F158'
+    wfimode["name"] = "WFI"
+    wfimode["detector"] = "WFI01"
+    wfimode["optical_element"] = "F158"
     meta = {}
-    meta['telescope'] = 'ROMAN'
-    meta['instrument'] = wfimode
-    meta['reftype'] = 'FLAT'
-    meta['pedigree'] = afot['meta']['pedigree']
-    meta['description'] = afot['meta']['description']
-    meta['author'] = afot['meta']['author']
-    meta['useafter'] = afot['meta']['useafter']
+    meta["telescope"] = "ROMAN"
+    meta["instrument"] = wfimode
+    meta["reftype"] = "FLAT"
+    meta["pedigree"] = afot["meta"]["pedigree"]
+    meta["description"] = afot["meta"]["description"]
+    meta["author"] = afot["meta"]["author"]
+    meta["useafter"] = afot["meta"]["useafter"]
     flatref = stnode.FlatRef()
-    flatref['meta'] = meta
+    flatref["meta"] = meta
 
-    flatref['data'] = afot['data']
-    flatref['dq'] = afot['dq']
-    flatref['err'] = afot['err']
+    flatref["data"] = afot["data"]
+    flatref["dq"] = afot["dq"]
+    flatref["err"] = afot["err"]
     afout = asdf.AsdfFile()
-    afout.tree = {'roman': flatref}
+    afout.tree = {"roman": flatref}
     afout.write_to(outfilepath)

--- a/src/roman_datamodels/mktest.py
+++ b/src/roman_datamodels/mktest.py
@@ -1,7 +1,9 @@
-from . import stnode
+import os.path
+
 import asdf
 import astropy.time as time
-import os.path
+
+from . import stnode
 
 NONUM = -999999
 NOSTR = "dummy value"

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -51,18 +51,16 @@ strict_validation = True
 _UNIT_NODE_CLASSES_BY_TAG = {Unit._tag: Unit}
 
 
-
 def set_validate(value):
     global validate
     validate = bool(value)
 
 
 validator_callbacks = HashableDict(asdfschema.YAML_VALIDATORS)
-validator_callbacks.update({'type': _check_type})
+validator_callbacks.update({"type": _check_type})
 
 
-def _value_change(path, value, schema, pass_invalid_values,
-                  strict_validation, ctx):
+def _value_change(path, value, schema, pass_invalid_values, strict_validation, ctx):
     """
     Validate a change in value against a schema.
     Trap error and return a flag.
@@ -90,14 +88,9 @@ def _check_value(value, schema, validator_context):
 
     validator_resolver = validator_context.resolver
 
-    temp_schema = {
-        '$schema':
-        'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'}
+    temp_schema = {"$schema": "http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema"}
     temp_schema.update(schema)
-    validator = asdfschema.get_validator(temp_schema,
-                                         validator_context,
-                                         validator_callbacks,
-                                         validator_resolver)
+    validator = asdfschema.get_validator(temp_schema, validator_context, validator_callbacks, validator_resolver)
 
     validator.validate(value, _schema=temp_schema)
     validator_context.close()
@@ -109,10 +102,10 @@ def _validate(attr, instance, schema, ctx):
 
 
 def _get_schema_for_property(schema, attr):
-    subschema = schema.get('properties', {}).get(attr, None)
+    subschema = schema.get("properties", {}).get(attr, None)
     if subschema is not None:
         return subschema
-    for combiner in ['allOf', 'anyOf']:
+    for combiner in ["allOf", "anyOf"]:
         for subschema in schema.get(combiner, []):
             subsubschema = _get_schema_for_property(subschema, attr)
             if subsubschema != {}:
@@ -128,9 +121,9 @@ class DNode(UserDict):
     def __init__(self, node=None, parent=None, name=None):
 
         if node is None:
-            self.__dict__['_data'] = {}
+            self.__dict__["_data"] = {}
         elif isinstance(node, dict):
-            self.__dict__['_data'] = node
+            self.__dict__["_data"] = node
         else:
             raise ValueError("Initializer only accepts dicts")
         self._x_schema = None
@@ -161,8 +154,8 @@ class DNode(UserDict):
         Permit accessing dict keys as attributes, assuming they are legal Python
         variable names.
         """
-        if key.startswith('_'):
-            raise AttributeError(f'No attribute {key}')
+        if key.startswith("_"):
+            raise AttributeError(f"No attribute {key}")
         if key in self._data:
             value = self._convert_to_scalar(key, self._data[key])
             if isinstance(value, dict):
@@ -178,22 +171,21 @@ class DNode(UserDict):
         """
         Permit assigning dict keys as attributes.
         """
-        if key[0] != '_':
+        if key[0] != "_":
             value = self._convert_to_scalar(key, value)
             if key in self._data:
                 if validate:
                     self._schema()
-                    schema = self._x_schema.get('properties')
+                    schema = self._x_schema.get("properties")
                     if schema is None:
                         # See if the key is in one of the combiners.
                         # This implementation is not completely general
                         # A more robust one would potentially handle nested
                         # references, though that is probably unlikely
                         # in practical cases.
-                        for combiner in ['allOf', 'anyOf']:
+                        for combiner in ["allOf", "anyOf"]:
                             for subschema in self._x_schema.get(combiner, []):
-                                subsubschema = _get_schema_for_property(
-                                    subschema, key)
+                                subsubschema = _get_schema_for_property(subschema, key)
                                 if subsubschema != {}:
                                     schema = subsubschema
                                     break
@@ -201,10 +193,9 @@ class DNode(UserDict):
                         schema = schema.get(key, None)
                     if schema is None or _validate(key, value, schema, self.ctx):
                         self._data[key] = value
-                self.__dict__['_data'][key] = value
+                self.__dict__["_data"][key] = value
             else:
-                raise AttributeError(
-                    f"No such attribute ({key}) found in node")
+                raise AttributeError(f"No such attribute ({key}) found in node")
         else:
             self.__dict__[key] = value
 
@@ -219,6 +210,7 @@ class DNode(UserDict):
             { "meta.observation.date": "2012-04-22T03:22:05.432" }
 
         """
+
         def convert_val(val):
             if isinstance(val, datetime.datetime):
                 return val.isoformat()
@@ -229,8 +221,9 @@ class DNode(UserDict):
         if include_arrays:
             return {key: convert_val(val) for (key, val) in self.items()}
         else:
-            return {key: convert_val(val) for (key, val) in self.items()
-                        if not isinstance(val, (np.ndarray, ndarray.NDArrayType))}
+            return {
+                key: convert_val(val) for (key, val) in self.items() if not isinstance(val, (np.ndarray, ndarray.NDArrayType))
+            }
 
     def _schema(self):
         """
@@ -294,8 +287,7 @@ class TaggedObjectNodeMeta(ABCMeta):
         super().__init__(*args, **kwargs)
         if self.__name__ != "TaggedObjectNode":
             if self._tag in _OBJECT_NODE_CLASSES_BY_TAG:
-                raise RuntimeError(
-                    f"TaggedObjectNode class for tag '{self._tag}' has been defined twice")
+                raise RuntimeError(f"TaggedObjectNode class for tag '{self._tag}' has been defined twice")
             _OBJECT_NODE_CLASSES_BY_TAG[self._tag] = self
 
 
@@ -335,13 +327,11 @@ class TaggedListNodeMeta(ABCMeta):
         super().__init__(*args, **kwargs)
         if self.__name__ != "TaggedListNode":
             if self._tag in _LIST_NODE_CLASSES_BY_TAG:
-                raise RuntimeError(
-                    f"TaggedListNode class for tag '{self._tag}' has been defined twice")
+                raise RuntimeError(f"TaggedListNode class for tag '{self._tag}' has been defined twice")
             _LIST_NODE_CLASSES_BY_TAG[self._tag] = self
 
 
 class TaggedListNode(LNode, metaclass=TaggedListNodeMeta):
-
     @property
     def tag(self):
         return self._tag
@@ -352,7 +342,7 @@ _SCALAR_NODE_CLASSES_BY_KEY = {}
 
 
 def _scalar_tag_to_key(tag):
-    return tag.split('/')[-1].split('-')[0]
+    return tag.split("/")[-1].split("-")[0]
 
 
 class TaggedScalarNodeMeta(ABCMeta):
@@ -365,8 +355,7 @@ class TaggedScalarNodeMeta(ABCMeta):
         super().__init__(*args, **kwargs)
         if self.__name__ != "TaggedScalarNode":
             if self._tag in _SCALAR_NODE_CLASSES_BY_TAG:
-                raise RuntimeError(
-                    f"TaggedScalarNode class for tag '{self._tag}' has been defined twice")
+                raise RuntimeError(f"TaggedScalarNode class for tag '{self._tag}' has been defined twice")
             _SCALAR_NODE_CLASSES_BY_TAG[self._tag] = self
             _SCALAR_NODE_CLASSES_BY_KEY[_scalar_tag_to_key(self._tag)] = self
 
@@ -432,6 +421,7 @@ class TaggedObjectNodeConverter(Converter):
     """
     Converter for all subclasses of TaggedObjectNode.
     """
+
     @property
     def tags(self):
         return list(_OBJECT_NODE_CLASSES_BY_TAG.keys())
@@ -454,6 +444,7 @@ class TaggedListNodeConverter(Converter):
     """
     Converter for all subclasses of TaggedListNode.
     """
+
     @property
     def tags(self):
         return list(_LIST_NODE_CLASSES_BY_TAG.keys())
@@ -476,6 +467,7 @@ class TaggedScalarNodeConverter(Converter):
     """
     Converter for all subclasses of TaggedScalarNode.
     """
+
     @property
     def tags(self):
         return list(_SCALAR_NODE_CLASSES_BY_TAG.keys())
@@ -544,7 +536,6 @@ class UnitConverter(Converter):
 
         return obj.to_string()
 
-
     def from_yaml_tree(self, node, tag, ctx):
         import astropy.units as u
 
@@ -553,8 +544,7 @@ class UnitConverter(Converter):
         return force_roman_unit(u.Unit(node, parse_strict="silent"))
 
 
-_DATAMODELS_MANIFEST_PATH = importlib_resources.files(
-    rad.resources) / "manifests" / "datamodels-1.0.yaml"
+_DATAMODELS_MANIFEST_PATH = importlib_resources.files(rad.resources) / "manifests" / "datamodels-1.0.yaml"
 _DATAMODELS_MANIFEST = yaml.safe_load(_DATAMODELS_MANIFEST_PATH.read_bytes())
 
 
@@ -565,6 +555,7 @@ def _class_name_from_tag_uri(tag_uri):
         class_name += "Ref"
     return class_name
 
+
 def _class_from_tag(tag, docstring):
     class_name = _class_name_from_tag_uri(tag["tag_uri"])
 
@@ -573,15 +564,13 @@ def _class_from_tag(tag, docstring):
         cls = type(
             class_name,
             (str, TaggedScalarNode),
-            {"_tag": tag["tag_uri"],
-                "__module__": "roman_datamodels.stnode", "__doc__": docstring},
+            {"_tag": tag["tag_uri"], "__module__": "roman_datamodels.stnode", "__doc__": docstring},
         )
     else:
         cls = type(
             class_name,
             (TaggedObjectNode,),
-            {"_tag": tag["tag_uri"],
-                "__module__": "roman_datamodels.stnode", "__doc__": docstring},
+            {"_tag": tag["tag_uri"], "__module__": "roman_datamodels.stnode", "__doc__": docstring},
         )
 
     globals()[class_name] = cls
@@ -609,8 +598,8 @@ for tag in _DATAMODELS_MANIFEST["tags"]:
 # List of node classes made available by this library.  This is part
 # of the public API.
 NODE_CLASSES = (
-    list(_OBJECT_NODE_CLASSES_BY_TAG.values()) +
-    list(_LIST_NODE_CLASSES_BY_TAG.values()) +
-    list(_SCALAR_NODE_CLASSES_BY_TAG.values()) +
-    list(_UNIT_NODE_CLASSES_BY_TAG.values())
+    list(_OBJECT_NODE_CLASSES_BY_TAG.values())
+    + list(_LIST_NODE_CLASSES_BY_TAG.values())
+    + list(_SCALAR_NODE_CLASSES_BY_TAG.values())
+    + list(_UNIT_NODE_CLASSES_BY_TAG.values())
 )

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -2,28 +2,27 @@
 Proof of concept of using tags with the data model framework
 """
 
+import datetime
 import sys
 import warnings
-import datetime
 from abc import ABCMeta
-from asdf.extension import Converter
 from collections import UserList
-import yaml
-import jsonschema
-import numpy as np
 
-from astropy.time import Time
 import asdf
 import asdf.schema as asdfschema
 import asdf.yamlutil as yamlutil
-from asdf.util import HashableDict
-from asdf.tags.core import ndarray
-
-from .validate import _check_type, ValidationWarning, _error_message
+import jsonschema
+import numpy as np
 import rad.resources
-from .stuserdict import STUserDict as UserDict
-from .units import Unit, CompositeUnit
+import yaml
+from asdf.extension import Converter
+from asdf.tags.core import ndarray
+from asdf.util import HashableDict
+from astropy.time import Time
 
+from .stuserdict import STUserDict as UserDict
+from .units import CompositeUnit, Unit
+from .validate import ValidationWarning, _check_type, _error_message
 
 if sys.version_info < (3, 9):
     import importlib_resources
@@ -548,6 +547,7 @@ class UnitConverter(Converter):
 
     def from_yaml_tree(self, node, tag, ctx):
         import astropy.units as u
+
         from roman_datamodels.units import force_roman_unit
 
         return force_roman_unit(u.Unit(node, parse_strict="silent"))

--- a/src/roman_datamodels/stuserdict.py
+++ b/src/roman_datamodels/stuserdict.py
@@ -25,23 +25,23 @@ import _collections_abc
 # except ImportError:
 #     pass
 
+
 class STUserDict(_collections_abc.MutableMapping):
 
     # Start by filling-out the abstract methods
     def __init__(*args, **kwargs):
         if not args:
-            raise TypeError("descriptor '__init__' of 'STUserDict' object "
-                            "needs an argument")
+            raise TypeError("descriptor '__init__' of 'STUserDict' object needs an argument")
         self, *args = args
         if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+            raise TypeError("expected at most 1 arguments, got %d" % len(args))
         if args:
             dict = args[0]
-        elif 'dict' in kwargs:
-            dict = kwargs.pop('dict')
+        elif "dict" in kwargs:
+            dict = kwargs.pop("dict")
             import warnings
-            warnings.warn("Passing 'dict' as keyword argument is deprecated",
-                          DeprecationWarning, stacklevel=2)
+
+            warnings.warn("Passing 'dict' as keyword argument is deprecated", DeprecationWarning, stacklevel=2)
         else:
             dict = None
         self._data = {}
@@ -50,7 +50,7 @@ class STUserDict(_collections_abc.MutableMapping):
         if kwargs:
             self.update(kwargs)
 
-    __init__.__text_signature__ = '($self, dict=None, /, **kwargs)'
+    __init__.__text_signature__ = "($self, dict=None, /, **kwargs)"
 
     def __len__(self) -> int:
         return len(self._data)
@@ -79,17 +79,18 @@ class STUserDict(_collections_abc.MutableMapping):
     def __repr__(self) -> str:
         return repr(self._data)
 
-    def __copy__(self) -> 'STUserDict':
+    def __copy__(self) -> "STUserDict":
         inst = self.__class__.__new__(self.__class__)
         inst.__dict__.update(self.__dict__)
         # Create a copy and avoid triggering descriptors
         inst.__dict__["_data"] = self.__dict__["_data"].copy()
         return inst
 
-    def copy(self) -> 'STUserDict':
+    def copy(self) -> "STUserDict":
         if self.__class__ is STUserDict:
             return STUserDict(self._data.copy())
         import copy
+
         data = self._data
         try:
             self._data = {}
@@ -100,7 +101,7 @@ class STUserDict(_collections_abc.MutableMapping):
         return c
 
     @classmethod
-    def fromkeys(cls, iterable, value=None) -> 'STUserDict':
+    def fromkeys(cls, iterable, value=None) -> "STUserDict":
         d = cls()
         for key in iterable:
             d[key] = value

--- a/src/roman_datamodels/stuserdict.py
+++ b/src/roman_datamodels/stuserdict.py
@@ -1,6 +1,6 @@
-import _collections_abc
 from typing import Any, Iterator
 
+import _collections_abc
 
 # import sys as _sys
 

--- a/src/roman_datamodels/testing/__init__.py
+++ b/src/roman_datamodels/testing/__init__.py
@@ -1,9 +1,8 @@
 """
 Helper methods for writing tests that involve roman_datamodels objects.
 """
-from .factories import create_node
 from .assertions import assert_node_equal
-
+from .factories import create_node
 
 __all__ = [
     "assert_node_equal",

--- a/src/roman_datamodels/testing/assertions.py
+++ b/src/roman_datamodels/testing/assertions.py
@@ -1,9 +1,9 @@
-from asdf.tags.core import NDArrayType
 import numpy as np
-from numpy.testing import assert_array_equal
+from asdf.tags.core import NDArrayType
 from astropy.modeling import Model
+from numpy.testing import assert_array_equal
 
-from ..stnode import TaggedObjectNode, TaggedListNode, TaggedScalarNode, Unit
+from ..stnode import TaggedListNode, TaggedObjectNode, TaggedScalarNode, Unit
 
 
 def assert_node_equal(node1, node2):

--- a/src/roman_datamodels/testing/assertions.py
+++ b/src/roman_datamodels/testing/assertions.py
@@ -58,6 +58,7 @@ def _assert_value_equal(value1, value2):
     else:
         assert value1 == value2
 
+
 def assert_model_equal(a, b):
     """
     Assert that two model instances are equivalent.

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -98,10 +98,10 @@ def _random_string_time():
     return datetime.utcfromtimestamp(_random_utc_timestamp()).strftime("%H:%M:%S.%f")[0:12]
 
 
-def _random_astropy_time(time_format='unix'):
-    timeobj =  Time(_random_utc_timestamp(), format="unix")
+def _random_astropy_time(time_format="unix"):
+    timeobj = Time(_random_utc_timestamp(), format="unix")
 
-    if time_format == 'unix':
+    if time_format == "unix":
         return timeobj
     else:
         time_str = timeobj.to_value(format=time_format)
@@ -112,9 +112,9 @@ def _random_astropy_time(time_format='unix'):
 def _random_int(min=None, max=None):
     # Assume 32-bit signed integers for now
     if min is None:
-        min = -1 * 2 ** 31
+        min = -1 * 2**31
     if max is None:
-        max = 2 ** 31 - 1
+        max = 2**31 - 1
     return random.randint(min, max)
 
 
@@ -151,6 +151,7 @@ def _random_array_float32(size=(4096, 4096), min=None, max=None, units=None):
         array = u.Quantity(array, units, dtype=np.float32)
     return array
 
+
 def _random_array_uint8(size=(4096, 4096), min=None, max=None, units=None):
     if min is None:
         min = np.iinfo("uint8").min
@@ -160,6 +161,7 @@ def _random_array_uint8(size=(4096, 4096), min=None, max=None, units=None):
     if units:
         array = u.Quantity(array, units, dtype=np.uint8)
     return array
+
 
 def _random_array_uint16(size=(4096, 4096), min=None, max=None, units=None):
     if min is None:
@@ -259,7 +261,6 @@ def create_aperture(**kwargs):
     raw = {
         "name": f"WFI_{aper_number:02d}_FULL",
         "position_angle": _random_angle_degrees(),
-
     }
     raw.update(kwargs)
 
@@ -283,13 +284,13 @@ def create_cal_step(**kwargs):
     raw = {
         "flat_field": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
         "dq_init": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
-        "assign_wcs" : _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
-        "dark" : _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
-        "jump" : _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
-        "linearity" : _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
+        "assign_wcs": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
+        "dark": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
+        "jump": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
+        "linearity": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
         "photom": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
-        "ramp_fit" : _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
-        "saturation" : _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
+        "ramp_fit": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
+        "saturation": _random_choice("N/A", "COMPLETE", "SKIPPED", "INCOMPLETE"),
     }
     raw.update(kwargs)
 
@@ -370,7 +371,7 @@ def create_exposure(**kwargs):
         "duration": _random_positive_float(),
         "effective_exposure_time": _random_positive_float(),
         "elapsed_exposure_time": _random_positive_float(),
-        "end_time": _random_astropy_time(time_format='isot'),
+        "end_time": _random_astropy_time(time_format="isot"),
         "end_time_mjd": _random_mjd_timestamp(),
         "end_time_tdb": _random_mjd_timestamp(),
         "exposure_time": _random_positive_float(),
@@ -381,13 +382,13 @@ def create_exposure(**kwargs):
         "groupgap": 0,
         "id": _random_positive_int(),
         "integration_time": _random_positive_float(),
-        "mid_time": _random_astropy_time(time_format='isot'),
+        "mid_time": _random_astropy_time(time_format="isot"),
         "mid_time_mjd": _random_mjd_timestamp(),
         "mid_time_tdb": _random_mjd_timestamp(),
         "nframes": 8,
         "ngroups": 6,
         "sca_number": _random_positive_int(),
-        "start_time": _random_astropy_time(time_format='isot'),
+        "start_time": _random_astropy_time(time_format="isot"),
         "start_time_mjd": _random_mjd_timestamp(),
         "start_time_tdb": _random_mjd_timestamp(),
         "type": _random_exposure_type(),
@@ -418,10 +419,10 @@ def create_ref_meta(**kwargs):
         "author": _random_string("Reference author "),
         "description": _random_string("Reference description "),
         "exposure": {
-            "type" : "WFI_IMAGE",
-            "ngroups" : 6,
-            "nframes" : 8,
-            "groupgap" : 0,
+            "type": "WFI_IMAGE",
+            "ngroups": 6,
+            "nframes": 8,
+            "groupgap": 0,
             "ma_table_name": _random_string("MA table "),
             "ma_table_number": _random_positive_int(max=998) + 1,
         },
@@ -483,10 +484,10 @@ def create_dark_ref(**kwargs):
         "data": _random_array_float32((2, 4096, 4096), units=ru.DN),
         "dq": _random_array_uint32(),
         "err": _random_array_float32((2, 4096, 4096), units=ru.DN),
-        "meta": create_ref_meta(reftype="DARK")
+        "meta": create_ref_meta(reftype="DARK"),
     }
     raw.update(kwargs)
-    raw['meta']['exposure']['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
+    raw["meta"]["exposure"]["p_exptype"] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
 
     return stnode.DarkRef(raw)
 
@@ -506,14 +507,11 @@ def create_distortion_ref(**kwargs):
     roman_datamodels.stnode.DistortionRef
     """
     m = models.Shift(1) & models.Shift(2)
-    raw = {
-        "coordinate_distortion_transform": m,
-        "meta": create_ref_meta(reftype="DISTORTION")
-    }
+    raw = {"coordinate_distortion_transform": m, "meta": create_ref_meta(reftype="DISTORTION")}
     raw.update(kwargs)
 
-    raw['meta']['input_units'] = u.pixel
-    raw['meta']['output_units'] = u.arcsec
+    raw["meta"]["input_units"] = u.pixel
+    raw["meta"]["output_units"] = u.arcsec
 
     return stnode.DistortionRef(raw)
 
@@ -587,8 +585,8 @@ def create_linearity_ref(**kwargs):
     }
     raw.update(kwargs)
 
-    raw['meta']['input_units'] = ru.DN
-    raw['meta']['output_units'] = ru.DN
+    raw["meta"]["input_units"] = ru.DN
+    raw["meta"]["output_units"] = ru.DN
 
     return stnode.LinearityRef(raw)
 
@@ -615,6 +613,7 @@ def create_mask_ref(**kwargs):
 
     return stnode.MaskRef(raw)
 
+
 def create_pixelarea_ref(**kwargs):
     """
     Create a dummy PixelareaRef instance with valid values for attributes
@@ -633,13 +632,14 @@ def create_pixelarea_ref(**kwargs):
         "data": _random_array_float32((4096, 4096)),
         "meta": create_ref_meta(reftype="AREA"),
     }
-    raw['meta']['photometry'] = {
-        'pixelarea_steradians': _random_positive_float() * u.sr,
-        'pixelarea_arcsecsq': _random_positive_float() * u.arcsec ** 2,
+    raw["meta"]["photometry"] = {
+        "pixelarea_steradians": _random_positive_float() * u.sr,
+        "pixelarea_arcsecsq": _random_positive_float() * u.arcsec**2,
     }
     raw.update(kwargs)
 
     return stnode.PixelareaRef(raw)
+
 
 def create_readnoise_ref(**kwargs):
     """
@@ -660,9 +660,10 @@ def create_readnoise_ref(**kwargs):
         "meta": create_ref_meta(reftype="READNOISE"),
     }
     raw.update(kwargs)
-    raw['meta']['exposure']['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
+    raw["meta"]["exposure"]["p_exptype"] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
 
     return stnode.ReadnoiseRef(raw)
+
 
 def create_saturation_ref(**kwargs):
     """
@@ -686,6 +687,7 @@ def create_saturation_ref(**kwargs):
     raw.update(kwargs)
 
     return stnode.SaturationRef(raw)
+
 
 def create_superbias_ref(**kwargs):
     """
@@ -711,6 +713,7 @@ def create_superbias_ref(**kwargs):
 
     return stnode.SuperbiasRef(raw)
 
+
 def create_wfi_img_photom_ref(**kwargs):
     """
     Create a dummy WfiImgPhotomRef instance with valid values for attributes
@@ -726,50 +729,49 @@ def create_wfi_img_photom_ref(**kwargs):
     roman_datamodels.stnode.WfiImgPhotomRef
     """
     raw_dict = {
-        "F062":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F087":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F106":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F129":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F146":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F158":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F184":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F213":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "GRISM":
-            {"photmjsr": None,
-             "uncertainty": None,
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "PRISM":
-            {"photmjsr": None,
-             "uncertainty": None,
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "DARK":
-            {"photmjsr": None,
-             "uncertainty": None,
-             "pixelareasr": 1.0e-13 * u.steradian},
+        "F062": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F087": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F106": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F129": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F146": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F158": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F184": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F213": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "GRISM": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
+        "PRISM": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
+        "DARK": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
     }
 
     raw = {
@@ -825,6 +827,7 @@ def create_guidestar(**kwargs):
     raw.update(kwargs)
 
     return stnode.Guidestar(raw)
+
 
 def create_file_date(**kwargs):
     return stnode.FileDate(kwargs.get("file_date", _random_astropy_time()))
@@ -972,10 +975,10 @@ def create_photometry(**kwargs):
     raw = {
         "conversion_megajanskys": _random_positive_float() * u.MJy / u.sr,
         "conversion_microjanskys": _random_positive_float() * u.uJy / u.sr,
-        "pixelarea_arcsecsq": _random_positive_float() * u.arcsec ** 2,
+        "pixelarea_arcsecsq": _random_positive_float() * u.arcsec**2,
         "pixelarea_steradians": _random_positive_float() * u.sr,
         "conversion_megajanskys_uncertainty": _random_positive_float() * u.MJy / u.sr,
-        "conversion_microjanskys_uncertainty": _random_positive_float() * u.uJy / u.sr
+        "conversion_microjanskys_uncertainty": _random_positive_float() * u.uJy / u.sr,
     }
     raw.update(kwargs)
 
@@ -1001,8 +1004,7 @@ def create_pixelarea(**kwargs):
     }
     raw.update(kwargs)
     raw["meta"] = {}
-    raw["meta"]["photometry"] = {'pixelarea_steradians': .3 * u.sr,
-                                 'pixelarea_arcsecsq': .3 * u.arcsec ** 2}
+    raw["meta"]["photometry"] = {"pixelarea_steradians": 0.3 * u.sr, "pixelarea_arcsecsq": 0.3 * u.arcsec**2}
 
     return stnode.Pixelarea(raw)
 
@@ -1075,12 +1077,10 @@ def create_ramp(**kwargs):
 
     raw = {
         "meta": create_meta(),
-
         "data": _random_array_float32((2, 4096, 4096), units=ru.electron),
         "pixeldq": _random_array_uint32((4096, 4096)),
         "groupdq": _random_array_uint8((2, 4096, 4096)),
-        "err": _random_array_float32(size=(2, 4096, 4096),min=0.0, units=ru.electron),
-
+        "err": _random_array_float32(size=(2, 4096, 4096), min=0.0, units=ru.electron),
         "amp33": _random_array_uint16((2, 4096, 128), units=ru.DN),
         "border_ref_pix_right": _random_array_float32((2, 4096, 4), units=ru.DN),
         "border_ref_pix_left": _random_array_float32((2, 4096, 4), units=ru.DN),
@@ -1089,11 +1089,12 @@ def create_ramp(**kwargs):
         "dq_border_ref_pix_right": _random_array_uint32((4096, 4)),
         "dq_border_ref_pix_left": _random_array_uint32((4096, 4)),
         "dq_border_ref_pix_top": _random_array_uint32((4, 4096)),
-        "dq_border_ref_pix_bottom": _random_array_uint32((4, 4096))
+        "dq_border_ref_pix_bottom": _random_array_uint32((4, 4096)),
     }
     raw.update(kwargs)
 
     return stnode.Ramp(raw)
+
 
 def create_ramp_fit_output(**kwargs):
     """
@@ -1114,7 +1115,6 @@ def create_ramp_fit_output(**kwargs):
 
     raw = {
         "meta": create_meta(),
-
         "slope": _random_array_float32(seg_shape, units=ru.electron / u.s),
         "sigslope": _random_array_float32(seg_shape, units=ru.electron / u.s),
         "yint": _random_array_float32(seg_shape, units=ru.electron),
@@ -1124,7 +1124,6 @@ def create_ramp_fit_output(**kwargs):
         "crmag": _random_array_float32(seg_shape, units=ru.electron),
         "var_poisson": _random_array_float32(seg_shape, units=ru.electron**2 / u.s**2),
         "var_rnoise": _random_array_float32(seg_shape, units=ru.electron**2 / u.s**2),
-
     }
     raw.update(kwargs)
 
@@ -1161,22 +1160,22 @@ def create_guidewindow(**kwargs):
     raw["meta"]["gw_end_time"] = _random_astropy_time()
     raw["meta"]["gw_function_start_time"] = _random_astropy_time()
     raw["meta"]["gw_function_end_time"] = _random_astropy_time()
-    raw['meta']['gw_frame_readout_time'] = _random_float()
-    raw['meta']['pedestal_resultant_exp_time'] = _random_float()
-    raw['meta']['signal_resultant_exp_time'] = _random_float()
-    raw['meta']['gw_acq_number'] = _random_int()
-    raw['meta']['gw_mode'] = 'WIM-ACQ'
-    raw['meta']['gw_window_xstart'] = _random_positive_int(4000)
-    raw['meta']['gw_window_ystart'] = _random_positive_int(4000)
-    raw['meta']['gw_window_xstop'] = raw['meta']["gw_window_xstart"] + 16
-    raw['meta']['gw_window_ystop'] = raw['meta']["gw_window_ystart"] + 16
-    raw['meta']['gw_window_xsize'] = 16
-    raw['meta']['gw_window_ysize'] = 16
-    raw['meta']['gw_acq_exec_stat'] = _random_string("Status ", 15)
+    raw["meta"]["gw_frame_readout_time"] = _random_float()
+    raw["meta"]["pedestal_resultant_exp_time"] = _random_float()
+    raw["meta"]["signal_resultant_exp_time"] = _random_float()
+    raw["meta"]["gw_acq_number"] = _random_int()
+    raw["meta"]["gw_mode"] = "WIM-ACQ"
+    raw["meta"]["gw_window_xstart"] = _random_positive_int(4000)
+    raw["meta"]["gw_window_ystart"] = _random_positive_int(4000)
+    raw["meta"]["gw_window_xstop"] = raw["meta"]["gw_window_xstart"] + 16
+    raw["meta"]["gw_window_ystop"] = raw["meta"]["gw_window_ystart"] + 16
+    raw["meta"]["gw_window_xsize"] = 16
+    raw["meta"]["gw_window_ysize"] = 16
+    raw["meta"]["gw_acq_exec_stat"] = _random_string("Status ", 15)
 
-    raw['meta']["gw_acq_exec_stat"] = _random_string("Status ", 15)
-    raw['meta']["gw_function_end_time"] = _random_astropy_time()
-    raw['meta']["gw_function_start_time"] = _random_astropy_time()
+    raw["meta"]["gw_acq_exec_stat"] = _random_string("Status ", 15)
+    raw["meta"]["gw_function_end_time"] = _random_astropy_time()
+    raw["meta"]["gw_function_start_time"] = _random_astropy_time()
 
     return stnode.Guidewindow(raw)
 
@@ -1337,11 +1336,9 @@ def create_wfi_image(**kwargs):
         "dq": _random_array_uint32((4088, 4088)),
         "err": _random_array_float32((4088, 4088), min=0.0, units=ru.electron / u.s),
         "meta": create_meta(),
-
         "var_flat": _random_array_float32((4088, 4088), units=ru.electron**2 / u.s**2),
         "var_poisson": _random_array_float32((4088, 4088), units=ru.electron**2 / u.s**2),
         "var_rnoise": _random_array_float32((4088, 4088), units=ru.electron**2 / u.s**2),
-
         "amp33": _random_array_uint16((2, 4096, 128), units=ru.DN),
         "border_ref_pix_right": _random_array_float32((2, 4096, 4), units=ru.DN),
         "border_ref_pix_left": _random_array_float32((2, 4096, 4), units=ru.DN),
@@ -1449,8 +1446,7 @@ def create_ref_file(**kwargs):
     -------
     roman_datamodels.stnode.RefFileName
     """
-    reftypes = ["dark", "distortion", "flat", "gain", "linearity", "mask", "readnoise",
-                "saturation", "photom" ]
+    reftypes = ["dark", "distortion", "flat", "gain", "linearity", "mask", "readnoise", "saturation", "photom"]
     val = "N/A"
     raw = dict(zip(reftypes, [val] * len(reftypes)))
     raw["crds"] = {"sw_version": "12.1", "context_used": "781"}

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -2,21 +2,22 @@
 Factory methods that create (not necessarily realistic) nodes
 that validate against their schemas.
 """
-from datetime import datetime
 import math
 import random
 import re
 import secrets
 import sys
+from datetime import datetime
 
-from astropy.time import Time
+import numpy as np
 from astropy import units as u
 from astropy.modeling import models
-import numpy as np
+from astropy.time import Time
 
 from roman_datamodels import units as ru
 
 from .. import stnode
+
 # from .. import table_definitions
 
 

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -23,45 +23,42 @@ def mk_exposure():
     roman_datamodels.stnode.Exposure
     """
     exp = stnode.Exposure()
-    exp['id'] = NONUM
-    exp['type'] = 'WFI_IMAGE'
-    exp['start_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    exp['mid_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    exp['end_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    exp['start_time_mjd'] = NONUM
-    exp['mid_time_mjd'] = NONUM
-    exp['end_time_mjd'] = NONUM
-    exp['start_time_tdb'] = NONUM
-    exp['mid_time_tdb'] = NONUM
-    exp['end_time_tdb'] = NONUM
-    exp['start_time_eng'] = NOSTR
-    exp['ngroups'] = 6
-    exp['nframes'] = 8
-    exp['data_problem'] = False
-    exp['sca_number'] = NONUM
-    exp['gain_factor'] = NONUM
-    exp['integration_time'] = NONUM
-    exp['elapsed_exposure_time'] = NONUM
-    exp['nints'] = NONUM
-    exp['integration_start'] = NONUM
-    exp['integration_end'] = NONUM
-    exp['frame_divisor'] = NONUM
-    exp['groupgap'] = 0
-    exp['nsamples'] = NONUM
-    exp['sample_time'] = NONUM
-    exp['frame_time'] = NONUM
-    exp['group_time'] = NONUM
-    exp['exposure_time'] = NONUM
-    exp['effective_exposure_time'] = NONUM
-    exp['duration'] = NONUM
-    exp['nresets_at_start'] = NONUM
-    exp['datamode'] = NONUM
-    exp['ma_table_name'] = NOSTR
-    exp['ma_table_number'] = NONUM
-    exp['level0_compressed'] = True
+    exp["id"] = NONUM
+    exp["type"] = "WFI_IMAGE"
+    exp["start_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    exp["mid_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    exp["end_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    exp["start_time_mjd"] = NONUM
+    exp["mid_time_mjd"] = NONUM
+    exp["end_time_mjd"] = NONUM
+    exp["start_time_tdb"] = NONUM
+    exp["mid_time_tdb"] = NONUM
+    exp["end_time_tdb"] = NONUM
+    exp["start_time_eng"] = NOSTR
+    exp["ngroups"] = 6
+    exp["nframes"] = 8
+    exp["data_problem"] = False
+    exp["sca_number"] = NONUM
+    exp["gain_factor"] = NONUM
+    exp["integration_time"] = NONUM
+    exp["elapsed_exposure_time"] = NONUM
+    exp["nints"] = NONUM
+    exp["integration_start"] = NONUM
+    exp["integration_end"] = NONUM
+    exp["frame_divisor"] = NONUM
+    exp["groupgap"] = 0
+    exp["nsamples"] = NONUM
+    exp["sample_time"] = NONUM
+    exp["frame_time"] = NONUM
+    exp["group_time"] = NONUM
+    exp["exposure_time"] = NONUM
+    exp["effective_exposure_time"] = NONUM
+    exp["duration"] = NONUM
+    exp["nresets_at_start"] = NONUM
+    exp["datamode"] = NONUM
+    exp["ma_table_name"] = NOSTR
+    exp["ma_table_number"] = NONUM
+    exp["level0_compressed"] = True
     return exp
 
 
@@ -75,9 +72,9 @@ def mk_wfi_mode():
     roman_datamodels.stnode.WfiMode
     """
     mode = stnode.WfiMode()
-    mode['name'] = 'WFI'
-    mode['detector'] = 'WFI01'
-    mode['optical_element'] = 'F062'
+    mode["name"] = "WFI"
+    mode["detector"] = "WFI01"
+    mode["optical_element"] = "F062"
     return mode
 
 
@@ -91,12 +88,12 @@ def mk_program():
     roman_datamodels.stnode.Program
     """
     prog = stnode.Program()
-    prog['title'] = NOSTR
-    prog['pi_name'] = NOSTR
-    prog['category'] = NOSTR
-    prog['subcategory'] = NOSTR
-    prog['science_category'] = NOSTR
-    prog['continuation_id'] = NONUM
+    prog["title"] = NOSTR
+    prog["pi_name"] = NOSTR
+    prog["category"] = NOSTR
+    prog["subcategory"] = NOSTR
+    prog["science_category"] = NOSTR
+    prog["continuation_id"] = NONUM
     return prog
 
 
@@ -110,21 +107,21 @@ def mk_observation():
     roman_datamodels.stnode.Observation
     """
     obs = stnode.Observation()
-    obs['obs_id'] = NOSTR
-    obs['visit_id'] = NOSTR
-    obs['program'] = NONUM
-    obs['execution_plan'] = NONUM
-    obs['pass'] = NONUM
-    obs['segment'] = NONUM
-    obs['observation'] = NONUM
-    obs['visit'] = NONUM
-    obs['visit_file_group'] = NONUM
-    obs['visit_file_sequence'] = NONUM
-    obs['visit_file_activity'] = NOSTR
-    obs['exposure'] = NONUM
-    obs['template'] = NOSTR
-    obs['observation_label'] = NOSTR
-    obs['survey'] = 'N/A'
+    obs["obs_id"] = NOSTR
+    obs["visit_id"] = NOSTR
+    obs["program"] = NONUM
+    obs["execution_plan"] = NONUM
+    obs["pass"] = NONUM
+    obs["segment"] = NONUM
+    obs["observation"] = NONUM
+    obs["visit"] = NONUM
+    obs["visit_file_group"] = NONUM
+    obs["visit_file_sequence"] = NONUM
+    obs["visit_file_activity"] = NOSTR
+    obs["exposure"] = NONUM
+    obs["template"] = NOSTR
+    obs["observation_label"] = NOSTR
+    obs["survey"] = "N/A"
     return obs
 
 
@@ -138,18 +135,18 @@ def mk_ephemeris():
     roman_datamodels.stnode.Ephemeris
     """
     ephem = stnode.Ephemeris()
-    ephem['earth_angle'] = NONUM
-    ephem['moon_angle'] = NONUM
-    ephem['ephemeris_reference_frame'] = NOSTR
-    ephem['sun_angle'] = NONUM
-    ephem['type'] = 'DEFINITIVE'
-    ephem['time'] = NONUM
-    ephem['spatial_x'] = NONUM
-    ephem['spatial_y'] = NONUM
-    ephem['spatial_z'] = NONUM
-    ephem['velocity_x'] = NONUM
-    ephem['velocity_y'] = NONUM
-    ephem['velocity_z'] = NONUM
+    ephem["earth_angle"] = NONUM
+    ephem["moon_angle"] = NONUM
+    ephem["ephemeris_reference_frame"] = NOSTR
+    ephem["sun_angle"] = NONUM
+    ephem["type"] = "DEFINITIVE"
+    ephem["time"] = NONUM
+    ephem["spatial_x"] = NONUM
+    ephem["spatial_y"] = NONUM
+    ephem["spatial_z"] = NONUM
+    ephem["velocity_x"] = NONUM
+    ephem["velocity_y"] = NONUM
+    ephem["velocity_z"] = NONUM
     return ephem
 
 
@@ -163,17 +160,15 @@ def mk_visit():
     roman_datamodels.stnode.Visit
     """
     visit = stnode.Visit()
-    visit['engineering_quality'] = 'OK'  # qqqq
-    visit['pointing_engdb_quality'] = 'CALCULATED'  # qqqq
-    visit['type'] = NOSTR
-    visit['start_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    visit['end_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    visit['status'] = NOSTR
-    visit['total_exposures'] = NONUM
-    visit['internal_target'] = False
-    visit['target_of_opportunity'] = False
+    visit["engineering_quality"] = "OK"  # qqqq
+    visit["pointing_engdb_quality"] = "CALCULATED"  # qqqq
+    visit["type"] = NOSTR
+    visit["start_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    visit["end_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    visit["status"] = NOSTR
+    visit["total_exposures"] = NONUM
+    visit["internal_target"] = False
+    visit["target_of_opportunity"] = False
     return visit
 
 
@@ -187,12 +182,12 @@ def mk_photometry():
     roman_datamodels.stnode.Photometry
     """
     phot = stnode.Photometry()
-    phot['conversion_microjanskys'] = NONUM * u.uJy / u.sr
-    phot['conversion_megajanskys'] = NONUM * u.MJy / u.sr
-    phot['pixelarea_steradians'] = NONUM * u.sr
-    phot['pixelarea_arcsecsq'] = NONUM * u.arcsec ** 2
-    phot['conversion_microjanskys_uncertainty'] = NONUM * u.uJy / u.sr
-    phot['conversion_megajanskys_uncertainty'] = NONUM * u.MJy / u.sr
+    phot["conversion_microjanskys"] = NONUM * u.uJy / u.sr
+    phot["conversion_megajanskys"] = NONUM * u.MJy / u.sr
+    phot["pixelarea_steradians"] = NONUM * u.sr
+    phot["pixelarea_arcsecsq"] = NONUM * u.arcsec**2
+    phot["conversion_microjanskys_uncertainty"] = NONUM * u.uJy / u.sr
+    phot["conversion_megajanskys_uncertainty"] = NONUM * u.MJy / u.sr
     return phot
 
 
@@ -206,7 +201,7 @@ def mk_coordinates():
     roman_datamodels.stnode.Coordinates
     """
     coord = stnode.Coordinates()
-    coord['reference_frame'] = 'ICRS'
+    coord["reference_frame"] = "ICRS"
     return coord
 
 
@@ -221,8 +216,8 @@ def mk_aperture():
     """
     aper = stnode.Aperture()
     aper_number = _random_positive_int(17) + 1
-    aper['name'] = f"WFI_{aper_number:02d}_FULL"
-    aper['position_angle'] = 30.
+    aper["name"] = f"WFI_{aper_number:02d}_FULL"
+    aper["position_angle"] = 30.0
     return aper
 
 
@@ -236,9 +231,9 @@ def mk_pointing():
     roman_datamodels.stnode.Pointing
     """
     point = stnode.Pointing()
-    point['ra_v1'] = NONUM
-    point['dec_v1'] = NONUM
-    point['pa_v3'] = NONUM
+    point["ra_v1"] = NONUM
+    point["dec_v1"] = NONUM
+    point["pa_v3"] = NONUM
     return point
 
 
@@ -252,20 +247,20 @@ def mk_target():
     roman_datamodels.stnode.Target
     """
     targ = stnode.Target()
-    targ['proposer_name'] = NOSTR
-    targ['catalog_name'] = NOSTR
-    targ['type'] = 'FIXED'
-    targ['ra'] = NONUM
-    targ['dec'] = NONUM
-    targ['ra_uncertainty'] = NONUM
-    targ['dec_uncertainty'] = NONUM
-    targ['proper_motion_ra'] = NONUM
-    targ['proper_motion_dec'] = NONUM
-    targ['proper_motion_epoch'] = NOSTR
-    targ['proposer_ra'] = NONUM
-    targ['proposer_dec'] = NONUM
-    targ['source_type_apt'] = 'POINT'
-    targ['source_type'] = 'POINT'
+    targ["proposer_name"] = NOSTR
+    targ["catalog_name"] = NOSTR
+    targ["type"] = "FIXED"
+    targ["ra"] = NONUM
+    targ["dec"] = NONUM
+    targ["ra_uncertainty"] = NONUM
+    targ["dec_uncertainty"] = NONUM
+    targ["proper_motion_ra"] = NONUM
+    targ["proper_motion_dec"] = NONUM
+    targ["proper_motion_epoch"] = NOSTR
+    targ["proposer_ra"] = NONUM
+    targ["proposer_dec"] = NONUM
+    targ["source_type_apt"] = "POINT"
+    targ["source_type"] = "POINT"
     return targ
 
 
@@ -279,9 +274,9 @@ def mk_velocity_aberration():
     roman_datamodels.stnode.VelocityAberration
     """
     vab = stnode.VelocityAberration()
-    vab['ra_offset'] = NONUM
-    vab['dec_offset'] = NONUM
-    vab['scale_factor'] = NONUM
+    vab["ra_offset"] = NONUM
+    vab["dec_offset"] = NONUM
+    vab["scale_factor"] = NONUM
     return vab
 
 
@@ -295,14 +290,14 @@ def mk_wcsinfo():
     roman_datamodels.stnode.Wcsinfo
     """
     wcsi = stnode.Wcsinfo()
-    wcsi['v2_ref'] = NONUM
-    wcsi['v3_ref'] = NONUM
-    wcsi['vparity'] = NONUM
-    wcsi['v3yangle'] = NONUM
-    wcsi['ra_ref'] = NONUM
-    wcsi['dec_ref'] = NONUM
-    wcsi['roll_ref'] = NONUM
-    wcsi['s_region'] = NOSTR
+    wcsi["v2_ref"] = NONUM
+    wcsi["v3_ref"] = NONUM
+    wcsi["vparity"] = NONUM
+    wcsi["v3yangle"] = NONUM
+    wcsi["ra_ref"] = NONUM
+    wcsi["dec_ref"] = NONUM
+    wcsi["roll_ref"] = NONUM
+    wcsi["s_region"] = NOSTR
     return wcsi
 
 
@@ -316,17 +311,18 @@ def mk_cal_step():
     roman_datamodels.stnode.CalStep
     """
     calstep = stnode.CalStep()
-    calstep['flat_field'] = 'INCOMPLETE'
-    calstep['dq_init'] = 'INCOMPLETE'
-    calstep['assign_wcs'] = 'INCOMPLETE'
-    calstep['dark'] = 'INCOMPLETE'
-    calstep['jump'] = 'INCOMPLETE'
-    calstep['linearity'] = 'INCOMPLETE'
-    calstep['photom'] = 'INCOMPLETE'
-    calstep['ramp_fit'] = 'INCOMPLETE'
-    calstep['saturation'] = 'INCOMPLETE'
+    calstep["flat_field"] = "INCOMPLETE"
+    calstep["dq_init"] = "INCOMPLETE"
+    calstep["assign_wcs"] = "INCOMPLETE"
+    calstep["dark"] = "INCOMPLETE"
+    calstep["jump"] = "INCOMPLETE"
+    calstep["linearity"] = "INCOMPLETE"
+    calstep["photom"] = "INCOMPLETE"
+    calstep["ramp_fit"] = "INCOMPLETE"
+    calstep["saturation"] = "INCOMPLETE"
 
     return calstep
+
 
 def mk_cal_logs():
     """
@@ -344,6 +340,7 @@ def mk_cal_logs():
         ]
     )
 
+
 def mk_guidestar():
     """
     Create a dummy Guide Star instance with valid values for attributes
@@ -354,79 +351,78 @@ def mk_guidestar():
     roman_datamodels.stnode.Guidestar
     """
     guide = stnode.Guidestar()
-    guide['gw_id'] = NOSTR
-    guide['gs_ra'] = NONUM
-    guide['gs_dec'] = NONUM
-    guide['gs_ura'] = NONUM
-    guide['gs_udec'] = NONUM
-    guide['gs_mag'] = NONUM
-    guide['gs_umag'] = NONUM
-    guide['gw_fgs_mode'] = "WSM-ACQ-2"
-    guide['data_start'] = NONUM
-    guide['data_end'] = NONUM
-    guide['gs_ctd_x'] = NONUM
-    guide['gs_ctd_y'] = NONUM
-    guide['gs_ctd_ux'] = NONUM
-    guide['gs_ctd_uy'] = NONUM
-    guide['gs_epoch'] = NOSTR
-    guide['gs_mura'] = NONUM
-    guide['gs_mudec'] = NONUM
-    guide['gs_para'] = NONUM
-    guide['gs_pattern_error'] = NONUM
-    guide['gw_window_xstart'] = NONUM
-    guide['gw_window_ystart'] = NONUM
-    guide['gw_window_xstop'] = guide['gw_window_xstart'] + 170
-    guide['gw_window_ystop'] = guide['gw_window_ystart'] + 24
-    guide['gw_window_xsize'] = 170
-    guide['gw_window_ysize'] = 24
+    guide["gw_id"] = NOSTR
+    guide["gs_ra"] = NONUM
+    guide["gs_dec"] = NONUM
+    guide["gs_ura"] = NONUM
+    guide["gs_udec"] = NONUM
+    guide["gs_mag"] = NONUM
+    guide["gs_umag"] = NONUM
+    guide["gw_fgs_mode"] = "WSM-ACQ-2"
+    guide["data_start"] = NONUM
+    guide["data_end"] = NONUM
+    guide["gs_ctd_x"] = NONUM
+    guide["gs_ctd_y"] = NONUM
+    guide["gs_ctd_ux"] = NONUM
+    guide["gs_ctd_uy"] = NONUM
+    guide["gs_epoch"] = NOSTR
+    guide["gs_mura"] = NONUM
+    guide["gs_mudec"] = NONUM
+    guide["gs_para"] = NONUM
+    guide["gs_pattern_error"] = NONUM
+    guide["gw_window_xstart"] = NONUM
+    guide["gw_window_ystart"] = NONUM
+    guide["gw_window_xstop"] = guide["gw_window_xstart"] + 170
+    guide["gw_window_ystop"] = guide["gw_window_ystart"] + 24
+    guide["gw_window_xsize"] = 170
+    guide["gw_window_ysize"] = 24
     return guide
 
 
 def mk_basic_meta():
     meta = {}
-    meta['calibration_software_version'] = '9.9.9'
-    meta['sdf_software_version'] = '7.7.7'
-    meta['filename'] = NOSTR
-    meta['file_date'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    meta['model_type'] = NOSTR
-    meta['origin'] = 'STSCI'
-    meta['prd_software_version'] = '8.8.8'
-    meta['telescope'] = 'ROMAN'
+    meta["calibration_software_version"] = "9.9.9"
+    meta["sdf_software_version"] = "7.7.7"
+    meta["filename"] = NOSTR
+    meta["file_date"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    meta["model_type"] = NOSTR
+    meta["origin"] = "STSCI"
+    meta["prd_software_version"] = "8.8.8"
+    meta["telescope"] = "ROMAN"
     return meta
 
 
 def mk_common_meta():
     meta = mk_basic_meta()
-    meta['aperture'] = mk_aperture()
-    meta['cal_step'] = mk_cal_step()
-    meta['coordinates'] = mk_coordinates()
-    meta['ephemeris'] = mk_ephemeris()
-    meta['exposure'] = mk_exposure()
-    meta['guidestar'] = mk_guidestar()
-    meta['instrument'] = mk_wfi_mode()
-    meta['observation'] = mk_observation()
-    meta['pointing'] = mk_pointing()
-    meta['program'] = mk_program()
-    meta['ref_file'] = mk_ref_file()
-    meta['target'] = mk_target()
-    meta['velocity_aberration'] = mk_velocity_aberration()
-    meta['visit'] = mk_visit()
-    meta['wcsinfo'] = mk_wcsinfo()
+    meta["aperture"] = mk_aperture()
+    meta["cal_step"] = mk_cal_step()
+    meta["coordinates"] = mk_coordinates()
+    meta["ephemeris"] = mk_ephemeris()
+    meta["exposure"] = mk_exposure()
+    meta["guidestar"] = mk_guidestar()
+    meta["instrument"] = mk_wfi_mode()
+    meta["observation"] = mk_observation()
+    meta["pointing"] = mk_pointing()
+    meta["program"] = mk_program()
+    meta["ref_file"] = mk_ref_file()
+    meta["target"] = mk_target()
+    meta["velocity_aberration"] = mk_velocity_aberration()
+    meta["visit"] = mk_visit()
+    meta["wcsinfo"] = mk_wcsinfo()
     return meta
 
+
 def add_ref_common(meta):
-    instrument = {'name': 'WFI', 'detector': 'WFI01',
-                  'optical_element': 'F158'}
-    meta['telescope'] = 'ROMAN'
-    meta['instrument'] = instrument
-    meta['origin'] = 'STSCI'
-    meta['pedigree'] = 'GROUND'
-    meta['author'] = 'test system'
-    meta['description'] = 'blah blah blah'
-    meta['useafter'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    meta['reftype'] = ''
+    instrument = {"name": "WFI", "detector": "WFI01", "optical_element": "F158"}
+    meta["telescope"] = "ROMAN"
+    meta["instrument"] = instrument
+    meta["origin"] = "STSCI"
+    meta["pedigree"] = "GROUND"
+    meta["author"] = "test system"
+    meta["description"] = "blah blah blah"
+    meta["useafter"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    meta["reftype"] = ""
+
 
 def mk_level1_science_raw(shape=None, filepath=None):
     """
@@ -450,7 +446,7 @@ def mk_level1_science_raw(shape=None, filepath=None):
     """
     meta = mk_common_meta()
     wfi_science_raw = stnode.WfiScienceRaw()
-    wfi_science_raw['meta'] = meta
+    wfi_science_raw["meta"] = meta
 
     if not shape:
         shape = (8, 4096, 4096)
@@ -458,16 +454,14 @@ def mk_level1_science_raw(shape=None, filepath=None):
     else:
         n_ints = shape[0]
 
-    wfi_science_raw['data'] = u.Quantity(np.zeros(shape, dtype=np.uint16),
-                                         ru.DN, dtype=np.uint16)
+    wfi_science_raw["data"] = u.Quantity(np.zeros(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
 
     # add amp 33 ref pix
-    wfi_science_raw['amp33'] = u.Quantity(np.zeros((n_ints, 4096, 128), dtype=np.uint16),
-                                         ru.DN, dtype=np.uint16)
+    wfi_science_raw["amp33"] = u.Quantity(np.zeros((n_ints, 4096, 128), dtype=np.uint16), ru.DN, dtype=np.uint16)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': wfi_science_raw}
+        af.tree = {"roman": wfi_science_raw}
         af.write_to(filepath)
     else:
         return wfi_science_raw
@@ -502,53 +496,44 @@ def mk_level2_image(shape=None, n_ints=None, filepath=None):
     roman_datamodels.stnode.WfiImage
     """
     meta = mk_common_meta()
-    meta['photometry'] = mk_photometry()
+    meta["photometry"] = mk_photometry()
     wfi_image = stnode.WfiImage()
-    wfi_image['meta'] = meta
+    wfi_image["meta"] = meta
     if not shape:
         shape = (4088, 4088)
     if not n_ints:
         n_ints = 8
 
     # add border reference pixel arrays
-    wfi_image['border_ref_pix_left'] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32),
-                                         ru.DN, dtype=np.float32)
-    wfi_image['border_ref_pix_right'] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32),
-                                         ru.DN, dtype=np.float32)
-    wfi_image['border_ref_pix_top'] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32),
-                                         ru.DN, dtype=np.float32)
-    wfi_image['border_ref_pix_bottom'] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32),
-                                         ru.DN, dtype=np.float32)
-
+    wfi_image["border_ref_pix_left"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), ru.DN, dtype=np.float32)
+    wfi_image["border_ref_pix_right"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), ru.DN, dtype=np.float32)
+    wfi_image["border_ref_pix_top"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), ru.DN, dtype=np.float32)
+    wfi_image["border_ref_pix_bottom"] = u.Quantity(
+        np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), ru.DN, dtype=np.float32
+    )
 
     # and their dq arrays
-    wfi_image['dq_border_ref_pix_left'] = np.zeros((shape[0] + 8, 4), dtype=np.uint32)
-    wfi_image['dq_border_ref_pix_right'] = np.zeros((shape[0] + 8, 4), dtype=np.uint32)
-    wfi_image['dq_border_ref_pix_top'] = np.zeros((4, shape[1] + 8), dtype=np.uint32)
-    wfi_image['dq_border_ref_pix_bottom'] = np.zeros((4, shape[1] + 8), dtype=np.uint32)
+    wfi_image["dq_border_ref_pix_left"] = np.zeros((shape[0] + 8, 4), dtype=np.uint32)
+    wfi_image["dq_border_ref_pix_right"] = np.zeros((shape[0] + 8, 4), dtype=np.uint32)
+    wfi_image["dq_border_ref_pix_top"] = np.zeros((4, shape[1] + 8), dtype=np.uint32)
+    wfi_image["dq_border_ref_pix_bottom"] = np.zeros((4, shape[1] + 8), dtype=np.uint32)
 
     # add amp 33 ref pixel array
     amp33_size = (n_ints, 4096, 128)
-    wfi_image['amp33'] = u.Quantity(np.zeros(amp33_size, dtype=np.uint16),
-                                         ru.DN, dtype=np.uint16)
+    wfi_image["amp33"] = u.Quantity(np.zeros(amp33_size, dtype=np.uint16), ru.DN, dtype=np.uint16)
 
-    wfi_image['data'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                         ru.electron / u.s, dtype=np.float32)
-    wfi_image['dq'] = np.zeros(shape, dtype=np.uint32)
-    wfi_image['err'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                         ru.electron / u.s, dtype=np.float32)
+    wfi_image["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
+    wfi_image["dq"] = np.zeros(shape, dtype=np.uint32)
+    wfi_image["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
 
-    wfi_image['var_poisson'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                         ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image['var_rnoise'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                         ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image['var_flat'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                         ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image['cal_logs'] = mk_cal_logs()
+    wfi_image["var_poisson"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image["var_rnoise"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image["var_flat"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image["cal_logs"] = mk_cal_logs()
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': wfi_image}
+        af.tree = {"roman": wfi_image}
         af.write_to(filepath)
     else:
         return wfi_image
@@ -574,22 +559,23 @@ def mk_flat(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     flatref = stnode.FlatRef()
-    meta['reftype'] = 'FLAT'
-    flatref['meta'] = meta
+    meta["reftype"] = "FLAT"
+    flatref["meta"] = meta
 
     if not shape:
         shape = (4096, 4096)
 
-    flatref['data'] = np.zeros(shape, dtype=np.float32)
-    flatref['dq'] = np.zeros(shape, dtype=np.uint32)
-    flatref['err'] = np.zeros(shape, dtype=np.float32)
+    flatref["data"] = np.zeros(shape, dtype=np.float32)
+    flatref["dq"] = np.zeros(shape, dtype=np.uint32)
+    flatref["err"] = np.zeros(shape, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': flatref}
+        af.tree = {"roman": flatref}
         af.write_to(filepath)
     else:
         return flatref
+
 
 def mk_dark(shape=None, filepath=None):
     """
@@ -611,28 +597,28 @@ def mk_dark(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     darkref = stnode.DarkRef()
-    meta['reftype'] = 'DARK'
-    darkref['meta'] = meta
+    meta["reftype"] = "DARK"
+    darkref["meta"] = meta
     exposure = {}
-    exposure['ngroups'] = 6
-    exposure['nframes'] = 8
-    exposure['groupgap'] = 0
-    exposure['type'] = 'WFI_IMAGE'
-    exposure['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
-    exposure['ma_table_name'] = NOSTR
-    exposure['ma_table_number'] = NONUM
-    darkref['meta']['exposure'] = exposure
+    exposure["ngroups"] = 6
+    exposure["nframes"] = 8
+    exposure["groupgap"] = 0
+    exposure["type"] = "WFI_IMAGE"
+    exposure["p_exptype"] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
+    exposure["ma_table_name"] = NOSTR
+    exposure["ma_table_number"] = NONUM
+    darkref["meta"]["exposure"] = exposure
 
     if not shape:
         shape = (2, 4096, 4096)
 
-    darkref['data'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
-    darkref['dq'] = np.zeros(shape[1:], dtype=np.uint32)
-    darkref['err'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    darkref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    darkref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
+    darkref["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': darkref}
+        af.tree = {"roman": darkref}
         af.write_to(filepath)
     else:
         return darkref
@@ -656,21 +642,20 @@ def mk_distortion(filepath=None):
     meta = {}
     add_ref_common(meta)
     distortionref = stnode.DistortionRef()
-    meta['reftype'] = 'DISTORTION'
-    distortionref['meta'] = meta
+    meta["reftype"] = "DISTORTION"
+    distortionref["meta"] = meta
 
-    distortionref['meta']['input_units'] = u.pixel
-    distortionref['meta']['output_units'] = u.arcsec
+    distortionref["meta"]["input_units"] = u.pixel
+    distortionref["meta"]["output_units"] = u.arcsec
 
-    distortionref['coordinate_distortion_transform'] = models.Shift(1) & models.Shift(2)
+    distortionref["coordinate_distortion_transform"] = models.Shift(1) & models.Shift(2)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': distortionref}
+        af.tree = {"roman": distortionref}
         af.write_to(filepath)
     else:
         return distortionref
-
 
 
 def mk_gain(shape=None, filepath=None):
@@ -693,17 +678,17 @@ def mk_gain(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     gainref = stnode.GainRef()
-    meta['reftype'] = 'GAIN'
-    gainref['meta'] = meta
+    meta["reftype"] = "GAIN"
+    gainref["meta"] = meta
 
     if not shape:
         shape = (4096, 4096)
 
-    gainref['data'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / ru.DN, dtype=np.float32)
+    gainref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': gainref}
+        af.tree = {"roman": gainref}
         af.write_to(filepath)
     else:
         return gainref
@@ -729,18 +714,18 @@ def mk_ipc(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     ipcref = stnode.IpcRef()
-    meta['reftype'] = 'IPC'
-    ipcref['meta'] = meta
+    meta["reftype"] = "IPC"
+    ipcref["meta"] = meta
 
     if not shape:
         shape = (3, 3)
 
-    ipcref['data'] = np.zeros(shape, dtype=np.float32)
-    ipcref['data'][int(np.floor(shape[0]/2))][int(np.floor(shape[1]/2))] = 1.0
+    ipcref["data"] = np.zeros(shape, dtype=np.float32)
+    ipcref["data"][int(np.floor(shape[0] / 2))][int(np.floor(shape[1] / 2))] = 1.0
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': ipcref}
+        af.tree = {"roman": ipcref}
         af.write_to(filepath)
     else:
         return ipcref
@@ -766,21 +751,21 @@ def mk_linearity(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     linearityref = stnode.LinearityRef()
-    meta['reftype'] = 'LINEARITY'
-    linearityref['meta'] = meta
+    meta["reftype"] = "LINEARITY"
+    linearityref["meta"] = meta
 
-    linearityref['meta']['input_units'] = ru.DN
-    linearityref['meta']['output_units'] = ru.DN
+    linearityref["meta"]["input_units"] = ru.DN
+    linearityref["meta"]["output_units"] = ru.DN
 
     if not shape:
         shape = (2, 4096, 4096)
 
-    linearityref['dq'] = np.zeros(shape[1:], dtype=np.uint32)
-    linearityref['coeffs'] = np.zeros(shape, dtype=np.float32)
+    linearityref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
+    linearityref["coeffs"] = np.zeros(shape, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': linearityref}
+        af.tree = {"roman": linearityref}
         af.write_to(filepath)
     else:
         return linearityref
@@ -806,20 +791,21 @@ def mk_mask(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     maskref = stnode.MaskRef()
-    meta['reftype'] = 'MASK'
-    maskref['meta'] = meta
+    meta["reftype"] = "MASK"
+    maskref["meta"] = meta
 
     if not shape:
         shape = (4096, 4096)
 
-    maskref['dq'] = np.zeros(shape, dtype=np.uint32)
+    maskref["dq"] = np.zeros(shape, dtype=np.uint32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': maskref}
+        af.tree = {"roman": maskref}
         af.write_to(filepath)
     else:
         return maskref
+
 
 def mk_pixelarea(shape=None, filepath=None):
     """
@@ -841,24 +827,25 @@ def mk_pixelarea(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     pixelarearef = stnode.PixelareaRef()
-    meta['reftype'] = 'AREA'
-    meta['photometry'] = {
-        'pixelarea_steradians': float(NONUM) * u.sr,
-        'pixelarea_arcsecsq': float(NONUM) * u.arcsec** 2,
+    meta["reftype"] = "AREA"
+    meta["photometry"] = {
+        "pixelarea_steradians": float(NONUM) * u.sr,
+        "pixelarea_arcsecsq": float(NONUM) * u.arcsec**2,
     }
-    pixelarearef['meta'] = meta
+    pixelarearef["meta"] = meta
 
     if not shape:
         shape = (4096, 4096)
 
-    pixelarearef['data'] = np.zeros(shape, dtype=np.float32)
+    pixelarearef["data"] = np.zeros(shape, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': pixelarearef}
+        af.tree = {"roman": pixelarearef}
         af.write_to(filepath)
     else:
         return pixelarearef
+
 
 def mk_wfi_img_photom(filepath=None):
     """
@@ -877,64 +864,63 @@ def mk_wfi_img_photom(filepath=None):
     meta = {}
     add_ref_common(meta)
     wfi_img_photomref = stnode.WfiImgPhotomRef()
-    meta['reftype'] = 'PHOTOM'
-    wfi_img_photomref['meta'] = meta
+    meta["reftype"] = "PHOTOM"
+    wfi_img_photomref["meta"] = meta
 
     wfi_img_photo_dict = {
-        "F062":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F087":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F106":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F129":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F146":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F158":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F184":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "F213":
-            {"photmjsr": (1.0e-15  * np.random.random() * u.megajansky / u.steradian),
-             "uncertainty": (1.0e-16  * np.random.random() * u.megajansky / u.steradian),
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "GRISM":
-            {"photmjsr": None,
-             "uncertainty": None,
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "PRISM":
-            {"photmjsr": None,
-             "uncertainty": None,
-             "pixelareasr": 1.0e-13 * u.steradian},
-        "DARK":
-            {"photmjsr": None,
-             "uncertainty": None,
-             "pixelareasr": 1.0e-13 * u.steradian},
+        "F062": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F087": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F106": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F129": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F146": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F158": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F184": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "F213": {
+            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "pixelareasr": 1.0e-13 * u.steradian,
+        },
+        "GRISM": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
+        "PRISM": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
+        "DARK": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
     }
-    wfi_img_photomref['phot_table'] = wfi_img_photo_dict
-
+    wfi_img_photomref["phot_table"] = wfi_img_photo_dict
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': wfi_img_photomref}
+        af.tree = {"roman": wfi_img_photomref}
         af.write_to(filepath)
     else:
         return wfi_img_photomref
+
 
 def mk_readnoise(shape=None, filepath=None):
     """
@@ -956,21 +942,21 @@ def mk_readnoise(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     readnoiseref = stnode.ReadnoiseRef()
-    meta['reftype'] = 'READNOISE'
-    readnoiseref['meta'] = meta
+    meta["reftype"] = "READNOISE"
+    readnoiseref["meta"] = meta
     exposure = {}
-    exposure['type'] = 'WFI_IMAGE'
-    exposure['p_exptype'] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
-    readnoiseref['meta']['exposure'] = exposure
+    exposure["type"] = "WFI_IMAGE"
+    exposure["p_exptype"] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
+    readnoiseref["meta"]["exposure"] = exposure
 
     if not shape:
         shape = (4096, 4096)
 
-    readnoiseref['data'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    readnoiseref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': readnoiseref}
+        af.tree = {"roman": readnoiseref}
         af.write_to(filepath)
     else:
         return readnoiseref
@@ -999,41 +985,38 @@ def mk_ramp(shape=None, n_ints=None, filepath=None):
     """
     meta = mk_common_meta()
     ramp = stnode.Ramp()
-    ramp['meta'] = meta
+    ramp["meta"] = meta
 
     if not shape:
         shape = (8, 4096, 4096)
 
     # add border reference pixel arrays
-    ramp['border_ref_pix_left'] = u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32),
-                                                      ru.DN, dtype=np.float32)
-    ramp['border_ref_pix_right'] = u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32),
-                                                      ru.DN, dtype=np.float32)
-    ramp['border_ref_pix_top'] = u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32),
-                                                      ru.DN, dtype=np.float32)
-    ramp['border_ref_pix_bottom'] = u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32),
-                                                      ru.DN, dtype=np.float32)
+    ramp["border_ref_pix_left"] = u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp["border_ref_pix_right"] = u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp["border_ref_pix_top"] = u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp["border_ref_pix_bottom"] = u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32), ru.DN, dtype=np.float32)
 
     # and their dq arrays
-    ramp['dq_border_ref_pix_left'] = np.zeros((shape[1], 4), dtype=np.uint32)
-    ramp['dq_border_ref_pix_right'] = np.zeros((shape[1], 4), dtype=np.uint32)
-    ramp['dq_border_ref_pix_top'] = np.zeros((4, shape[2]), dtype=np.uint32)
-    ramp['dq_border_ref_pix_bottom'] = np.zeros((4, shape[2]), dtype=np.uint32)
+    ramp["dq_border_ref_pix_left"] = np.zeros((shape[1], 4), dtype=np.uint32)
+    ramp["dq_border_ref_pix_right"] = np.zeros((shape[1], 4), dtype=np.uint32)
+    ramp["dq_border_ref_pix_top"] = np.zeros((4, shape[2]), dtype=np.uint32)
+    ramp["dq_border_ref_pix_bottom"] = np.zeros((4, shape[2]), dtype=np.uint32)
 
     # add amp 33 ref pixel array
-    ramp['amp33'] = u.Quantity(np.full(shape, 1.0, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    ramp["amp33"] = u.Quantity(np.full(shape, 1.0, dtype=np.uint16), ru.DN, dtype=np.uint16)
 
-    ramp['data'] = u.Quantity(np.full(shape, 1.0, dtype=np.float32), ru.DN, dtype=np.float32)
-    ramp['pixeldq'] = np.zeros(shape[1:], dtype=np.uint32)
-    ramp['groupdq'] = np.zeros(shape, dtype=np.uint8)
-    ramp['err'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp["data"] = u.Quantity(np.full(shape, 1.0, dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp["pixeldq"] = np.zeros(shape[1:], dtype=np.uint32)
+    ramp["groupdq"] = np.zeros(shape, dtype=np.uint8)
+    ramp["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': ramp}
+        af.tree = {"roman": ramp}
         af.write_to(filepath)
     else:
         return ramp
+
 
 def mk_rampfitoutput(shape=None, filepath=None):
     """
@@ -1054,35 +1037,28 @@ def mk_rampfitoutput(shape=None, filepath=None):
     """
     meta = mk_common_meta()
     rampfitoutput = stnode.RampFitOutput()
-    rampfitoutput['meta'] = meta
+    rampfitoutput["meta"] = meta
 
     if not shape:
         shape = (8, 4096, 4096)
 
-    rampfitoutput['slope'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                        ru.electron / u.s, dtype=np.float32)
-    rampfitoutput['sigslope'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                        ru.electron / u.s, dtype=np.float32)
-    rampfitoutput['yint'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                        ru.electron, dtype=np.float32)
-    rampfitoutput['sigyint'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                        ru.electron, dtype=np.float32)
-    rampfitoutput['pedestal'] = u.Quantity(np.zeros(shape[1:], dtype=np.float32),
-                                           ru.electron, dtype=np.float32)
-    rampfitoutput['weights'] = np.zeros(shape, dtype=np.float32)
-    rampfitoutput['crmag'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                        ru.electron, dtype=np.float32)
-    rampfitoutput['var_poisson'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                              ru.electron**2 / u.s**2, dtype=np.float32)
-    rampfitoutput['var_rnoise'] = u.Quantity(np.zeros(shape, dtype=np.float32),
-                                             ru.electron**2 / u.s**2, dtype=np.float32)
+    rampfitoutput["slope"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
+    rampfitoutput["sigslope"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
+    rampfitoutput["yint"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron, dtype=np.float32)
+    rampfitoutput["sigyint"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron, dtype=np.float32)
+    rampfitoutput["pedestal"] = u.Quantity(np.zeros(shape[1:], dtype=np.float32), ru.electron, dtype=np.float32)
+    rampfitoutput["weights"] = np.zeros(shape, dtype=np.float32)
+    rampfitoutput["crmag"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron, dtype=np.float32)
+    rampfitoutput["var_poisson"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    rampfitoutput["var_rnoise"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': rampfitoutput}
+        af.tree = {"roman": rampfitoutput}
         af.write_to(filepath)
     else:
         return rampfitoutput
+
 
 def mk_guidewindow(shape=None, filepath=None):
     """
@@ -1103,51 +1079,41 @@ def mk_guidewindow(shape=None, filepath=None):
     """
     meta = mk_common_meta()
     guidewindow = stnode.Guidewindow()
-    guidewindow['meta'] = meta
+    guidewindow["meta"] = meta
 
-    guidewindow['meta']['file_creation_time'] = time.Time(
-        '2020-01-01T20:00:00.0', format='isot', scale='utc')
-    guidewindow['meta']['gw_start_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    guidewindow['meta']['gw_end_time'] = time.Time(
-        '2020-01-01T10:00:00.0', format='isot', scale='utc')
-    guidewindow['meta']['gw_function_start_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    guidewindow['meta']['gw_function_end_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    guidewindow['meta']['gw_frame_readout_time'] = NONUM
-    guidewindow['meta']['pedestal_resultant_exp_time'] = NONUM
-    guidewindow['meta']['signal_resultant_exp_time'] = NONUM
-    guidewindow['meta']['gw_acq_number'] = NONUM
-    guidewindow['meta']['gw_mode'] = 'WIM-ACQ'
-    guidewindow['meta']['gw_window_xstart'] = NONUM
-    guidewindow['meta']['gw_window_ystart'] = NONUM
-    guidewindow['meta']['gw_window_xstop'] = guidewindow['meta']['gw_window_xstart'] + 170
-    guidewindow['meta']['gw_window_ystop'] = guidewindow['meta']['gw_window_ystart'] + 24
-    guidewindow['meta']['gw_window_xsize'] = 170
-    guidewindow['meta']['gw_window_ysize'] = 24
+    guidewindow["meta"]["file_creation_time"] = time.Time("2020-01-01T20:00:00.0", format="isot", scale="utc")
+    guidewindow["meta"]["gw_start_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    guidewindow["meta"]["gw_end_time"] = time.Time("2020-01-01T10:00:00.0", format="isot", scale="utc")
+    guidewindow["meta"]["gw_function_start_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    guidewindow["meta"]["gw_function_end_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    guidewindow["meta"]["gw_frame_readout_time"] = NONUM
+    guidewindow["meta"]["pedestal_resultant_exp_time"] = NONUM
+    guidewindow["meta"]["signal_resultant_exp_time"] = NONUM
+    guidewindow["meta"]["gw_acq_number"] = NONUM
+    guidewindow["meta"]["gw_mode"] = "WIM-ACQ"
+    guidewindow["meta"]["gw_window_xstart"] = NONUM
+    guidewindow["meta"]["gw_window_ystart"] = NONUM
+    guidewindow["meta"]["gw_window_xstop"] = guidewindow["meta"]["gw_window_xstart"] + 170
+    guidewindow["meta"]["gw_window_ystop"] = guidewindow["meta"]["gw_window_ystart"] + 24
+    guidewindow["meta"]["gw_window_xsize"] = 170
+    guidewindow["meta"]["gw_window_ysize"] = 24
 
-    guidewindow['meta']['gw_function_start_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    guidewindow['meta']['gw_function_end_time'] = time.Time(
-        '2020-01-01T00:00:00.0', format='isot', scale='utc')
-    guidewindow['meta']['data_start'] = NONUM
-    guidewindow['meta']['data_end'] = NONUM
-    guidewindow['meta']['gw_acq_exec_stat'] = _random_string("Status ", 15)
+    guidewindow["meta"]["gw_function_start_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    guidewindow["meta"]["gw_function_end_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    guidewindow["meta"]["data_start"] = NONUM
+    guidewindow["meta"]["data_end"] = NONUM
+    guidewindow["meta"]["gw_acq_exec_stat"] = _random_string("Status ", 15)
 
     if not shape:
         shape = (2, 8, 16, 32, 32)
 
-    guidewindow['pedestal_frames'] = u.Quantity(np.zeros(shape, dtype=np.uint16),
-                                         ru.DN, dtype=np.uint16)
-    guidewindow['signal_frames'] = u.Quantity(np.zeros(shape, dtype=np.uint16),
-                                         ru.DN, dtype=np.uint16)
-    guidewindow['amp33'] = u.Quantity(np.zeros(shape, dtype=np.uint16),
-                                         ru.DN, dtype=np.uint16)
+    guidewindow["pedestal_frames"] = u.Quantity(np.zeros(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    guidewindow["signal_frames"] = u.Quantity(np.zeros(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    guidewindow["amp33"] = u.Quantity(np.zeros(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': guidewindow}
+        af.tree = {"roman": guidewindow}
         af.write_to(filepath)
     else:
         return guidewindow
@@ -1173,21 +1139,22 @@ def mk_saturation(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     saturationref = stnode.SaturationRef()
-    meta['reftype'] = 'SATURATION'
-    saturationref['meta'] = meta
+    meta["reftype"] = "SATURATION"
+    saturationref["meta"] = meta
 
     if not shape:
         shape = (4096, 4096)
 
-    saturationref['dq'] = np.zeros(shape, dtype=np.uint32)
-    saturationref['data'] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    saturationref["dq"] = np.zeros(shape, dtype=np.uint32)
+    saturationref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': saturationref}
+        af.tree = {"roman": saturationref}
         af.write_to(filepath)
     else:
         return saturationref
+
 
 def mk_superbias(shape=None, filepath=None):
     """
@@ -1209,19 +1176,19 @@ def mk_superbias(shape=None, filepath=None):
     meta = {}
     add_ref_common(meta)
     superbiasref = stnode.SuperbiasRef()
-    meta['reftype'] = 'BIAS'
-    superbiasref['meta'] = meta
+    meta["reftype"] = "BIAS"
+    superbiasref["meta"] = meta
 
     if not shape:
         shape = (4096, 4096)
 
-    superbiasref['data'] = np.zeros(shape, dtype=np.float32)
-    superbiasref['dq'] = np.zeros(shape, dtype=np.uint32)
-    superbiasref['err'] = np.zeros(shape, dtype=np.float32)
+    superbiasref["data"] = np.zeros(shape, dtype=np.float32)
+    superbiasref["dq"] = np.zeros(shape, dtype=np.uint32)
+    superbiasref["err"] = np.zeros(shape, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
-        af.tree = {'roman': superbiasref}
+        af.tree = {"roman": superbiasref}
         af.write_to(filepath)
     else:
         return superbiasref
@@ -1237,15 +1204,15 @@ def mk_ref_file():
     roman_datamodels.stnode.RefFile
     """
     ref_file = stnode.RefFile()
-    ref_file['dark'] = 'N/A'
-    ref_file['distortion'] = 'N/A'
-    ref_file['flat'] = 'N/A'
-    ref_file['gain'] = 'N/A'
-    ref_file['linearity'] = 'N/A'
-    ref_file['mask'] = 'N/A'
-    ref_file['readnoise'] = 'N/A'
-    ref_file['saturation'] = 'N/A'
-    ref_file['photom'] = 'N/A'
-    ref_file['crds'] = {'sw_version': "12.3.1", "context_used": "roman_0815.pmap"}
+    ref_file["dark"] = "N/A"
+    ref_file["distortion"] = "N/A"
+    ref_file["flat"] = "N/A"
+    ref_file["gain"] = "N/A"
+    ref_file["linearity"] = "N/A"
+    ref_file["mask"] = "N/A"
+    ref_file["readnoise"] = "N/A"
+    ref_file["saturation"] = "N/A"
+    ref_file["photom"] = "N/A"
+    ref_file["crds"] = {"sw_version": "12.3.1", "context_used": "roman_0815.pmap"}
 
     return ref_file

--- a/src/roman_datamodels/testing/utils.py
+++ b/src/roman_datamodels/testing/utils.py
@@ -3,10 +3,11 @@ import astropy.time as time
 import numpy as np
 from astropy import units as u
 from astropy.modeling import models
+
 from roman_datamodels import units as ru
 
-from .factories import _random_positive_int, _random_string
 from .. import stnode
+from .factories import _random_positive_int, _random_string
 
 NONUM = -999999
 NOSTR = "dummy value"

--- a/src/roman_datamodels/units.py
+++ b/src/roman_datamodels/units.py
@@ -3,7 +3,7 @@ from astropy import units as u
 __all__ = ["Unit"]
 
 
-ROMAN_UNIT_SYMBOLS = ['DN', 'electron']
+ROMAN_UNIT_SYMBOLS = ["DN", "electron"]
 
 
 class UnitMixin:
@@ -25,6 +25,7 @@ class UnitMixin:
         try:
             # Cannot handle this as Unit, re-try as Quantity
             from astropy.units.quantity import Quantity
+
             return Quantity(1, self) / m
         except TypeError:
             return NotImplemented
@@ -43,6 +44,7 @@ class UnitMixin:
         # Cannot handle this as Unit, re-try as Quantity.
         try:
             from astropy.units.quantity import Quantity
+
             return Quantity(1, unit=self) * m
         except TypeError:
             return NotImplemented

--- a/src/roman_datamodels/units.py
+++ b/src/roman_datamodels/units.py
@@ -1,6 +1,5 @@
 from astropy import units as u
 
-
 __all__ = ["Unit"]
 
 
@@ -102,8 +101,9 @@ def force_roman_unit(unit):
         A roman unit version if called for
     """
 
-    import roman_datamodels.units as units
     import astropy.units as u
+
+    import roman_datamodels.units as units
 
     if (ru := getattr(units, unit.to_string(), None)) is not None:
         return ru

--- a/src/roman_datamodels/util.py
+++ b/src/roman_datamodels/util.py
@@ -10,8 +10,6 @@ from pydoc import locate
 
 import psutil
 
-# from . import s3_utils
-# from .basic_utils import bytes2human
 from .extensions import DATAMODEL_EXTENSIONS
 
 log = logging.getLogger(__name__)

--- a/src/roman_datamodels/util.py
+++ b/src/roman_datamodels/util.py
@@ -10,8 +10,8 @@ from pydoc import locate
 
 import psutil
 
-#from . import s3_utils
-#from .basic_utils import bytes2human
+# from . import s3_utils
+# from .basic_utils import bytes2human
 from .extensions import DATAMODEL_EXTENSIONS
 
 log = logging.getLogger(__name__)
@@ -19,11 +19,11 @@ log.addHandler(logging.NullHandler())
 
 
 __all__ = [
-    'bytes2human',
-    'NoTypeWarning',
-    'get_schema_uri_from_converter',
-    'can_broadcast',
-    'to_camelcase',
+    "bytes2human",
+    "NoTypeWarning",
+    "get_schema_uri_from_converter",
+    "can_broadcast",
+    "to_camelcase",
 ]
 
 
@@ -51,14 +51,14 @@ def bytes2human(n):
     >>> bytes2human(100001221)
         '95.4M'
     """
-    symbols = ('K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+    symbols = ("K", "M", "G", "T", "P", "E", "Z", "Y")
     prefix = {}
     for i, s in enumerate(symbols):
         prefix[s] = 1 << (i + 1) * 10
     for s in reversed(symbols):
         if n >= prefix[s]:
             value = float(n) / prefix[s]
-            return f'{value:.1f}{s}'
+            return f"{value:.1f}{s}"
     return "%sB" % n
 
 
@@ -75,9 +75,9 @@ def get_schema_uri_from_converter(converter_class):
     # Presume these are from the same directory tree
     rclass = locate(classname)
     tag = rclass._tag
-    schema_uri = next(
-        t for t in DATAMODEL_EXTENSIONS[0].tags if t.tag_uri == tag).schema_uris[0]
+    schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags if t.tag_uri == tag).schema_uris[0]
     return schema_uri
+
 
 # def open(init=None, memmap=False, **kwargs):
 #     """
@@ -193,8 +193,7 @@ def _class_from_model_type(hdulist):
     """
     Get the model type from the primary header, lookup to get class
     """
-    raise NotImplementedError(
-        "stdatamodels does not yet support automatic model class selection")
+    raise NotImplementedError("stdatamodels does not yet support automatic model class selection")
     # from . import _defined_models as defined_models
 
     # if hdulist:
@@ -215,8 +214,7 @@ def _class_from_ramp_type(hdulist, shape):
     """
     Special check to see if file is ramp file
     """
-    raise NotImplementedError(
-        "stdatamodels does not yet support automatic model class selection")
+    raise NotImplementedError("stdatamodels does not yet support automatic model class selection")
     # if not hdulist:
     #     new_class = None
     # else:
@@ -238,8 +236,7 @@ def _class_from_reftype(hdulist, shape):
     """
     Get the class name from the reftype and other header keywords
     """
-    raise NotImplementedError(
-        "stdatamodels does not yet support automatic model class selection")
+    raise NotImplementedError("stdatamodels does not yet support automatic model class selection")
     # if not hdulist:
     #     new_class = None
 
@@ -269,8 +266,7 @@ def _class_from_shape(hdulist, shape):
     """
     Get the class name from the shape
     """
-    raise NotImplementedError(
-        "stdatamodels does not yet support automatic model class selection")
+    raise NotImplementedError("stdatamodels does not yet support automatic model class selection")
     # if len(shape) == 0:
     #     from . import model_base
     #     new_class = model_base.DataModel
@@ -312,7 +308,7 @@ def can_broadcast(a, b):
 
 
 def to_camelcase(token):
-    return ''.join(x.capitalize() for x in token.split('_-'))
+    return "".join(x.capitalize() for x in token.split("_-"))
 
 
 def is_association(asn_data):
@@ -320,25 +316,25 @@ def is_association(asn_data):
     Test if an object is an association by checking for required fields
     """
     if isinstance(asn_data, dict):
-        if 'asn_id' in asn_data and 'asn_pool' in asn_data:
+        if "asn_id" in asn_data and "asn_pool" in asn_data:
             return True
     return False
 
 
 def get_short_doc(schema):
-    title = schema.get('title', None)
-    description = schema.get('description', None)
+    title = schema.get("title", None)
+    description = schema.get("description", None)
     if description is None:
-        description = title or ''
+        description = title or ""
     else:
         if title is not None:
-            description = title + '\n\n' + description
-    return description.partition('\n')[0]
+            description = title + "\n\n" + description
+    return description.partition("\n")[0]
 
 
 def ensure_ascii(s):
     if isinstance(s, bytes):
-        s = s.decode('ascii')
+        s = s.decode("ascii")
     return s
 
 
@@ -378,13 +374,10 @@ def create_history_entry(description, software=None):
     elif software is not None:
         software = Software(software)
 
-    entry = HistoryEntry({
-        'description': description,
-        'time': datetime.datetime.utcnow()
-    })
+    entry = HistoryEntry({"description": description, "time": datetime.datetime.utcnow()})
 
     if software is not None:
-        entry['software'] = software
+        entry["software"] = software
     return entry
 
 
@@ -404,8 +397,8 @@ def get_envar_as_boolean(name, default=False):
     default : bool
         If the environmental variable cannot be accessed, use as the default.
     """
-    truths = ('true', 't', 'yes', 'y')
-    falses = ('false', 'f', 'no', 'n')
+    truths = ("true", "t", "yes", "y")
+    falses = ("false", "f", "no", "n")
     if name in os.environ:
         value = os.environ[name]
         try:
@@ -413,13 +406,11 @@ def get_envar_as_boolean(name, default=False):
         except ValueError:
             value_lowcase = value.lower()
             if value_lowcase not in truths + falses:
-                raise ValueError(
-                    f'Cannot convert value "{value}" to boolean unambiguously.')
+                raise ValueError(f'Cannot convert value "{value}" to boolean unambiguously.')
             return value_lowcase in truths
         return value
 
-    log.debug(
-        f'Environmental "{name}" cannot be found. Using default value of "{default}".')
+    log.debug(f'Environmental "{name}" cannot be found. Using default value of "{default}".')
     return default
 
 
@@ -451,7 +442,7 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
     """
     # Determine desired allowed amount.
     if allowed is None:
-        allowed = os.environ.get('DMODEL_ALLOWED_MEMORY', None)
+        allowed = os.environ.get("DMODEL_ALLOWED_MEMORY", None)
         if allowed is not None:
             allowed = float(allowed)
 
@@ -473,19 +464,16 @@ def check_memory_allocation(shape, allowed=None, model_type=None, include_swap=T
 
     # Get available memory
     available = get_available_memory(include_swap=include_swap)
-    log.debug(
-        f'Model size {bytes2human(size)} available system memory {bytes2human(available)}')
+    log.debug(f"Model size {bytes2human(size)} available system memory {bytes2human(available)}")
 
     if size > available:
         log.warning(
-            f'Model {model_type} shape {shape} requires {bytes2human(size)} which is more than'
-            f' system available {bytes2human(available)}'
+            f"Model {model_type} shape {shape} requires {bytes2human(size)} which is more than"
+            f" system available {bytes2human(available)}"
         )
 
     if allowed and size > (allowed * available):
-        log.debug(
-            f'Model size greater than allowed memory {bytes2human(allowed * available)}'
-        )
+        log.debug(f"Model size greater than allowed memory {bytes2human(allowed * available)}")
         return False, size
 
     return True, size
@@ -508,7 +496,7 @@ def get_available_memory(include_swap=True):
 
     # Apple MacOS
     log.debug(f'Running OS is "{system}"')
-    if system in ['Darwin']:
+    if system in ["Darwin"]:
         return get_available_memory_darwin(include_swap=include_swap)
 
     # Default to Linux-like:
@@ -564,11 +552,9 @@ def get_available_memory_darwin(include_swap=True):
 
         # Attempt to determine amount of free disk space on the boot partition.
         try:
-            swap = psutil.disk_usage('/private/var/vm').free
+            swap = psutil.disk_usage("/private/var/vm").free
         except FileNotFoundError as exception:
-            log.warn('Cannot determine available swap space.'
-                     f'Reason:\n'
-                     f'{"".join(traceback.format_exception(exception))}')
+            log.warn(f'Cannot determine available swap space.Reason:\n{"".join(traceback.format_exception(exception))}')
             swap = 0
         available += swap
 

--- a/src/roman_datamodels/util.py
+++ b/src/roman_datamodels/util.py
@@ -2,17 +2,18 @@
 Various utility functions and data types
 """
 
+import logging
 import os
-from platform import system as platform_system
-import psutil
 import traceback
+from platform import system as platform_system
 from pydoc import locate
+
+import psutil
 
 #from . import s3_utils
 #from .basic_utils import bytes2human
 from .extensions import DATAMODEL_EXTENSIONS
 
-import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
@@ -368,8 +369,9 @@ def create_history_entry(description, software=None):
     >>> entry = create_history_entry(description="HISTORY of this file", software=soft)
 
     """
-    from asdf.tags.core import Software, HistoryEntry
     import datetime
+
+    from asdf.tags.core import HistoryEntry, Software
 
     if isinstance(software, list):
         software = [Software(x) for x in software]

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -11,8 +11,8 @@ from asdf import yamlutil
 from asdf.util import HashableDict
 
 __all__ = [
-    'ValidationWarning',
-    'value_change',
+    "ValidationWarning",
+    "value_change",
 ]
 
 
@@ -20,8 +20,7 @@ class ValidationWarning(Warning):
     pass
 
 
-def value_change(value, pass_invalid_values,
-                 strict_validation):
+def value_change(value, pass_invalid_values, strict_validation):
     """
     Validate a change in value against a schema.
     Trap error and return a flag.
@@ -47,13 +46,12 @@ def _check_type(validator, types, instance, schema):
     if instance is None:
         errors = []
     else:
-        errors = asdf_schema.validate_type(validator, types,
-                                           instance, schema)
+        errors = asdf_schema.validate_type(validator, types, instance, schema)
     return errors
 
 
 validator_callbacks = HashableDict(asdf_schema.YAML_VALIDATORS)
-validator_callbacks.update({'type': _check_type})
+validator_callbacks.update({"type": _check_type})
 
 
 def _check_value(value):
@@ -64,13 +62,8 @@ def _check_value(value):
     validator_context = AsdfFile()
     validator_resolver = validator_context.resolver
 
-    temp_schema = {
-        '$schema':
-        'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema'}
-    validator = asdf_schema.get_validator(temp_schema,
-                                          validator_context,
-                                          validator_callbacks,
-                                          validator_resolver)
+    temp_schema = {"$schema": "http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema"}
+    validator = asdf_schema.get_validator(temp_schema, validator_context, validator_callbacks, validator_resolver)
 
     value = yamlutil.custom_tree_to_tagged_tree(value, validator_context)
     validator.validate(value, _schema=temp_schema)
@@ -83,7 +76,7 @@ def _error_message(path, error):
     """
     if isinstance(path, list):
         spath = [str(p) for p in path]
-        name = '.'.join(spath)
+        name = ".".join(spath)
     else:
         name = str(path)
 

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -3,12 +3,12 @@ Functions that support validation of model changes
 """
 
 import warnings
+
 import jsonschema
 from asdf import AsdfFile
 from asdf import schema as asdf_schema
-from asdf.util import HashableDict
 from asdf import yamlutil
-
+from asdf.util import HashableDict
 
 __all__ = [
     'ValidationWarning',

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,8 +1,8 @@
 import asdf
 import pytest
 
-from roman_datamodels.testing import create_node
 from roman_datamodels import stnode
+from roman_datamodels.testing import create_node
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -4,36 +4,36 @@ import pytest
 
 from roman_datamodels import filetype
 
-DATA_DIRECTORY = Path(__file__).parent / 'data'
+DATA_DIRECTORY = Path(__file__).parent / "data"
 
 
 def test_filetype():
-    file_1 = filetype.check(DATA_DIRECTORY / 'empty.json')
-    file_2 = filetype.check(DATA_DIRECTORY / 'example_schema.json')
-    file_3 = filetype.check(open(DATA_DIRECTORY / 'fake.json'))
-    file_4 = filetype.check(DATA_DIRECTORY / 'empty.asdf')
-    file_5 = filetype.check(DATA_DIRECTORY / 'pluto.asdf')
-    file_6 = filetype.check(open(DATA_DIRECTORY / 'pluto.asdf', 'rb'))
-    file_7 = filetype.check(DATA_DIRECTORY / 'fake.asdf')
-    file_8 = filetype.check(open(DATA_DIRECTORY / 'fake.asdf'))
-    file_9 = filetype.check(str(DATA_DIRECTORY / 'pluto.asdf'))
+    file_1 = filetype.check(DATA_DIRECTORY / "empty.json")
+    file_2 = filetype.check(DATA_DIRECTORY / "example_schema.json")
+    file_3 = filetype.check(open(DATA_DIRECTORY / "fake.json"))
+    file_4 = filetype.check(DATA_DIRECTORY / "empty.asdf")
+    file_5 = filetype.check(DATA_DIRECTORY / "pluto.asdf")
+    file_6 = filetype.check(open(DATA_DIRECTORY / "pluto.asdf", "rb"))
+    file_7 = filetype.check(DATA_DIRECTORY / "fake.asdf")
+    file_8 = filetype.check(open(DATA_DIRECTORY / "fake.asdf"))
+    file_9 = filetype.check(str(DATA_DIRECTORY / "pluto.asdf"))
 
-    assert file_1 == 'asn'
-    assert file_2 == 'asn'
-    assert file_3 == 'asn'
-    assert file_3 == 'asn'
-    assert file_4 == 'asdf'
-    assert file_5 == 'asdf'
-    assert file_6 == 'asdf'
-    assert file_7 == 'asdf'
-    assert file_8 == 'asn'
-    assert file_9 == 'asdf'
+    assert file_1 == "asn"
+    assert file_2 == "asn"
+    assert file_3 == "asn"
+    assert file_3 == "asn"
+    assert file_4 == "asdf"
+    assert file_5 == "asdf"
+    assert file_6 == "asdf"
+    assert file_7 == "asdf"
+    assert file_8 == "asn"
+    assert file_9 == "asdf"
 
     with pytest.raises(ValueError):
-        filetype.check(DATA_DIRECTORY / 'empty.txt')
+        filetype.check(DATA_DIRECTORY / "empty.txt")
 
     with pytest.raises(ValueError):
         filetype.check(2)
 
     with pytest.raises(ValueError):
-        filetype.check('test')
+        filetype.check("test")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,8 +12,7 @@ from roman_datamodels import units as ru
 from roman_datamodels.extensions import DATAMODEL_EXTENSIONS
 from roman_datamodels.testing import utils
 
-EXPECTED_COMMON_REFERENCE = \
-    {'$ref': 'ref_common-1.0.0'}
+EXPECTED_COMMON_REFERENCE = {"$ref": "ref_common-1.0.0"}
 
 
 # Helper class to iterate over model subclasses
@@ -27,9 +26,9 @@ def iter_subclasses(model_class, include_base_model=True):
 def test_model_schemas():
     dmodels = datamodels.model_registry.keys()
     for model in dmodels:
-        schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags
-                          if t._tag_uri == model._tag).schema_uris[0]
+        schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags if t._tag_uri == model._tag).schema_uris[0]
         asdf.schema.load_schema(schema_uri)
+
 
 # Testing core schema
 def test_core_schema(tmp_path):
@@ -38,42 +37,41 @@ def test_core_schema(tmp_path):
 
     wfi_image = utils.mk_level2_image(shape=(10, 10))
     with asdf.AsdfFile() as af:
-        af.tree = {'roman': wfi_image}
+        af.tree = {"roman": wfi_image}
 
         # Test telescope name
-        af.tree['roman'].meta.telescope = 'NOTROMAN'
+        af.tree["roman"].meta.telescope = "NOTROMAN"
         with pytest.raises(ValidationError):
             af.write_to(file_path)
-        af.tree['roman'].meta['telescope'] = 'NOTROMAN'
+        af.tree["roman"].meta["telescope"] = "NOTROMAN"
         with pytest.raises(ValidationError):
             af.write_to(file_path)
-        af.tree['roman'].meta.telescope = 'ROMAN'
+        af.tree["roman"].meta.telescope = "ROMAN"
 
         # Test origin name
-        af.tree['roman'].meta.origin = 'NOTSTSCI'
+        af.tree["roman"].meta.origin = "NOTSTSCI"
         with pytest.raises(ValidationError):
             af.write_to(file_path)
-        af.tree['roman'].meta['origin'] = 'NOTIPAC/SSC'
+        af.tree["roman"].meta["origin"] = "NOTIPAC/SSC"
         with pytest.raises(ValidationError):
             af.write_to(file_path)
-        af.tree['roman'].meta.origin = 'IPAC/SSC'
-        af.tree['roman'].meta.origin = 'STSCI'
+        af.tree["roman"].meta.origin = "IPAC/SSC"
+        af.tree["roman"].meta.origin = "STSCI"
 
         af.write_to(file_path)
     # Now mangle the file
-    with open(file_path, 'rb') as fp:
+    with open(file_path, "rb") as fp:
         fcontents = fp.read()
-    romanloc = fcontents.find(bytes('ROMAN', 'utf-8'))
-    newcontents = fcontents[:romanloc] + \
-        bytes('X', 'utf-8') + fcontents[romanloc + 1:]
-    with open(file_path, 'wb') as fp:
+    romanloc = fcontents.find(bytes("ROMAN", "utf-8"))
+    newcontents = fcontents[:romanloc] + bytes("X", "utf-8") + fcontents[romanloc + 1 :]
+    with open(file_path, "wb") as fp:
         fp.write(newcontents)
     with pytest.raises(ValidationError):
         with datamodels.open(file_path) as model:
             pass
     asdf.get_config().validate_on_read = False
     with datamodels.open(file_path) as model:
-        assert model.meta.telescope == 'XOMAN'
+        assert model.meta.telescope == "XOMAN"
     asdf.get_config().validate_on_read = True
 
 
@@ -81,7 +79,7 @@ def test_core_schema(tmp_path):
 def test_make_ramp():
     ramp = utils.mk_ramp(shape=(2, 20, 20))
 
-    assert ramp.meta.exposure.type == 'WFI_IMAGE'
+    assert ramp.meta.exposure.type == "WFI_IMAGE"
     assert ramp.data.dtype == np.float32
     assert ramp.data.unit == ru.DN
     assert ramp.pixeldq.dtype == np.uint32
@@ -98,10 +96,10 @@ def test_make_ramp():
 
 def test_opening_ramp_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testramp.asdf'
+    file_path = tmp_path / "testramp.asdf"
     utils.mk_ramp(filepath=file_path)
     ramp = datamodels.open(file_path)
-    assert ramp.meta.instrument.optical_element == 'F062'
+    assert ramp.meta.instrument.optical_element == "F062"
     assert isinstance(ramp, datamodels.RampModel)
 
 
@@ -109,7 +107,7 @@ def test_opening_ramp_ref(tmp_path):
 def test_make_rampfitoutput():
     rampfitoutput = utils.mk_rampfitoutput(shape=(2, 20, 20))
 
-    assert rampfitoutput.meta.exposure.type == 'WFI_IMAGE'
+    assert rampfitoutput.meta.exposure.type == "WFI_IMAGE"
     assert rampfitoutput.slope.dtype == np.float32
     assert rampfitoutput.slope.unit == ru.electron / u.s
     assert rampfitoutput.sigslope.dtype == np.float32
@@ -137,10 +135,10 @@ def test_make_rampfitoutput():
 
 def test_opening_rampfitoutput_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testrampfitoutput.asdf'
+    file_path = tmp_path / "testrampfitoutput.asdf"
     utils.mk_rampfitoutput(filepath=file_path)
     rampfitoutput = datamodels.open(file_path)
-    assert rampfitoutput.meta.instrument.optical_element == 'F062'
+    assert rampfitoutput.meta.instrument.optical_element == "F062"
     assert isinstance(rampfitoutput, datamodels.RampFitOutputModel)
 
 
@@ -148,7 +146,7 @@ def test_opening_rampfitoutput_ref(tmp_path):
 def test_make_guidewindow():
     guidewindow = utils.mk_guidewindow(shape=(2, 8, 16, 32, 32))
 
-    assert guidewindow.meta.exposure.type == 'WFI_IMAGE'
+    assert guidewindow.meta.exposure.type == "WFI_IMAGE"
     assert guidewindow.pedestal_frames.dtype == np.uint16
     assert guidewindow.pedestal_frames.unit == ru.DN
     assert guidewindow.signal_frames.dtype == np.uint16
@@ -166,10 +164,10 @@ def test_make_guidewindow():
 
 def test_opening_guidewindow_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testguidewindow.asdf'
+    file_path = tmp_path / "testguidewindow.asdf"
     utils.mk_guidewindow(filepath=file_path)
     guidewindow = datamodels.open(file_path)
-    assert guidewindow.meta.gw_mode == 'WIM-ACQ'
+    assert guidewindow.meta.gw_mode == "WIM-ACQ"
     assert isinstance(guidewindow, datamodels.GuidewindowModel)
 
 
@@ -182,7 +180,7 @@ def test_reference_file_model_base(tmp_path):
     for tag in tags:
         schema = asdf.schema.load_schema(tag.schema_uris[0])
         # Check that schema references common reference schema
-        allofs = schema['properties']['meta']['allOf']
+        allofs = schema["properties"]["meta"]["allOf"]
         found_common = False
         for item in allofs:
             if item == EXPECTED_COMMON_REFERENCE:
@@ -194,7 +192,7 @@ def test_reference_file_model_base(tmp_path):
 # Flat tests
 def test_make_flat():
     flat = utils.mk_flat(shape=(20, 20))
-    assert flat.meta.reftype == 'FLAT'
+    assert flat.meta.reftype == "FLAT"
     assert flat.data.dtype == np.float32
     assert flat.dq.dtype == np.uint32
     assert flat.dq.shape == (20, 20)
@@ -204,13 +202,15 @@ def test_make_flat():
     flat_model = datamodels.FlatRefModel(flat)
     assert flat_model.validate() is None
 
+
 def test_opening_flat_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testflat.asdf'
+    file_path = tmp_path / "testflat.asdf"
     utils.mk_flat(filepath=file_path)
     flat = datamodels.open(file_path)
-    assert flat.meta.instrument.optical_element == 'F158'
+    assert flat.meta.instrument.optical_element == "F158"
     assert isinstance(flat, datamodels.FlatRefModel)
+
 
 def test_flat_model(tmp_path):
     # Set temporary asdf file
@@ -218,18 +218,18 @@ def test_flat_model(tmp_path):
 
     meta = {}
     utils.add_ref_common(meta)
-    meta['reftype'] = "FLAT"
+    meta["reftype"] = "FLAT"
     flatref = stnode.FlatRef()
-    flatref['meta'] = meta
-    flatref.meta.instrument['optical_element'] = 'F062'
+    flatref["meta"] = meta
+    flatref.meta.instrument["optical_element"] = "F062"
     shape = (4096, 4096)
-    flatref['data'] = np.zeros(shape, dtype=np.float32)
-    flatref['dq'] = np.zeros(shape, dtype=np.uint32)
-    flatref['err'] = np.zeros(shape, dtype=np.float32)
+    flatref["data"] = np.zeros(shape, dtype=np.float32)
+    flatref["dq"] = np.zeros(shape, dtype=np.uint32)
+    flatref["err"] = np.zeros(shape, dtype=np.float32)
 
     # Testing flat file asdf file
     with asdf.AsdfFile(meta) as af:
-        af.tree = {'roman': flatref}
+        af.tree = {"roman": flatref}
         af.write_to(file_path)
 
         # Test that asdf file opens properly
@@ -244,7 +244,7 @@ def test_flat_model(tmp_path):
 # Dark Current tests
 def test_make_dark():
     dark = utils.mk_dark(shape=(3, 20, 20))
-    assert dark.meta.reftype == 'DARK'
+    assert dark.meta.reftype == "DARK"
     assert dark.data.dtype == np.float32
     assert dark.dq.dtype == np.uint32
     assert dark.dq.shape == (20, 20)
@@ -258,21 +258,20 @@ def test_make_dark():
 
 def test_opening_dark_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testdark.asdf'
+    file_path = tmp_path / "testdark.asdf"
     utils.mk_dark(filepath=file_path)
     dark = datamodels.open(file_path)
-    assert dark.meta.instrument.optical_element == 'F158'
+    assert dark.meta.instrument.optical_element == "F158"
     assert isinstance(dark, datamodels.DarkRefModel)
-
 
 
 # Distortion tests
 def test_make_distortion():
     distortion = utils.mk_distortion()
-    assert distortion.meta.reftype == 'DISTORTION'
-    assert distortion['meta']['input_units'] == u.pixel
-    assert distortion['meta']['output_units'] == u.arcsec
-    assert isinstance(distortion['coordinate_distortion_transform'], Model)
+    assert distortion.meta.reftype == "DISTORTION"
+    assert distortion["meta"]["input_units"] == u.pixel
+    assert distortion["meta"]["output_units"] == u.arcsec
+    assert isinstance(distortion["coordinate_distortion_transform"], Model)
 
     # Test validation
     distortion_model = datamodels.DistortionRefModel(distortion)
@@ -281,17 +280,17 @@ def test_make_distortion():
 
 def test_opening_distortion_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testdistortion.asdf'
+    file_path = tmp_path / "testdistortion.asdf"
     utils.mk_distortion(filepath=file_path)
     distortion = datamodels.open(file_path)
-    assert distortion.meta.instrument.optical_element == 'F158'
+    assert distortion.meta.instrument.optical_element == "F158"
     assert isinstance(distortion, datamodels.DistortionRefModel)
 
 
 # Gain tests
 def test_make_gain():
     gain = utils.mk_gain(shape=(20, 20))
-    assert gain.meta.reftype == 'GAIN'
+    assert gain.meta.reftype == "GAIN"
     assert gain.data.dtype == np.float32
     assert gain.data.unit == ru.electron / ru.DN
 
@@ -302,19 +301,19 @@ def test_make_gain():
 
 def test_opening_gain_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testgain.asdf'
+    file_path = tmp_path / "testgain.asdf"
     utils.mk_gain(filepath=file_path)
     gain = datamodels.open(file_path)
-    assert gain.meta.instrument.optical_element == 'F158'
+    assert gain.meta.instrument.optical_element == "F158"
     assert isinstance(gain, datamodels.GainRefModel)
 
 
 # Gain tests
 def test_make_ipc():
     ipc = utils.mk_ipc(shape=(21, 21))
-    assert ipc.meta.reftype == 'IPC'
+    assert ipc.meta.reftype == "IPC"
     assert ipc.data.dtype == np.float32
-    assert ipc.data[10,10] == 1.0
+    assert ipc.data[10, 10] == 1.0
     assert np.sum(ipc.data) == 1.0
 
     # Test validation
@@ -324,19 +323,19 @@ def test_make_ipc():
 
 def test_opening_ipc_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testipc.asdf'
+    file_path = tmp_path / "testipc.asdf"
     utils.mk_ipc(filepath=file_path)
     ipc = datamodels.open(file_path)
     assert ipc.data[1, 1] == 1.0
     assert np.sum(ipc.data) == 1.0
-    assert ipc.meta.instrument.optical_element == 'F158'
+    assert ipc.meta.instrument.optical_element == "F158"
     assert isinstance(ipc, datamodels.IpcRefModel)
 
 
 # Linearity tests
 def test_make_linearity():
     linearity = utils.mk_linearity(shape=(2, 20, 20))
-    assert linearity.meta.reftype == 'LINEARITY'
+    assert linearity.meta.reftype == "LINEARITY"
     assert linearity.coeffs.dtype == np.float32
     assert linearity.dq.dtype == np.uint32
 
@@ -347,17 +346,17 @@ def test_make_linearity():
 
 def test_opening_linearity_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testlinearity.asdf'
+    file_path = tmp_path / "testlinearity.asdf"
     utils.mk_linearity(filepath=file_path)
     linearity = datamodels.open(file_path)
-    assert linearity.meta.instrument.optical_element == 'F158'
+    assert linearity.meta.instrument.optical_element == "F158"
     assert isinstance(linearity, datamodels.LinearityRefModel)
 
 
 # Mask tests
 def test_make_mask():
     mask = utils.mk_mask(shape=(20, 20))
-    assert mask.meta.reftype == 'MASK'
+    assert mask.meta.reftype == "MASK"
     assert mask.dq.dtype == np.uint32
 
     # Test validation
@@ -367,17 +366,17 @@ def test_make_mask():
 
 def test_opening_mask_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testmask.asdf'
+    file_path = tmp_path / "testmask.asdf"
     utils.mk_mask(filepath=file_path)
     mask = datamodels.open(file_path)
-    assert mask.meta.instrument.optical_element == 'F158'
+    assert mask.meta.instrument.optical_element == "F158"
     assert isinstance(mask, datamodels.MaskRefModel)
 
 
 # Pixel Area tests
 def test_make_pixelarea():
     pixearea = utils.mk_pixelarea(shape=(20, 20))
-    assert pixearea.meta.reftype == 'AREA'
+    assert pixearea.meta.reftype == "AREA"
     assert type(pixearea.meta.photometry.pixelarea_steradians) == u.Quantity
     assert type(pixearea.meta.photometry.pixelarea_arcsecsq) == u.Quantity
     assert pixearea.data.dtype == np.float32
@@ -389,17 +388,17 @@ def test_make_pixelarea():
 
 def test_opening_pixelarea_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testpixelarea.asdf'
+    file_path = tmp_path / "testpixelarea.asdf"
     utils.mk_pixelarea(filepath=file_path)
     pixelarea = datamodels.open(file_path)
-    assert pixelarea.meta.instrument.optical_element == 'F158'
+    assert pixelarea.meta.instrument.optical_element == "F158"
     assert isinstance(pixelarea, datamodels.PixelareaRefModel)
 
 
 # Read Noise tests
 def test_make_readnoise():
     readnoise = utils.mk_readnoise(shape=(20, 20))
-    assert readnoise.meta.reftype == 'READNOISE'
+    assert readnoise.meta.reftype == "READNOISE"
     assert readnoise.data.dtype == np.float32
     assert readnoise.data.unit == ru.DN
 
@@ -410,36 +409,36 @@ def test_make_readnoise():
 
 def test_opening_readnoise_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testreadnoise.asdf'
+    file_path = tmp_path / "testreadnoise.asdf"
     utils.mk_readnoise(filepath=file_path)
     readnoise = datamodels.open(file_path)
-    assert readnoise.meta.instrument.optical_element == 'F158'
+    assert readnoise.meta.instrument.optical_element == "F158"
     assert isinstance(readnoise, datamodels.ReadnoiseRefModel)
 
 
 def test_add_model_attribute(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testreadnoise.asdf'
+    file_path = tmp_path / "testreadnoise.asdf"
     utils.mk_readnoise(filepath=file_path)
     readnoise = datamodels.open(file_path)
-    readnoise['new_attribute'] = 77
+    readnoise["new_attribute"] = 77
     assert readnoise.new_attribute == 77
     with pytest.raises(ValueError):
-        readnoise['_underscore'] = 'bad'
-    file_path2 = tmp_path / 'testreadnoise2.asdf'
+        readnoise["_underscore"] = "bad"
+    file_path2 = tmp_path / "testreadnoise2.asdf"
     readnoise.save(file_path2)
     readnoise2 = datamodels.open(file_path2)
     assert readnoise2.new_attribute == 77
     readnoise2.new_attribute = 88
     assert readnoise2.new_attribute == 88
     with pytest.raises(ValidationError):
-        readnoise['data'] = 'bad_data_value'
+        readnoise["data"] = "bad_data_value"
 
 
 # Saturation tests
 def test_make_saturation():
     saturation = utils.mk_saturation(shape=(20, 20))
-    assert saturation.meta.reftype == 'SATURATION'
+    assert saturation.meta.reftype == "SATURATION"
     assert saturation.dq.dtype == np.uint32
     assert saturation.data.dtype == np.float32
     assert saturation.data.unit == ru.DN
@@ -451,17 +450,17 @@ def test_make_saturation():
 
 def test_opening_saturation_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testsaturation.asdf'
+    file_path = tmp_path / "testsaturation.asdf"
     utils.mk_saturation(filepath=file_path)
     saturation = datamodels.open(file_path)
-    assert saturation.meta.instrument.optical_element == 'F158'
+    assert saturation.meta.instrument.optical_element == "F158"
     assert isinstance(saturation, datamodels.SaturationRefModel)
 
 
 # Super Bias tests
 def test_make_superbias():
     superbias = utils.mk_superbias(shape=(20, 20))
-    assert superbias.meta.reftype == 'BIAS'
+    assert superbias.meta.reftype == "BIAS"
     assert superbias.data.dtype == np.float32
     assert superbias.err.dtype == np.float32
     assert superbias.dq.dtype == np.uint32
@@ -474,10 +473,10 @@ def test_make_superbias():
 
 def test_opening_superbias_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testsuperbias.asdf'
+    file_path = tmp_path / "testsuperbias.asdf"
     utils.mk_superbias(filepath=file_path)
     superbias = datamodels.open(file_path)
-    assert superbias.meta.instrument.optical_element == 'F158'
+    assert superbias.meta.instrument.optical_element == "F158"
     assert isinstance(superbias, datamodels.SuperbiasRefModel)
 
 
@@ -485,7 +484,7 @@ def test_opening_superbias_ref(tmp_path):
 def test_make_wfi_img_photom():
     wfi_img_photom = utils.mk_wfi_img_photom()
 
-    assert wfi_img_photom.meta.reftype == 'PHOTOM'
+    assert wfi_img_photom.meta.reftype == "PHOTOM"
     assert isinstance(wfi_img_photom.phot_table.F146.photmjsr, u.Quantity)
     assert wfi_img_photom.phot_table.F146.photmjsr.unit == u.megajansky / u.steradian
     assert isinstance(wfi_img_photom.phot_table.F184.photmjsr, u.Quantity)
@@ -509,11 +508,11 @@ def test_make_wfi_img_photom():
 
 def test_opening_wfi_img_photom_ref(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testwfi_img_photom.asdf'
+    file_path = tmp_path / "testwfi_img_photom.asdf"
     utils.mk_wfi_img_photom(filepath=file_path)
     wfi_img_photom = datamodels.open(file_path)
 
-    assert wfi_img_photom.meta.instrument.optical_element == 'F158'
+    assert wfi_img_photom.meta.instrument.optical_element == "F158"
     assert isinstance(wfi_img_photom, datamodels.WfiImgPhotomRefModel)
 
 
@@ -531,11 +530,11 @@ def test_level1_science_raw():
 
 def test_opening_level1_science_raw(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testwfi_science_raw.asdf'
+    file_path = tmp_path / "testwfi_science_raw.asdf"
     utils.mk_level1_science_raw(filepath=file_path)
     wfi_science_raw = datamodels.open(file_path)
 
-    assert wfi_science_raw.meta.instrument.optical_element == 'F062'
+    assert wfi_science_raw.meta.instrument.optical_element == "F062"
     assert isinstance(wfi_science_raw, datamodels.ScienceRawModel)
 
 
@@ -551,7 +550,7 @@ def test_level2_image():
     assert wfi_image.var_poisson.dtype == np.float32
     assert wfi_image.var_poisson.unit == ru.electron**2 / u.s**2
     assert wfi_image.var_rnoise.dtype == np.float32
-    assert wfi_image.var_rnoise.unit == ru.electron ** 2 / u.s ** 2
+    assert wfi_image.var_rnoise.unit == ru.electron**2 / u.s**2
     assert wfi_image.var_flat.dtype == np.float32
     assert type(wfi_image.cal_logs[0]) == str
 
@@ -562,57 +561,56 @@ def test_level2_image():
 
 def test_opening_level2_image(tmp_path):
     # First make test reference file
-    file_path = tmp_path / 'testwfi_image.asdf'
+    file_path = tmp_path / "testwfi_image.asdf"
     utils.mk_level2_image(filepath=file_path)
     wfi_image = datamodels.open(file_path)
 
-    assert wfi_image.meta.instrument.optical_element == 'F062'
+    assert wfi_image.meta.instrument.optical_element == "F062"
     assert isinstance(wfi_image, datamodels.ImageModel)
+
 
 def test_datamodel_info_search(capsys):
     wfi_science_raw = utils.mk_level1_science_raw()
     af = asdf.AsdfFile()
-    af.tree = {'roman': wfi_science_raw}
+    af.tree = {"roman": wfi_science_raw}
     dm = datamodels.open(af)
     dm.info(max_rows=200)
     captured = capsys.readouterr()
     assert "optical_element" in captured.out
-    result = dm.search('optical_element')
-    assert 'F062' in repr(result)
-    assert result.node == 'F062'
+    result = dm.search("optical_element")
+    assert "F062" in repr(result)
+    assert result.node == "F062"
 
 
 def test_datamodel_schema_info():
     wfi_science_raw = utils.mk_level1_science_raw()
     af = asdf.AsdfFile()
-    af.tree = {'roman': wfi_science_raw}
+    af.tree = {"roman": wfi_science_raw}
     dm = datamodels.open(af)
 
-    info = dm.schema_info('archive_catalog')
-    assert info['roman']['meta']['aperture'] == {
-        'name': {
-            'archive_catalog': (
-                {'datatype': 'nvarchar(40)', 'destination': ['ScienceCommon.aperture_name']},
-                dm.meta.aperture.name
+    info = dm.schema_info("archive_catalog")
+    assert info["roman"]["meta"]["aperture"] == {
+        "name": {
+            "archive_catalog": (
+                {"datatype": "nvarchar(40)", "destination": ["ScienceCommon.aperture_name"]},
+                dm.meta.aperture.name,
             ),
         },
-        'position_angle': {
-            'archive_catalog': ({'datatype':'float', 'destination': ['ScienceCommon.position_angle']}, 30.0)
-        }
+        "position_angle": {"archive_catalog": ({"datatype": "float", "destination": ["ScienceCommon.position_angle"]}, 30.0)},
     }
 
 
 def test_crds_parameters(tmp_path):
     # CRDS uses meta.exposure.start_time to compare to USEAFTER
-    file_path = tmp_path / 'testwfi_image.asdf'
+    file_path = tmp_path / "testwfi_image.asdf"
     utils.mk_level2_image(filepath=file_path)
     wfi_image = datamodels.open(file_path)
 
     crds_pars = wfi_image.get_crds_parameters()
-    assert 'roman.meta.exposure.start_time' in crds_pars
+    assert "roman.meta.exposure.start_time" in crds_pars
 
     utils.mk_ramp(filepath=file_path)
     ramp = datamodels.open(file_path)
 
     crds_pars = ramp.get_crds_parameters()
-    assert 'roman.meta.exposure.start_time' in crds_pars
+    assert "roman.meta.exposure.start_time" in crds_pars

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,19 +1,16 @@
-import pytest
 import warnings
 
-from jsonschema import ValidationError
-from astropy import units as u
-from roman_datamodels import units as ru
 import asdf
-from astropy.modeling import Model
 import numpy as np
+import pytest
+from astropy import units as u
+from astropy.modeling import Model
+from jsonschema import ValidationError
 
-from roman_datamodels import datamodels
-from roman_datamodels import stnode
+from roman_datamodels import datamodels, stnode
+from roman_datamodels import units as ru
 from roman_datamodels.extensions import DATAMODEL_EXTENSIONS
-
 from roman_datamodels.testing import utils
-
 
 EXPECTED_COMMON_REFERENCE = \
     {'$ref': 'ref_common-1.0.0'}

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,14 +1,12 @@
-import pytest
-
-from astropy.io import fits
 import asdf
 import numpy as np
-from numpy.testing import assert_array_equal
+import pytest
 from astropy import units as u
+from astropy.io import fits
+from numpy.testing import assert_array_equal
 
-from roman_datamodels import units as ru
 from roman_datamodels import datamodels
-
+from roman_datamodels import units as ru
 from roman_datamodels.testing import utils
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -13,9 +13,9 @@ from roman_datamodels.testing import utils
 def test_asdf_file_input():
     tree = utils.mk_level2_image()
     with asdf.AsdfFile() as af:
-        af.tree = {'roman': tree}
+        af.tree = {"roman": tree}
         model = datamodels.open(af)
-        assert model.meta.telescope == 'ROMAN'
+        assert model.meta.telescope == "ROMAN"
         model.close()
         # should the asdf file be closed by model.close()?
 
@@ -24,7 +24,7 @@ def test_path_input(tmp_path):
     file_path = tmp_path / "test.asdf"
     with asdf.AsdfFile() as af:
         tree = utils.mk_level2_image()
-        af.tree = {'roman': tree}
+        af.tree = {"roman": tree}
         af.write_to(file_path)
 
     # Test with PurePath input:
@@ -52,13 +52,12 @@ def test_path_input(tmp_path):
 def test_model_input(tmp_path):
     file_path = tmp_path / "test.asdf"
 
-    data = u.Quantity(np.random.uniform(size=(1024, 1024)).astype(np.float32),
-                      ru.electron/u.s, dtype=np.float32)
+    data = u.Quantity(np.random.uniform(size=(1024, 1024)).astype(np.float32), ru.electron / u.s, dtype=np.float32)
 
     with asdf.AsdfFile() as af:
-        af.tree = {'roman': utils.mk_level2_image()}
-        af.tree['roman'].meta['bozo'] = 'clown'
-        af.tree['roman'].data = data
+        af.tree = {"roman": utils.mk_level2_image()}
+        af.tree["roman"].meta["bozo"] = "clown"
+        af.tree["roman"].data = data
         af.write_to(file_path)
 
     original_model = datamodels.open(file_path)
@@ -78,18 +77,28 @@ def test_invalid_input():
     with pytest.raises(TypeError):
         datamodels.open(fits.HDUList())
 
+
 def test_memmap(tmp_path):
-    data = u.Quantity(np.zeros((400, 400,), dtype=np.float32),
-                      ru.electron/u.s, dtype=np.float32)
-    new_value = u.Quantity(1.0, ru.electron/u.s, dtype=np.float32)
+    data = u.Quantity(
+        np.zeros(
+            (
+                400,
+                400,
+            ),
+            dtype=np.float32,
+        ),
+        ru.electron / u.s,
+        dtype=np.float32,
+    )
+    new_value = u.Quantity(1.0, ru.electron / u.s, dtype=np.float32)
     new_data = data.copy()
     new_data[6, 19] = new_value
 
     file_path = tmp_path / "test.asdf"
     with asdf.AsdfFile() as af:
-        af.tree = {'roman': utils.mk_level2_image()}
+        af.tree = {"roman": utils.mk_level2_image()}
 
-        af.tree['roman'].data = data
+        af.tree["roman"].data = data
         af.write_to(file_path)
 
     # Since quantities don't inherit from np.memmap we have to test they are effectively
@@ -114,22 +123,35 @@ def test_memmap(tmp_path):
         assert model.data[6, 19] == new_value
         assert (model.data == new_data).all()
 
-@pytest.mark.parametrize("kwargs", [
-    {"memmap": False}, # explicit False
-    {}, # default
-])
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"memmap": False},  # explicit False
+        {},  # default
+    ],
+)
 def test_no_memmap(tmp_path, kwargs):
-    data = u.Quantity(np.zeros((400, 400,), dtype=np.float32),
-                      ru.electron/u.s, dtype=np.float32)
-    new_value = u.Quantity(1.0, ru.electron/u.s, dtype=np.float32)
+    data = u.Quantity(
+        np.zeros(
+            (
+                400,
+                400,
+            ),
+            dtype=np.float32,
+        ),
+        ru.electron / u.s,
+        dtype=np.float32,
+    )
+    new_value = u.Quantity(1.0, ru.electron / u.s, dtype=np.float32)
     new_data = data.copy()
     new_data[6, 19] = new_value
 
     file_path = tmp_path / "test.asdf"
     with asdf.AsdfFile() as af:
-        af.tree = {'roman': utils.mk_level2_image()}
+        af.tree = {"roman": utils.mk_level2_image()}
 
-        af.tree['roman'].data = data
+        af.tree["roman"].data = data
         af.write_to(file_path)
 
     # Since quantities don't inherit from np.memmap we have to test they are effectively

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -10,9 +10,7 @@ def test_generated_node_classes(manifest):
         class_name = stnode._class_name_from_tag_uri(tag["tag_uri"])
         node_class = getattr(stnode, class_name)
 
-        assert issubclass(node_class, (
-            stnode.TaggedObjectNode, stnode.TaggedListNode, stnode.TaggedScalarNode, stnode.Unit
-        ))
+        assert issubclass(node_class, (stnode.TaggedObjectNode, stnode.TaggedListNode, stnode.TaggedScalarNode, stnode.Unit))
         assert node_class._tag == tag["tag_uri"]
         assert tag["description"] in node_class.__doc__
         assert tag["tag_uri"] in node_class.__doc__
@@ -59,9 +57,7 @@ def test_serialization(node_class, tmp_path):
 
 
 def test_info(capsys):
-    node = stnode.WfiMode({"optical_element": "GRISM",
-                           "detector": "WFI18",
-                           "name": "WFI"})
+    node = stnode.WfiMode({"optical_element": "GRISM", "detector": "WFI18", "name": "WFI"})
     tree = dict(wfimode=node)
     af = asdf.AsdfFile(tree)
     af.info()
@@ -71,23 +67,17 @@ def test_info(capsys):
 
 
 def test_schema_info():
-    node = stnode.WfiMode({"optical_element": "GRISM",
-                           "detector": "WFI18",
-                           "name": "WFI"})
+    node = stnode.WfiMode({"optical_element": "GRISM", "detector": "WFI18", "name": "WFI"})
     tree = dict(wfimode=node)
     af = asdf.AsdfFile(tree)
 
     info = af.schema_info("archive_catalog")
     assert info == {
-        'wfimode': {
-            'detector': {
-                'archive_catalog': ({'datatype': 'nvarchar(10)', 'destination': ['ScienceCommon.detector']}, "WFI18")
+        "wfimode": {
+            "detector": {"archive_catalog": ({"datatype": "nvarchar(10)", "destination": ["ScienceCommon.detector"]}, "WFI18")},
+            "name": {"archive_catalog": ({"datatype": "nvarchar(5)", "destination": ["ScienceCommon.instrument_name"]}, "WFI")},
+            "optical_element": {
+                "archive_catalog": ({"datatype": "nvarchar(20)", "destination": ["ScienceCommon.optical_element"]}, "GRISM")
             },
-            'name': {
-                'archive_catalog': ({'datatype': 'nvarchar(5)', 'destination': ['ScienceCommon.instrument_name']}, "WFI")
-            },
-            'optical_element': {
-                'archive_catalog': ({'datatype': 'nvarchar(20)', 'destination': ['ScienceCommon.optical_element']}, "GRISM")
-            }
         }
     }

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -1,8 +1,7 @@
 import asdf
 import pytest
 
-from roman_datamodels import stnode
-from roman_datamodels import units
+from roman_datamodels import stnode, units
 from roman_datamodels.testing import assert_node_equal, create_node
 
 

--- a/tests/test_stuserdict.py
+++ b/tests/test_stuserdict.py
@@ -1,6 +1,7 @@
 from copy import copy
 
 import pytest
+
 from roman_datamodels.stuserdict import STUserDict
 
 

--- a/tests/test_stuserdict.py
+++ b/tests/test_stuserdict.py
@@ -6,10 +6,10 @@ from roman_datamodels.stuserdict import STUserDict
 
 
 def test_init():
-    input_1 = {'a': 1, 'b': 2, 'c': 3}
-    input_2 = {'first': 1, 'second': 2, 'third': 3, 'b': 3}
-    input_3 = {0: 'first', 1: 'second'}
-    input_4 = {b'test': 344, '0': True, 'b': 3}
+    input_1 = {"a": 1, "b": 2, "c": 3}
+    input_2 = {"first": 1, "second": 2, "third": 3, "b": 3}
+    input_3 = {0: "first", 1: "second"}
+    input_4 = {b"test": 344, "0": True, "b": 3}
 
     user_dict_1 = STUserDict(input_1)
     user_dict_2 = STUserDict(input_1, **input_2)
@@ -40,38 +40,38 @@ def test_init():
 
 
 def test_datamodel():
-    input_1 = {'a': 1, 'b': 2, 'c': 3}
-    input_2 = {'first': 1, 'second': 2, 'third': 3, 'b': 3}
+    input_1 = {"a": 1, "b": 2, "c": 3}
+    input_2 = {"first": 1, "second": 2, "third": 3, "b": 3}
 
     user_dict_1 = STUserDict(**input_1)
     user_dict_2 = STUserDict(input_1, **input_2)
 
     assert len(user_dict_1) == 3
     assert list(user_dict_1) == list(input_1)
-    assert user_dict_1['b'] == 2
+    assert user_dict_1["b"] == 2
 
     assert len(user_dict_2) == 6
     assert list(user_dict_2) == list({**input_1, **input_2})
-    assert user_dict_2['b'] == 3
+    assert user_dict_2["b"] == 3
 
     with pytest.raises(KeyError):
-        user_dict_1['test']
+        user_dict_1["test"]
 
-    user_dict_1['c'] = 4
-    user_dict_1['test'] = 'test value'
+    user_dict_1["c"] = 4
+    user_dict_1["test"] = "test value"
 
-    assert user_dict_1['c'] == 4
-    assert 'test' in user_dict_1
-    assert user_dict_1['test'] == 'test value'
+    assert user_dict_1["c"] == 4
+    assert "test" in user_dict_1
+    assert user_dict_1["test"] == "test value"
 
-    del user_dict_1['test']
+    del user_dict_1["test"]
 
-    assert 'test' not in user_dict_1
+    assert "test" not in user_dict_1
 
 
 def test_copy():
-    input_1 = {'a': 1, 'b': 2, 'c': 3}
-    input_2 = {'first': 1, 'second': 2, 'third': 3, 'b': 3}
+    input_1 = {"a": 1, "b": 2, "c": 3}
+    input_2 = {"first": 1, "second": 2, "third": 3, "b": 3}
 
     user_dict_1 = STUserDict(**input_1)
     user_dict_2 = STUserDict(input_1, **input_2)
@@ -93,7 +93,7 @@ def test_copy():
 
 
 def test_from_keys():
-    keys_1 = ['a', 'b', 'c']
+    keys_1 = ["a", "b", "c"]
 
     user_dict_1 = STUserDict.fromkeys(keys_1)
     user_dict_2 = STUserDict.fromkeys(keys_1, value=1)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,7 +1,7 @@
 import asdf
 import pytest
-
 from astropy import units as u
+
 from roman_datamodels import units
 
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -7,10 +7,10 @@ from roman_datamodels import units
 
 def test_RomanUnit_fail():
     with pytest.raises(ValueError):
-        units.Unit('foo')
+        units.Unit("foo")
 
 
-@pytest.mark.parametrize('unit', units.ROMAN_UNIT_SYMBOLS)
+@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
 def test_roman_datamodels_unit(unit):
     roman_unit = getattr(units, unit)
     astropy_unit = getattr(u, unit)
@@ -27,7 +27,7 @@ def test_roman_datamodels_unit(unit):
     assert roman_value == astropy_value
 
 
-@pytest.mark.parametrize('unit', units.ROMAN_UNIT_SYMBOLS)
+@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
 def test_string(unit):
     roman_unit = getattr(units, unit)
     astropy_unit = getattr(u, unit)
@@ -35,7 +35,7 @@ def test_string(unit):
     assert roman_unit.to_string() == astropy_unit.to_string() == unit
 
 
-@pytest.mark.parametrize('unit', units.ROMAN_UNIT_SYMBOLS)
+@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
 def test_unit_serialization(unit, tmp_path):
     roman_unit = getattr(units, unit)
 
@@ -49,7 +49,7 @@ def test_unit_serialization(unit, tmp_path):
         assert af["unit"] == roman_unit
 
 
-@pytest.mark.parametrize('unit', units.ROMAN_UNIT_SYMBOLS)
+@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
 def test_quantity_serialization(unit, tmp_path):
     quantity = 3.14 * getattr(units, unit)
 
@@ -63,12 +63,12 @@ def test_quantity_serialization(unit, tmp_path):
         assert isinstance(af["quantity"].unit, units.Unit)
 
 
-@pytest.mark.parametrize('unit', units.ROMAN_UNIT_SYMBOLS)
-@pytest.mark.parametrize('pwr', [-2, -1, 2])
+@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
+@pytest.mark.parametrize("pwr", [-2, -1, 2])
 def test_roman_unit_pow(unit, pwr, tmp_path):
     roman_unit = getattr(units, unit)
 
-    power = roman_unit ** pwr
+    power = roman_unit**pwr
     assert isinstance(power, units.CompositeUnit)
 
     file_path = tmp_path / "test.asdf"
@@ -87,7 +87,7 @@ def test_roman_unit_pow(unit, pwr, tmp_path):
         assert af["power"].powers[0] == pwr
 
 
-@pytest.mark.parametrize('unit', units.ROMAN_UNIT_SYMBOLS)
+@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
 def test_roman_unit_div_astropy_unit(unit, tmp_path):
     roman_unit = getattr(units, unit)
 
@@ -114,14 +114,14 @@ def test_roman_unit_div_astropy_unit(unit, tmp_path):
         assert af["composite"].powers[1] == -1
 
 
-@pytest.mark.parametrize('unit', units.ROMAN_UNIT_SYMBOLS)
+@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
 def test_astropy_unit_div_roman_unit(unit, tmp_path):
     roman_unit = getattr(units, unit)
 
     composite = roman_unit / u.s
     assert isinstance(composite, units.CompositeUnit)
 
-    composite = composite ** -1
+    composite = composite**-1
     assert isinstance(composite, units.CompositeUnit)
 
     file_path = tmp_path / "test.asdf"
@@ -144,7 +144,7 @@ def test_astropy_unit_div_roman_unit(unit, tmp_path):
         assert af["composite"].powers[1] == -1
 
 
-@pytest.mark.parametrize('unit', units.ROMAN_UNIT_SYMBOLS)
+@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
 def test_roman_unit_mul_astropy_unit(unit, tmp_path):
     roman_unit = getattr(units, unit)
 
@@ -200,7 +200,7 @@ def test_force_roman_unit():
         assert isinstance(uu := units.force_roman_unit(unit), u.NamedUnit) and not isinstance(uu, units.Unit)
 
         # Powers
-        assert isinstance(units.force_roman_unit(unit ** -1), u.CompositeUnit) and not isinstance(uu, units.CompositeUnit)
+        assert isinstance(units.force_roman_unit(unit**-1), u.CompositeUnit) and not isinstance(uu, units.CompositeUnit)
 
         # Division
         assert isinstance(units.force_roman_unit(unit / u.s), u.CompositeUnit) and not isinstance(uu, units.CompositeUnit)


### PR DESCRIPTION
This PR applies some code formatters to `roman_datamodels`. Namely:

- [`isort`](https://pycqa.github.io/isort/) to sort the imports.
- [`black`](https://black.readthedocs.io/en/stable/) to consistently format the code.

Note that this PR is based off #119, which should be merged first.