### PR TITLE
Start using codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,14 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+    - id: codespell
+      args: ["--write-changes"]
+      additional_dependencies:
+        - tomli
+
 - repo: https://github.com/asottile/pyupgrade
   rev: 'v3.3.1'
   hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 - Add ``pre-commit`` support. [#119]
 - Apply ``isort`` and ``black`` code formatters to all files. [#120]
 - Switch from ``flake8`` to ``ruff`` for code linting. [#121]
+- Start using ``codespell`` for automated spell checking. [#122]
 
 0.14.0 (2022-11-14)
 ===================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -416,7 +416,7 @@ epub_theme = "epub"
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/docs/roman_datamodels/datamodels/introduction.rst
+++ b/docs/roman_datamodels/datamodels/introduction.rst
@@ -29,7 +29,7 @@ of data file. It can apply to raw data (i.e., data from the ground system
 that the calibration pipelines start with), intermediate data products, or
 the final data products sent to observers or the archive.
 
-While the roman_datamodels respository would seem like the location of the
+While the roman_datamodels repository would seem like the location of the
 Roman datamodels, it is the combination of the schemas in the rad repository
 with the converter software in the roman_datamodels that form the totality
 of the datamodels. The schemas are intentionally kept separate to remove
@@ -41,7 +41,7 @@ The following documentation outlines the basic relationship between these
 elements with links to some examples and a list of existing datamodels.
 
 It should be noted that how datamodels are implemented for Roman has
-signficant difference from those used for JWST. These differences will
+significant difference from those used for JWST. These differences will
 be explained at various points in the documentation.
 
 Datamodel Outline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,8 @@ force-exclude = '''
 
 [tool.ruff]
 line-length = 130
+
+[tool.codespell]
+skip="*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
+# ignore-words-list="""
+# """

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -1,6 +1,6 @@
 """
 This module provides the same interface as the older, non-tag version of datamodels
-for the whole asdf file. It will start very basic, initialy only to support running
+for the whole asdf file. It will start very basic, initially only to support running
 of the flat field step, but many other methods and capabilities will be added to
 keep consistency with the JWST data model version.
 
@@ -89,7 +89,7 @@ class DataModel:
 
     @property
     def schema_uri(self):
-        # Determine the schema corresonding to this model's tag
+        # Determine the schema corresponding to this model's tag
         schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags if t.tag_uri == self._instance._tag).schema_uri
         return schema_uri
 
@@ -406,7 +406,7 @@ def open(init, memmap=False, target=None, **kwargs):
     if target is not None:
         if not issubclass(target, DataModel):
             raise ValueError("Target must be a subclass of DataModel")
-    # Temp fix to catch JWST args defore being passed to asdf open
+    # Temp fix to catch JWST args before being passed to asdf open
     if "asn_n_members" in kwargs:
         del kwargs["asn_n_members"]
     if isinstance(init, asdf.AsdfFile):

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -257,7 +257,7 @@ class LNode(UserList):
         elif isinstance(node, list):
             self.data = node
         else:
-            raise ValueError("Initalizer only accepts lists")
+            raise ValueError("Initializer only accepts lists")
         # else:
         #     self.data = node.data
 


### PR DESCRIPTION
Applies the [`codespell`](https://github.com/codespell-project/codespell) to `roman_datamodels` in order to automatically catch (and fix) most common spelling mistakes. Note that if `codespell` catches/fixes a word which is not misspelled, one can easily ignore the word by adding it to a new line under the `ignore-words-list` in the `pyproject.toml` file.

Note this is based on #121 so that it should be merged first.