### PR TITLE
import `tomli` as `tomllib` for `docs` builds before Python 3.11

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,10 @@ from pathlib import Path
 
 import sphinx
 import stsci_rtd_theme
-import tomli
-
+ sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
 
 def setup(app):
     try:
@@ -37,7 +39,7 @@ sys.path.insert(0, os.path.abspath("roman_datamodels/"))
 
 # -- General configuration ------------------------------------------------
 with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:
-    conf = tomli.load(configuration_file)
+    conf = tomllib.load(configuration_file)
 setup_cfg = conf["project"]
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import sphinx
 import stsci_rtd_theme
 
-sys.version_info < (3, 11):
+if sys.version_info < (3, 11):
     import tomli as tomllib
 else:
     import tomllib

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import sphinx
 import stsci_rtd_theme
 
- sys.version_info < (3, 11):
+sys.version_info < (3, 11):
     import tomli as tomllib
 else:
     import tomllib

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import sphinx
 import stsci_rtd_theme
+
  sys.version_info < (3, 11):
     import tomli as tomllib
 else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ if sys.version_info < (3, 11):
 else:
     import tomllib
 
+
 def setup(app):
     try:
         app.add_css_file("stsci.css")


### PR DESCRIPTION
`tomli` is implemented read-only as `tomllib` in Python 3.11