### PR TITLE
handle upcoming asdf deprecations

### DIFF
--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -11,9 +11,9 @@ import datetime
 import os
 import os.path
 import sys
+import warnings
 from collections import OrderedDict
 from collections.abc import Sequence
-import warnings
 from pathlib import PurePath
 
 import asdf

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -24,7 +24,9 @@ from astropy.time import Time
 from . import stnode, validate
 from .extensions import DATAMODEL_EXTENSIONS
 
-if packaging.version.Version(asdf.__version__) < packaging.version.Version("3.0"):
+# .dev is included in the version comparison to allow for correct version
+# comparisons with development versions of asdf 3.0
+if packaging.version.Version(asdf.__version__) < packaging.version.Version("3.dev"):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -86,11 +86,9 @@ def _check_value(value, schema, validator_context):
     Perform the actual validation.
     """
 
-    validator_resolver = validator_context.resolver
-
     temp_schema = {"$schema": "http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema"}
     temp_schema.update(schema)
-    validator = asdfschema.get_validator(temp_schema, validator_context, validator_callbacks, validator_resolver)
+    validator = asdfschema.get_validator(temp_schema, validator_context, validator_callbacks)
 
     validator.validate(value, _schema=temp_schema)
     validator_context.close()

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -60,10 +60,9 @@ def _check_value(value):
     """
 
     validator_context = AsdfFile()
-    validator_resolver = validator_context.resolver
 
     temp_schema = {"$schema": "http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema"}
-    validator = asdf_schema.get_validator(temp_schema, validator_context, validator_callbacks, validator_resolver)
+    validator = asdf_schema.get_validator(temp_schema, validator_context, validators=validator_callbacks)
 
     value = yamlutil.custom_tree_to_tagged_tree(value, validator_context)
     validator.validate(value, _schema=temp_schema)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,5 +1,8 @@
+import warnings
+
 import asdf
 import numpy as np
+import packaging.version
 import pytest
 from astropy import units as u
 from astropy.io import fits
@@ -18,6 +21,34 @@ def test_asdf_file_input():
         assert model.meta.telescope == "ROMAN"
         model.close()
         # should the asdf file be closed by model.close()?
+
+
+@pytest.mark.skipif(
+    packaging.version.Version(asdf.__version__) >= packaging.version.Version("3.0"),
+    reason="asdf >= 3.0 has no AsdfInFits support",
+)
+def test_asdf_in_fits_error(tmp_path):
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=asdf.exceptions.AsdfDeprecationWarning,
+            message=r"AsdfInFits has been deprecated.*",
+        )
+        from asdf.fits_embed import AsdfInFits
+    from astropy.io import fits
+
+    fn = tmp_path / "AsdfInFits.fits"
+
+    # generate an AsdfInFits file
+    hdulist = fits.HDUList()
+    tree = {"roman": []}
+    ff = AsdfInFits(hdulist, tree)
+    ff.write_to(fn, overwrite=True)
+
+    # attempt to open it with datamodels, verify error
+    with pytest.raises(TypeError, match=r"Roman datamodels does not accept FITS files or objects"):
+        with datamodels.open(fn):
+            pass
 
 
 def test_path_input(tmp_path):

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -24,7 +24,7 @@ def test_asdf_file_input():
 
 
 @pytest.mark.skipif(
-    packaging.version.Version(asdf.__version__) >= packaging.version.Version("3.0"),
+    packaging.version.Version(asdf.__version__) >= packaging.version.Version("3.dev"),
     reason="asdf >= 3.0 has no AsdfInFits support",
 )
 def test_asdf_in_fits_error(tmp_path):


### PR DESCRIPTION
asdf is deprecating AsdfInFits and resolvers. These are both used in roman_datamodels.
https://github.com/asdf-format/asdf/pull/1337
https://github.com/asdf-format/asdf/pull/1362

This PR conditionally handles importing AsdfInFits (based on the asdf version) for checking files to raise an exception when code attempts to use AsdfInFits for a datamodel.

Resolvers are older versions of resource mappings. The uses of resolver in this package can be removed as the rad schema are registered [using a resource mapping, not a resolver](https://github.com/spacetelescope/rad/blob/5b64a95600e0130800a1c13a710c046c2c361a1f/pyproject.toml#L43)) and the default resolver argument to ` asdf.schema.get_validator` is sufficient.