### PR TITLE
Deprecate `roman_datamodels.units`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 
 - Moved datamodel maker utilities and split random functions out to utility file. [#128]
 
+- Begin process of removing ``roman_datamodels.units`` for non-VOUnit support in favor
+  of non-VOUnit support coming directly via ``asdf-astropy``. [#131]
+
 
 0.14.1 (2023-01-31)
 ===================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ classifiers = [
 ]
 dependencies = [
     'asdf >=2.14.2',
-    'asdf-astropy >=0.3.0',
+    'asdf-astropy >=0.4.0',
     'gwcs >=0.18.1',
     'psutil >=5.7.2',
     'numpy',
     'astropy >=5.0.4',
-    'rad @git+https://github.com/spacetelescope/rad.git@main#egg=rad',
+    'rad @ git+https://github.com/spacetelescope/rad.git@main#egg=rad',
     'asdf-standard >=1.0.3',
 ]
 dynamic = ['version']

--- a/src/roman_datamodels/conftest.py
+++ b/src/roman_datamodels/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore = ["units.py"]

--- a/src/roman_datamodels/maker_utils.py
+++ b/src/roman_datamodels/maker_utils.py
@@ -7,7 +7,6 @@ from astropy import units as u
 from astropy.modeling import models
 
 from roman_datamodels import stnode
-from roman_datamodels import units as ru
 from roman_datamodels.random_utils import generate_positive_int, generate_string
 
 NONUM = -999999
@@ -455,10 +454,10 @@ def mk_level1_science_raw(shape=None, filepath=None):
     else:
         n_ints = shape[0]
 
-    wfi_science_raw["data"] = u.Quantity(np.zeros(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    wfi_science_raw["data"] = u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
 
     # add amp 33 ref pix
-    wfi_science_raw["amp33"] = u.Quantity(np.zeros((n_ints, 4096, 128), dtype=np.uint16), ru.DN, dtype=np.uint16)
+    wfi_science_raw["amp33"] = u.Quantity(np.zeros((n_ints, 4096, 128), dtype=np.uint16), u.DN, dtype=np.uint16)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -506,12 +505,10 @@ def mk_level2_image(shape=None, n_ints=None, filepath=None):
         n_ints = 8
 
     # add border reference pixel arrays
-    wfi_image["border_ref_pix_left"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), ru.DN, dtype=np.float32)
-    wfi_image["border_ref_pix_right"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), ru.DN, dtype=np.float32)
-    wfi_image["border_ref_pix_top"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), ru.DN, dtype=np.float32)
-    wfi_image["border_ref_pix_bottom"] = u.Quantity(
-        np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), ru.DN, dtype=np.float32
-    )
+    wfi_image["border_ref_pix_left"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), u.DN, dtype=np.float32)
+    wfi_image["border_ref_pix_right"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), u.DN, dtype=np.float32)
+    wfi_image["border_ref_pix_top"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), u.DN, dtype=np.float32)
+    wfi_image["border_ref_pix_bottom"] = u.Quantity(np.zeros((n_ints, shape[0] + 8, 4), dtype=np.float32), u.DN, dtype=np.float32)
 
     # and their dq arrays
     wfi_image["dq_border_ref_pix_left"] = np.zeros((shape[0] + 8, 4), dtype=np.uint32)
@@ -521,15 +518,15 @@ def mk_level2_image(shape=None, n_ints=None, filepath=None):
 
     # add amp 33 ref pixel array
     amp33_size = (n_ints, 4096, 128)
-    wfi_image["amp33"] = u.Quantity(np.zeros(amp33_size, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    wfi_image["amp33"] = u.Quantity(np.zeros(amp33_size, dtype=np.uint16), u.DN, dtype=np.uint16)
 
-    wfi_image["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
+    wfi_image["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32)
     wfi_image["dq"] = np.zeros(shape, dtype=np.uint32)
-    wfi_image["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
+    wfi_image["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32)
 
-    wfi_image["var_poisson"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image["var_rnoise"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
-    wfi_image["var_flat"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image["var_poisson"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image["var_rnoise"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
+    wfi_image["var_flat"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
     wfi_image["cal_logs"] = mk_cal_logs()
 
     if filepath:
@@ -613,9 +610,9 @@ def mk_dark(shape=None, filepath=None):
     if not shape:
         shape = (2, 4096, 4096)
 
-    darkref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    darkref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
     darkref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
-    darkref["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    darkref["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -685,7 +682,7 @@ def mk_gain(shape=None, filepath=None):
     if not shape:
         shape = (4096, 4096)
 
-    gainref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / ru.DN, dtype=np.float32)
+    gainref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -755,8 +752,8 @@ def mk_linearity(shape=None, filepath=None):
     meta["reftype"] = "LINEARITY"
     linearityref["meta"] = meta
 
-    linearityref["meta"]["input_units"] = ru.DN
-    linearityref["meta"]["output_units"] = ru.DN
+    linearityref["meta"]["input_units"] = u.DN
+    linearityref["meta"]["output_units"] = u.DN
 
     if not shape:
         shape = (2, 4096, 4096)
@@ -795,8 +792,8 @@ def mk_inverse_linearity(shape=None, filepath=None):
     meta["reftype"] = "INVERSE_LINEARITY"
     inverselinearityref["meta"] = meta
 
-    inverselinearityref["meta"]["input_units"] = ru.DN
-    inverselinearityref["meta"]["output_units"] = ru.DN
+    inverselinearityref["meta"]["input_units"] = u.DN
+    inverselinearityref["meta"]["output_units"] = u.DN
 
     if not shape:
         shape = (2, 4096, 4096)
@@ -993,7 +990,7 @@ def mk_readnoise(shape=None, filepath=None):
     if not shape:
         shape = (4096, 4096)
 
-    readnoiseref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    readnoiseref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -1032,10 +1029,10 @@ def mk_ramp(shape=None, n_ints=None, filepath=None):
         shape = (8, 4096, 4096)
 
     # add border reference pixel arrays
-    ramp["border_ref_pix_left"] = u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32), ru.DN, dtype=np.float32)
-    ramp["border_ref_pix_right"] = u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32), ru.DN, dtype=np.float32)
-    ramp["border_ref_pix_top"] = u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32), ru.DN, dtype=np.float32)
-    ramp["border_ref_pix_bottom"] = u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp["border_ref_pix_left"] = u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32), u.DN, dtype=np.float32)
+    ramp["border_ref_pix_right"] = u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32), u.DN, dtype=np.float32)
+    ramp["border_ref_pix_top"] = u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32), u.DN, dtype=np.float32)
+    ramp["border_ref_pix_bottom"] = u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32), u.DN, dtype=np.float32)
 
     # and their dq arrays
     ramp["dq_border_ref_pix_left"] = np.zeros((shape[1], 4), dtype=np.uint32)
@@ -1044,12 +1041,12 @@ def mk_ramp(shape=None, n_ints=None, filepath=None):
     ramp["dq_border_ref_pix_bottom"] = np.zeros((4, shape[2]), dtype=np.uint32)
 
     # add amp 33 ref pixel array
-    ramp["amp33"] = u.Quantity(np.full(shape, 1.0, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    ramp["amp33"] = u.Quantity(np.full(shape, 1.0, dtype=np.uint16), u.DN, dtype=np.uint16)
 
-    ramp["data"] = u.Quantity(np.full(shape, 1.0, dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp["data"] = u.Quantity(np.full(shape, 1.0, dtype=np.float32), u.DN, dtype=np.float32)
     ramp["pixeldq"] = np.zeros(shape[1:], dtype=np.uint32)
     ramp["groupdq"] = np.zeros(shape, dtype=np.uint8)
-    ramp["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    ramp["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -1083,15 +1080,15 @@ def mk_rampfitoutput(shape=None, filepath=None):
     if not shape:
         shape = (8, 4096, 4096)
 
-    rampfitoutput["slope"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
-    rampfitoutput["sigslope"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron / u.s, dtype=np.float32)
-    rampfitoutput["yint"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron, dtype=np.float32)
-    rampfitoutput["sigyint"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron, dtype=np.float32)
-    rampfitoutput["pedestal"] = u.Quantity(np.zeros(shape[1:], dtype=np.float32), ru.electron, dtype=np.float32)
+    rampfitoutput["slope"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32)
+    rampfitoutput["sigslope"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32)
+    rampfitoutput["yint"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron, dtype=np.float32)
+    rampfitoutput["sigyint"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron, dtype=np.float32)
+    rampfitoutput["pedestal"] = u.Quantity(np.zeros(shape[1:], dtype=np.float32), u.electron, dtype=np.float32)
     rampfitoutput["weights"] = np.zeros(shape, dtype=np.float32)
-    rampfitoutput["crmag"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron, dtype=np.float32)
-    rampfitoutput["var_poisson"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
-    rampfitoutput["var_rnoise"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.electron**2 / u.s**2, dtype=np.float32)
+    rampfitoutput["crmag"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron, dtype=np.float32)
+    rampfitoutput["var_poisson"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
+    rampfitoutput["var_rnoise"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -1205,9 +1202,9 @@ def mk_guidewindow(shape=None, filepath=None):
     if not shape:
         shape = (2, 8, 16, 32, 32)
 
-    guidewindow["pedestal_frames"] = u.Quantity(np.zeros(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
-    guidewindow["signal_frames"] = u.Quantity(np.zeros(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
-    guidewindow["amp33"] = u.Quantity(np.zeros(shape, dtype=np.uint16), ru.DN, dtype=np.uint16)
+    guidewindow["pedestal_frames"] = u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
+    guidewindow["signal_frames"] = u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
+    guidewindow["amp33"] = u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
 
     if filepath:
         af = asdf.AsdfFile()
@@ -1244,7 +1241,7 @@ def mk_saturation(shape=None, filepath=None):
         shape = (4096, 4096)
 
     saturationref["dq"] = np.zeros(shape, dtype=np.uint32)
-    saturationref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), ru.DN, dtype=np.float32)
+    saturationref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
 
     if filepath:
         af = asdf.AsdfFile()

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -19,6 +19,7 @@ from asdf.extension import Converter
 from asdf.tags.core import ndarray
 from asdf.util import HashableDict
 from astropy.time import Time
+from astropy.units import Unit  # noqa: F401
 
 from .stuserdict import STUserDict as UserDict
 from .validate import ValidationWarning, _check_type, _error_message

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -21,7 +21,6 @@ from asdf.util import HashableDict
 from astropy.time import Time
 
 from .stuserdict import STUserDict as UserDict
-from .units import CompositeUnit, Unit
 from .validate import ValidationWarning, _check_type, _error_message
 
 if sys.version_info < (3, 9):
@@ -48,7 +47,7 @@ validate = True
 strict_validation = True
 
 
-_UNIT_NODE_CLASSES_BY_TAG = {Unit._tag: Unit}
+_UNIT_NODE_TAGS = ["asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0"]
 
 
 def set_validate(value):
@@ -495,51 +494,18 @@ class TaggedScalarNodeConverter(Converter):
 
 
 class UnitConverter(Converter):
-    @property
-    def tags(self):
-        return list(_UNIT_NODE_CLASSES_BY_TAG.keys())
-
-    @property
-    def types(self):
-        return [Unit, CompositeUnit]
+    tags = _UNIT_NODE_TAGS
+    types = []
 
     def to_yaml_tree(self, obj, tag, ctx):
-        if isinstance(obj, Unit):
-            return self._base_to_yaml_tree(obj, tag, ctx)
-        elif isinstance(obj, CompositeUnit):
-            return self._composite_to_yaml_tree(obj, tag, ctx)
-        else:
-            raise TypeError(f"Unsupported type {type(obj)}")
-
-    def _base_to_yaml_tree(self, obj, tag, ctx):
-        import roman_datamodels.units as units
-
-        unit = obj.to_string()
-        if unit in units.ROMAN_UNIT_SYMBOLS:
-            return unit
-        else:
-            raise ValueError(f"Unit {unit} is not a valid Roman unit")
-
-    def _composite_to_yaml_tree(self, obj, tag, ctx):
-        from astropy.units import UnitsError
-
-        for unit in obj.bases:
-            if isinstance(unit, Unit):
-                self._base_to_yaml_tree(unit, tag, ctx)
-            else:
-                try:
-                    unit.to_string(format="vounit")
-                except (UnitsError, ValueError) as e:
-                    raise ValueError(f"Unit '{unit}' is not representable as VOUnit and cannot be serialized to ASDF") from e
-
-        return obj.to_string()
+        msg = "Converting to rad unit tags is no longer suppoerted. Support is now native to asdf-astropy."
+        raise NotImplementedError(msg)
 
     def from_yaml_tree(self, node, tag, ctx):
-        import astropy.units as u
+        from asdf_astropy.converters.unit import UnitConverter as AstropyUnitConverter
 
-        from roman_datamodels.units import force_roman_unit
-
-        return force_roman_unit(u.Unit(node, parse_strict="silent"))
+        # rad unit tags are being replaced by the non-vounit tags in asdf-astropy
+        return AstropyUnitConverter().from_yaml_tree(node, "tag:astropy.org:astropy/units/unit-1.0.0", ctx)
 
 
 _DATAMODELS_MANIFEST_PATH = importlib_resources.files(rad.resources) / "manifests" / "datamodels-1.0.yaml"
@@ -587,8 +553,8 @@ for tag in _DATAMODELS_MANIFEST["tags"]:
         _LIST_NODE_CLASSES_BY_TAG[tag["tag_uri"]].__doc__ = docstring
     elif tag["tag_uri"] in _SCALAR_NODE_CLASSES_BY_TAG:
         _SCALAR_NODE_CLASSES_BY_TAG[tag["tag_uri"]].__doc__ = docstring
-    elif tag["tag_uri"] in _UNIT_NODE_CLASSES_BY_TAG:
-        _UNIT_NODE_CLASSES_BY_TAG[tag["tag_uri"]].__doc__ = docstring
+    elif tag["tag_uri"] in _UNIT_NODE_TAGS:
+        pass
     else:
         _class_from_tag(tag, docstring)
 
@@ -599,5 +565,4 @@ NODE_CLASSES = (
     list(_OBJECT_NODE_CLASSES_BY_TAG.values())
     + list(_LIST_NODE_CLASSES_BY_TAG.values())
     + list(_SCALAR_NODE_CLASSES_BY_TAG.values())
-    + list(_UNIT_NODE_CLASSES_BY_TAG.values())
 )

--- a/src/roman_datamodels/testing/assertions.py
+++ b/src/roman_datamodels/testing/assertions.py
@@ -3,7 +3,7 @@ from asdf.tags.core import NDArrayType
 from astropy.modeling import Model
 from numpy.testing import assert_array_equal
 
-from ..stnode import TaggedListNode, TaggedObjectNode, TaggedScalarNode, Unit
+from ..stnode import TaggedListNode, TaggedObjectNode, TaggedScalarNode
 
 
 def assert_node_equal(node1, node2):
@@ -42,8 +42,6 @@ def assert_node_equal(node1, node2):
         value2 = node2.__class__.__bases__[0](node2)
 
         assert value1 == value2
-    elif isinstance(node1, Unit):
-        assert node1 == node2
     else:
         raise RuntimeError(f"Unhandled node class: {node1.__class__.__name__}")
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -10,7 +10,6 @@ from astropy import units as u
 from astropy.modeling import models
 
 from roman_datamodels import random_utils
-from roman_datamodels import units as ru
 
 from .. import stnode
 
@@ -289,9 +288,9 @@ def create_dark_ref(**kwargs):
     roman_datamodels.stnode.DarkRef
     """
     raw = {
-        "data": random_utils.generate_array_float32((2, 4096, 4096), units=ru.DN),
+        "data": random_utils.generate_array_float32((2, 4096, 4096), units=u.DN),
         "dq": random_utils.generate_array_uint32(),
-        "err": random_utils.generate_array_float32((2, 4096, 4096), units=ru.DN),
+        "err": random_utils.generate_array_float32((2, 4096, 4096), units=u.DN),
         "meta": create_ref_meta(reftype="DARK"),
     }
     raw.update(kwargs)
@@ -339,7 +338,7 @@ def create_gain_ref(**kwargs):
     roman_datamodels.stnode.GainRef
     """
     raw = {
-        "data": random_utils.generate_array_float32((4096, 4096), units=ru.electron / ru.DN),
+        "data": random_utils.generate_array_float32((4096, 4096), units=u.electron / u.DN),
         "meta": create_ref_meta(reftype="GAIN"),
     }
     raw.update(kwargs)
@@ -393,8 +392,8 @@ def create_linearity_ref(**kwargs):
     }
     raw.update(kwargs)
 
-    raw["meta"]["input_units"] = ru.DN
-    raw["meta"]["output_units"] = ru.DN
+    raw["meta"]["input_units"] = u.DN
+    raw["meta"]["output_units"] = u.DN
 
     return stnode.LinearityRef(raw)
 
@@ -420,8 +419,8 @@ def create_inverse_linearity_ref(**kwargs):
     }
     raw.update(kwargs)
 
-    raw["meta"]["input_units"] = ru.DN
-    raw["meta"]["output_units"] = ru.DN
+    raw["meta"]["input_units"] = u.DN
+    raw["meta"]["output_units"] = u.DN
 
     return stnode.InverseLinearityRef(raw)
 
@@ -491,7 +490,7 @@ def create_readnoise_ref(**kwargs):
     roman_datamodels.stnode.ReadnoiseRef
     """
     raw = {
-        "data": random_utils.generate_array_float32((4096, 4096), units=ru.DN),
+        "data": random_utils.generate_array_float32((4096, 4096), units=u.DN),
         "meta": create_ref_meta(reftype="READNOISE"),
     }
     raw.update(kwargs)
@@ -515,7 +514,7 @@ def create_saturation_ref(**kwargs):
     roman_datamodels.stnode.SaturationRef
     """
     raw = {
-        "data": random_utils.generate_array_float32((4096, 4096), units=ru.DN),
+        "data": random_utils.generate_array_float32((4096, 4096), units=u.DN),
         "dq": random_utils.generate_array_uint32((4096, 4096)),
         "meta": create_ref_meta(reftype="SATURATION"),
     }
@@ -914,15 +913,15 @@ def create_ramp(**kwargs):
 
     raw = {
         "meta": create_meta(),
-        "data": random_utils.generate_array_float32((2, 4096, 4096), units=ru.electron),
+        "data": random_utils.generate_array_float32((2, 4096, 4096), units=u.electron),
         "pixeldq": random_utils.generate_array_uint32((4096, 4096)),
         "groupdq": random_utils.generate_array_uint8((2, 4096, 4096)),
-        "err": random_utils.generate_array_float32(size=(2, 4096, 4096), min=0.0, units=ru.electron),
-        "amp33": random_utils.generate_array_uint16((2, 4096, 128), units=ru.DN),
-        "border_ref_pix_right": random_utils.generate_array_float32((2, 4096, 4), units=ru.DN),
-        "border_ref_pix_left": random_utils.generate_array_float32((2, 4096, 4), units=ru.DN),
-        "border_ref_pix_top": random_utils.generate_array_float32((2, 4, 4096), units=ru.DN),
-        "border_ref_pix_bottom": random_utils.generate_array_float32((2, 4, 4096), units=ru.DN),
+        "err": random_utils.generate_array_float32(size=(2, 4096, 4096), min=0.0, units=u.electron),
+        "amp33": random_utils.generate_array_uint16((2, 4096, 128), units=u.DN),
+        "border_ref_pix_right": random_utils.generate_array_float32((2, 4096, 4), units=u.DN),
+        "border_ref_pix_left": random_utils.generate_array_float32((2, 4096, 4), units=u.DN),
+        "border_ref_pix_top": random_utils.generate_array_float32((2, 4, 4096), units=u.DN),
+        "border_ref_pix_bottom": random_utils.generate_array_float32((2, 4, 4096), units=u.DN),
         "dq_border_ref_pix_right": random_utils.generate_array_uint32((4096, 4)),
         "dq_border_ref_pix_left": random_utils.generate_array_uint32((4096, 4)),
         "dq_border_ref_pix_top": random_utils.generate_array_uint32((4, 4096)),
@@ -952,15 +951,15 @@ def create_ramp_fit_output(**kwargs):
 
     raw = {
         "meta": create_meta(),
-        "slope": random_utils.generate_array_float32(seg_shape, units=ru.electron / u.s),
-        "sigslope": random_utils.generate_array_float32(seg_shape, units=ru.electron / u.s),
-        "yint": random_utils.generate_array_float32(seg_shape, units=ru.electron),
-        "sigyint": random_utils.generate_array_float32(seg_shape, units=ru.electron),
-        "pedestal": random_utils.generate_array_float32(seg_shape[1:], units=ru.electron),
+        "slope": random_utils.generate_array_float32(seg_shape, units=u.electron / u.s),
+        "sigslope": random_utils.generate_array_float32(seg_shape, units=u.electron / u.s),
+        "yint": random_utils.generate_array_float32(seg_shape, units=u.electron),
+        "sigyint": random_utils.generate_array_float32(seg_shape, units=u.electron),
+        "pedestal": random_utils.generate_array_float32(seg_shape[1:], units=u.electron),
         "weights": random_utils.generate_array_float32(seg_shape),
-        "crmag": random_utils.generate_array_float32(seg_shape, units=ru.electron),
-        "var_poisson": random_utils.generate_array_float32(seg_shape, units=ru.electron**2 / u.s**2),
-        "var_rnoise": random_utils.generate_array_float32(seg_shape, units=ru.electron**2 / u.s**2),
+        "crmag": random_utils.generate_array_float32(seg_shape, units=u.electron),
+        "var_poisson": random_utils.generate_array_float32(seg_shape, units=u.electron**2 / u.s**2),
+        "var_rnoise": random_utils.generate_array_float32(seg_shape, units=u.electron**2 / u.s**2),
     }
     raw.update(kwargs)
 
@@ -1054,9 +1053,9 @@ def create_guidewindow(**kwargs):
 
     raw = {
         "meta": create_meta(),
-        "pedestal_frames": random_utils.generate_array_uint16(seg_shape, units=ru.DN),
-        "signal_frames": random_utils.generate_array_uint16(seg_shape, units=ru.DN),
-        "amp33": random_utils.generate_array_uint16(seg_shape, units=ru.DN),
+        "pedestal_frames": random_utils.generate_array_uint16(seg_shape, units=u.DN),
+        "signal_frames": random_utils.generate_array_uint16(seg_shape, units=u.DN),
+        "amp33": random_utils.generate_array_uint16(seg_shape, units=u.DN),
     }
     raw.update(kwargs)
 
@@ -1237,18 +1236,18 @@ def create_wfi_image(**kwargs):
     """
 
     raw = {
-        "data": random_utils.generate_array_float32((4088, 4088), units=ru.electron / u.s),
+        "data": random_utils.generate_array_float32((4088, 4088), units=u.electron / u.s),
         "dq": random_utils.generate_array_uint32((4088, 4088)),
-        "err": random_utils.generate_array_float32((4088, 4088), min=0.0, units=ru.electron / u.s),
+        "err": random_utils.generate_array_float32((4088, 4088), min=0.0, units=u.electron / u.s),
         "meta": create_meta(),
-        "var_flat": random_utils.generate_array_float32((4088, 4088), units=ru.electron**2 / u.s**2),
-        "var_poisson": random_utils.generate_array_float32((4088, 4088), units=ru.electron**2 / u.s**2),
-        "var_rnoise": random_utils.generate_array_float32((4088, 4088), units=ru.electron**2 / u.s**2),
-        "amp33": random_utils.generate_array_uint16((2, 4096, 128), units=ru.DN),
-        "border_ref_pix_right": random_utils.generate_array_float32((2, 4096, 4), units=ru.DN),
-        "border_ref_pix_left": random_utils.generate_array_float32((2, 4096, 4), units=ru.DN),
-        "border_ref_pix_top": random_utils.generate_array_float32((2, 4, 4096), units=ru.DN),
-        "border_ref_pix_bottom": random_utils.generate_array_float32((2, 4, 4096), units=ru.DN),
+        "var_flat": random_utils.generate_array_float32((4088, 4088), units=u.electron**2 / u.s**2),
+        "var_poisson": random_utils.generate_array_float32((4088, 4088), units=u.electron**2 / u.s**2),
+        "var_rnoise": random_utils.generate_array_float32((4088, 4088), units=u.electron**2 / u.s**2),
+        "amp33": random_utils.generate_array_uint16((2, 4096, 128), units=u.DN),
+        "border_ref_pix_right": random_utils.generate_array_float32((2, 4096, 4), units=u.DN),
+        "border_ref_pix_left": random_utils.generate_array_float32((2, 4096, 4), units=u.DN),
+        "border_ref_pix_top": random_utils.generate_array_float32((2, 4, 4096), units=u.DN),
+        "border_ref_pix_bottom": random_utils.generate_array_float32((2, 4, 4096), units=u.DN),
         "dq_border_ref_pix_right": random_utils.generate_array_uint32((4096, 4)),
         "dq_border_ref_pix_left": random_utils.generate_array_uint32((4096, 4)),
         "dq_border_ref_pix_top": random_utils.generate_array_uint32((4, 4096)),
@@ -1301,8 +1300,8 @@ def create_wfi_science_raw(**kwargs):
     """
     raw = {
         # TODO: What should this shape be?
-        "data": random_utils.generate_array_uint16((2, 4096, 4096), units=ru.DN),
-        "amp33": random_utils.generate_array_uint16((2, 4096, 128), units=ru.DN),
+        "data": random_utils.generate_array_uint16((2, 4096, 4096), units=u.DN),
+        "amp33": random_utils.generate_array_uint16((2, 4096, 128), units=u.DN),
         "meta": create_meta(),
     }
     raw.update(kwargs)
@@ -1358,9 +1357,3 @@ def create_ref_file(**kwargs):
     raw.update(kwargs)
 
     return stnode.RefFile(raw)
-
-
-def create_unit(**kwargs):
-    import roman_datamodels.units as u
-
-    return u.DN

--- a/src/roman_datamodels/units.py
+++ b/src/roman_datamodels/units.py
@@ -1,121 +1,13 @@
+import warnings
+
 from astropy import units as u
 
-__all__ = ["Unit"]
+warnings.warn(
+    category=DeprecationWarning,
+    message="The roman_datamodels.units module is deprecated. Use astropy.units instead.",
+)
 
+DN = u.DN
+electron = u.electron
 
-ROMAN_UNIT_SYMBOLS = ["DN", "electron"]
-
-
-class UnitMixin:
-    def __pow__(self, p):
-        from astropy.units.core import validate_power
-
-        p = validate_power(p)
-        return CompositeUnit(1, [self], [p], _error_check=False)
-
-    def __truediv__(self, m):
-        if isinstance(m, (bytes, str)):
-            m = Unit(m)
-
-        if isinstance(m, u.UnitBase):
-            if m.is_unity():
-                return self
-            return CompositeUnit(1, [self, m], [1, -1], _error_check=False)
-
-        try:
-            # Cannot handle this as Unit, re-try as Quantity
-            from astropy.units.quantity import Quantity
-
-            return Quantity(1, self) / m
-        except TypeError:
-            return NotImplemented
-
-    def __mul__(self, m):
-        if isinstance(m, (bytes, str)):
-            m = u.Unit(m)
-
-        if isinstance(m, u.UnitBase):
-            if m.is_unity():
-                return self
-            elif self.is_unity():
-                return m
-            return CompositeUnit(1, [self, m], [1, 1], _error_check=False)
-
-        # Cannot handle this as Unit, re-try as Quantity.
-        try:
-            from astropy.units.quantity import Quantity
-
-            return Quantity(1, unit=self) * m
-        except TypeError:
-            return NotImplemented
-
-
-class CompositeUnit(UnitMixin, u.CompositeUnit):
-    """
-    Class for handling composite units containing a roman unit.
-    """
-
-    _tag = "asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0"
-
-
-class Unit(UnitMixin, u.Unit):
-    """
-    Class for the non-VOunits, which need to be serialized by Roman.
-    """
-
-    _tag = "asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0"
-
-
-def def_roman_unit(symbol):
-    """
-    Define a Roman unit version of an astropy unit.
-
-    This will automatically add the unit to the namespace of this module
-
-    Parameters
-    ----------
-    symbol : str
-        The symbol of the astropy unit to define a Roman unit for.
-
-    Returns
-    -------
-
-    A RomanUnit instance
-    """
-
-    represents = getattr(u, symbol)
-
-    return Unit(symbol, represents=represents, namespace=globals())
-
-
-def force_roman_unit(unit):
-    """
-    Force a unit to be a roman unit. If necessary
-
-    Parameters
-    ----------
-
-    unit :
-        The unit to force to be a roman unit
-
-    Returns
-    -------
-        A roman unit version if called for
-    """
-
-    import astropy.units as u
-
-    import roman_datamodels.units as units
-
-    if (ru := getattr(units, unit.to_string(), None)) is not None:
-        return ru
-    elif isinstance(unit, u.CompositeUnit):
-        bases = [getattr(units, base.to_string(), base) for base in unit.bases]
-        if any([isinstance(base, units.Unit) for base in bases]):
-            return units.CompositeUnit(unit.scale, bases, unit.powers)
-
-    return unit
-
-
-for unit in ROMAN_UNIT_SYMBOLS:
-    def_roman_unit(unit)
+__all__ = ["DN", "electron"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,6 @@ from jsonschema import ValidationError
 from roman_datamodels import datamodels
 from roman_datamodels import maker_utils as utils
 from roman_datamodels import stnode
-from roman_datamodels import units as ru
 from roman_datamodels.extensions import DATAMODEL_EXTENSIONS
 
 EXPECTED_COMMON_REFERENCE = {"$ref": "ref_common-1.0.0"}
@@ -106,13 +105,13 @@ def test_make_ramp():
 
     assert ramp.meta.exposure.type == "WFI_IMAGE"
     assert ramp.data.dtype == np.float32
-    assert ramp.data.unit == ru.DN
+    assert ramp.data.unit == u.DN
     assert ramp.pixeldq.dtype == np.uint32
     assert ramp.pixeldq.shape == (20, 20)
     assert ramp.groupdq.dtype == np.uint8
     assert ramp.err.dtype == np.float32
     assert ramp.err.shape == (2, 20, 20)
-    assert ramp.err.unit == ru.DN
+    assert ramp.err.unit == u.DN
 
     # Test validation
     ramp = datamodels.RampModel(ramp)
@@ -134,22 +133,22 @@ def test_make_rampfitoutput():
 
     assert rampfitoutput.meta.exposure.type == "WFI_IMAGE"
     assert rampfitoutput.slope.dtype == np.float32
-    assert rampfitoutput.slope.unit == ru.electron / u.s
+    assert rampfitoutput.slope.unit == u.electron / u.s
     assert rampfitoutput.sigslope.dtype == np.float32
-    assert rampfitoutput.sigslope.unit == ru.electron / u.s
+    assert rampfitoutput.sigslope.unit == u.electron / u.s
     assert rampfitoutput.yint.dtype == np.float32
-    assert rampfitoutput.yint.unit == ru.electron
+    assert rampfitoutput.yint.unit == u.electron
     assert rampfitoutput.sigyint.dtype == np.float32
-    assert rampfitoutput.sigyint.unit == ru.electron
+    assert rampfitoutput.sigyint.unit == u.electron
     assert rampfitoutput.pedestal.dtype == np.float32
-    assert rampfitoutput.pedestal.unit == ru.electron
+    assert rampfitoutput.pedestal.unit == u.electron
     assert rampfitoutput.weights.dtype == np.float32
     assert rampfitoutput.crmag.dtype == np.float32
-    assert rampfitoutput.crmag.unit == ru.electron
+    assert rampfitoutput.crmag.unit == u.electron
     assert rampfitoutput.var_poisson.dtype == np.float32
-    assert rampfitoutput.var_poisson.unit == ru.electron**2 / u.s**2
+    assert rampfitoutput.var_poisson.unit == u.electron**2 / u.s**2
     assert rampfitoutput.var_rnoise.dtype == np.float32
-    assert rampfitoutput.var_rnoise.unit == ru.electron**2 / u.s**2
+    assert rampfitoutput.var_rnoise.unit == u.electron**2 / u.s**2
     assert rampfitoutput.var_poisson.shape == (2, 20, 20)
     assert rampfitoutput.pedestal.shape == (20, 20)
 
@@ -207,11 +206,11 @@ def test_make_guidewindow():
 
     assert guidewindow.meta.exposure.type == "WFI_IMAGE"
     assert guidewindow.pedestal_frames.dtype == np.uint16
-    assert guidewindow.pedestal_frames.unit == ru.DN
+    assert guidewindow.pedestal_frames.unit == u.DN
     assert guidewindow.signal_frames.dtype == np.uint16
-    assert guidewindow.signal_frames.unit == ru.DN
+    assert guidewindow.signal_frames.unit == u.DN
     assert guidewindow.amp33.dtype == np.uint16
-    assert guidewindow.amp33.unit == ru.DN
+    assert guidewindow.amp33.unit == u.DN
     assert guidewindow.pedestal_frames.shape == (2, 8, 16, 32, 32)
     assert guidewindow.signal_frames.shape == (2, 8, 16, 32, 32)
     assert guidewindow.amp33.shape == (2, 8, 16, 32, 32)
@@ -360,7 +359,7 @@ def test_make_dark():
     assert dark.dq.dtype == np.uint32
     assert dark.dq.shape == (20, 20)
     assert dark.err.dtype == np.float32
-    assert dark.data.unit == ru.DN
+    assert dark.data.unit == u.DN
 
     # Test validation
     dark_model = datamodels.DarkRefModel(dark)
@@ -403,7 +402,7 @@ def test_make_gain():
     gain = utils.mk_gain(shape=(20, 20))
     assert gain.meta.reftype == "GAIN"
     assert gain.data.dtype == np.float32
-    assert gain.data.unit == ru.electron / ru.DN
+    assert gain.data.unit == u.electron / u.DN
 
     # Test validation
     gain_model = datamodels.GainRefModel(gain)
@@ -532,7 +531,7 @@ def test_make_readnoise():
     readnoise = utils.mk_readnoise(shape=(20, 20))
     assert readnoise.meta.reftype == "READNOISE"
     assert readnoise.data.dtype == np.float32
-    assert readnoise.data.unit == ru.DN
+    assert readnoise.data.unit == u.DN
 
     # Test validation
     readnoise_model = datamodels.ReadnoiseRefModel(readnoise)
@@ -573,7 +572,7 @@ def test_make_saturation():
     assert saturation.meta.reftype == "SATURATION"
     assert saturation.dq.dtype == np.uint32
     assert saturation.data.dtype == np.float32
-    assert saturation.data.unit == ru.DN
+    assert saturation.data.unit == u.DN
 
     # Test validation
     saturation_model = datamodels.SaturationRefModel(saturation)
@@ -653,7 +652,7 @@ def test_level1_science_raw():
     wfi_science_raw = utils.mk_level1_science_raw()
 
     assert wfi_science_raw.data.dtype == np.uint16
-    assert wfi_science_raw.data.unit == ru.DN
+    assert wfi_science_raw.data.unit == u.DN
 
     # Test validation
     wfi_science_raw_model = datamodels.ScienceRawModel(wfi_science_raw)
@@ -675,14 +674,14 @@ def test_level2_image():
     wfi_image = utils.mk_level2_image()
 
     assert wfi_image.data.dtype == np.float32
-    assert wfi_image.data.unit == ru.electron / u.s
+    assert wfi_image.data.unit == u.electron / u.s
     assert wfi_image.dq.dtype == np.uint32
     assert wfi_image.err.dtype == np.float32
-    assert wfi_image.err.unit == ru.electron / u.s
+    assert wfi_image.err.unit == u.electron / u.s
     assert wfi_image.var_poisson.dtype == np.float32
-    assert wfi_image.var_poisson.unit == ru.electron**2 / u.s**2
+    assert wfi_image.var_poisson.unit == u.electron**2 / u.s**2
     assert wfi_image.var_rnoise.dtype == np.float32
-    assert wfi_image.var_rnoise.unit == ru.electron**2 / u.s**2
+    assert wfi_image.var_rnoise.unit == u.electron**2 / u.s**2
     assert wfi_image.var_flat.dtype == np.float32
     assert type(wfi_image.cal_logs[0]) == str
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -10,7 +10,6 @@ from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels
 from roman_datamodels import maker_utils as utils
-from roman_datamodels import units as ru
 
 
 def test_asdf_file_input():
@@ -83,7 +82,7 @@ def test_path_input(tmp_path):
 def test_model_input(tmp_path):
     file_path = tmp_path / "test.asdf"
 
-    data = u.Quantity(np.random.uniform(size=(1024, 1024)).astype(np.float32), ru.electron / u.s, dtype=np.float32)
+    data = u.Quantity(np.random.uniform(size=(1024, 1024)).astype(np.float32), u.electron / u.s, dtype=np.float32)
 
     with asdf.AsdfFile() as af:
         af.tree = {"roman": utils.mk_level2_image()}
@@ -118,10 +117,10 @@ def test_memmap(tmp_path):
             ),
             dtype=np.float32,
         ),
-        ru.electron / u.s,
+        u.electron / u.s,
         dtype=np.float32,
     )
-    new_value = u.Quantity(1.0, ru.electron / u.s, dtype=np.float32)
+    new_value = u.Quantity(1.0, u.electron / u.s, dtype=np.float32)
     new_data = data.copy()
     new_data[6, 19] = new_value
 
@@ -171,10 +170,10 @@ def test_no_memmap(tmp_path, kwargs):
             ),
             dtype=np.float32,
         ),
-        ru.electron / u.s,
+        u.electron / u.s,
         dtype=np.float32,
     )
-    new_value = u.Quantity(1.0, ru.electron / u.s, dtype=np.float32)
+    new_value = u.Quantity(1.0, u.electron / u.s, dtype=np.float32)
     new_data = data.copy()
     new_data[6, 19] = new_value
 

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -1,7 +1,7 @@
 import asdf
 import pytest
 
-from roman_datamodels import stnode, units
+from roman_datamodels import stnode
 from roman_datamodels.testing import assert_node_equal, create_node
 
 
@@ -11,13 +11,10 @@ def test_generated_node_classes(manifest):
         node_class = getattr(stnode, class_name)
 
         assert issubclass(node_class, (stnode.TaggedObjectNode, stnode.TaggedListNode, stnode.TaggedScalarNode, stnode.Unit))
-        assert node_class._tag == tag["tag_uri"]
-        assert tag["description"] in node_class.__doc__
-        assert tag["tag_uri"] in node_class.__doc__
-        if issubclass(node_class, stnode.Unit):
-            assert issubclass(node_class, units.Unit)
-            assert node_class.__module__ == units.__name__
-        else:
+        if not issubclass(node_class, stnode.Unit):
+            assert node_class._tag == tag["tag_uri"]
+            assert tag["description"] in node_class.__doc__
+            assert tag["tag_uri"] in node_class.__doc__
             assert node_class.__module__ == stnode.__name__
             assert node_class.__name__ in stnode.__all__
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,211 +1,36 @@
 import asdf
+import astropy.units as u
 import pytest
-from astropy import units as u
+from asdf.testing.helpers import yaml_to_asdf
 
-from roman_datamodels import units
-
-
-def test_RomanUnit_fail():
-    with pytest.raises(ValueError):
-        units.Unit("foo")
+with pytest.warns(DeprecationWarning, match=r"The roman_datamodels.units module is deprecated. Use astropy.units instead"):
+    from roman_datamodels import units
 
 
-@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
-def test_roman_datamodels_unit(unit):
-    roman_unit = getattr(units, unit)
-    astropy_unit = getattr(u, unit)
-
-    assert roman_unit == astropy_unit
-
-    assert isinstance(roman_unit, units.Unit)
-    assert isinstance(roman_unit, u.Unit)
-    assert not isinstance(astropy_unit, units.Unit)
-
-    roman_value = 10 * roman_unit
-    astropy_value = 10 * astropy_unit
-
-    assert roman_value == astropy_value
+@pytest.mark.parametrize("unit", units.__all__)
+def test_units(unit):
+    assert getattr(units, unit) == getattr(u, unit)
 
 
-@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
-def test_string(unit):
-    roman_unit = getattr(units, unit)
-    astropy_unit = getattr(u, unit)
+@pytest.mark.parametrize("unit", units.__all__)
+def test_base_roman_unit(unit):
+    """Test deserialization of a base Roman units"""
+    yaml = f"""
+unit: !<asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0> {unit}
+    """
 
-    assert roman_unit.to_string() == astropy_unit.to_string() == unit
-
-
-@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
-def test_unit_serialization(unit, tmp_path):
-    roman_unit = getattr(units, unit)
-
-    file_path = tmp_path / "test.asdf"
-    with asdf.AsdfFile() as af:
-        af["unit"] = roman_unit
-        af.write_to(file_path)
-
-    with asdf.open(file_path) as af:
-        assert isinstance(af["unit"], units.Unit)
-        assert af["unit"] == roman_unit
+    buff = yaml_to_asdf(yaml)
+    with asdf.open(buff) as af:
+        assert af["unit"] == getattr(u, unit)
 
 
-@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
-def test_quantity_serialization(unit, tmp_path):
-    quantity = 3.14 * getattr(units, unit)
+@pytest.mark.parametrize("unit", ["electron / s", "electron2 / s2", "electron / DN"])
+def test_compound_roman_unit(unit):
+    """Test deserialization of a compound Roman units"""
+    yaml = f"""
+unit: !<asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0> {unit}
+    """
 
-    file_path = tmp_path / "test.asdf"
-    with asdf.AsdfFile() as af:
-        af["quantity"] = quantity
-        af.write_to(file_path)
-
-    with asdf.open(file_path) as af:
-        assert af["quantity"] == quantity
-        assert isinstance(af["quantity"].unit, units.Unit)
-
-
-@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
-@pytest.mark.parametrize("pwr", [-2, -1, 2])
-def test_roman_unit_pow(unit, pwr, tmp_path):
-    roman_unit = getattr(units, unit)
-
-    power = roman_unit**pwr
-    assert isinstance(power, units.CompositeUnit)
-
-    file_path = tmp_path / "test.asdf"
-    with asdf.AsdfFile() as af:
-        af["power"] = power
-        af.write_to(file_path)
-
-    with asdf.open(file_path) as af:
-        assert isinstance(af["power"], units.CompositeUnit)
-        assert af["power"] == power
-
-        ru = af["power"].bases[0]
-        assert isinstance(ru, units.Unit)
-        assert ru == roman_unit
-
-        assert af["power"].powers[0] == pwr
-
-
-@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
-def test_roman_unit_div_astropy_unit(unit, tmp_path):
-    roman_unit = getattr(units, unit)
-
-    composite = roman_unit / u.s
-    assert isinstance(composite, units.CompositeUnit)
-
-    file_path = tmp_path / "test.asdf"
-    with asdf.AsdfFile() as af:
-        af["composite"] = composite
-        af.write_to(file_path)
-
-    with asdf.open(file_path) as af:
-        assert isinstance(af["composite"], units.CompositeUnit)
-        assert af["composite"] == composite
-
-        ru = af["composite"].bases[0]
-        assert isinstance(ru, units.Unit)
-        assert ru == roman_unit
-        assert af["composite"].powers[0] == 1
-
-        uu = af["composite"].bases[1]
-        assert isinstance(uu, u.NamedUnit) and not isinstance(uu, units.Unit)
-        assert uu == u.s
-        assert af["composite"].powers[1] == -1
-
-
-@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
-def test_astropy_unit_div_roman_unit(unit, tmp_path):
-    roman_unit = getattr(units, unit)
-
-    composite = roman_unit / u.s
-    assert isinstance(composite, units.CompositeUnit)
-
-    composite = composite**-1
-    assert isinstance(composite, units.CompositeUnit)
-
-    file_path = tmp_path / "test.asdf"
-    with asdf.AsdfFile() as af:
-        af["composite"] = composite
-        af.write_to(file_path)
-
-    with asdf.open(file_path) as af:
-        assert isinstance(af["composite"], units.CompositeUnit)
-        assert af["composite"] == composite
-
-        uu = af["composite"].bases[0]
-        assert isinstance(uu, u.NamedUnit) and not isinstance(uu, units.Unit)
-        assert uu == u.s
-        assert af["composite"].powers[0] == 1
-
-        ru = af["composite"].bases[1]
-        assert isinstance(ru, units.Unit)
-        assert ru == roman_unit
-        assert af["composite"].powers[1] == -1
-
-
-@pytest.mark.parametrize("unit", units.ROMAN_UNIT_SYMBOLS)
-def test_roman_unit_mul_astropy_unit(unit, tmp_path):
-    roman_unit = getattr(units, unit)
-
-    composite = roman_unit * u.s
-    assert isinstance(composite, units.CompositeUnit)
-
-    file_path = tmp_path / "test.asdf"
-    with asdf.AsdfFile() as af:
-        af["composite"] = composite
-        af.write_to(file_path)
-
-    with asdf.open(file_path) as af:
-        assert isinstance(af["composite"], units.CompositeUnit)
-        assert af["composite"] == composite
-
-        ru = af["composite"].bases[0]
-        assert isinstance(ru, units.Unit)
-        assert ru == roman_unit
-        assert af["composite"].powers[0] == 1
-
-        uu = af["composite"].bases[1]
-        assert isinstance(uu, u.NamedUnit) and not isinstance(uu, units.Unit)
-        assert uu == u.s
-        assert af["composite"].powers[1] == 1
-
-
-def test_force_roman_unit():
-    # Roman units
-    for unit in units.ROMAN_UNIT_SYMBOLS:
-        # Basic conversion
-        assert isinstance(units.force_roman_unit(getattr(units, unit)), units.Unit)
-        assert isinstance(units.force_roman_unit(getattr(u, unit)), units.Unit)
-
-        # Powers
-        assert isinstance(units.force_roman_unit(getattr(units, unit) ** -1), units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(getattr(u, unit) ** -1), units.CompositeUnit)
-
-        # Division
-        assert isinstance(units.force_roman_unit(getattr(units, unit) / u.s), units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(getattr(u, unit) / u.s), units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(u.s / getattr(units, unit)), units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(u.s / getattr(u, unit)), units.CompositeUnit)
-
-        # Multiplication
-        assert isinstance(units.force_roman_unit(getattr(units, unit) * u.s), units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(getattr(u, unit) * u.s), units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(u.s * getattr(units, unit)), units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(u.s * getattr(u, unit)), units.CompositeUnit)
-
-    # Non-Roman units
-    for unit in [u.m, u.kg]:
-        # Basic conversion
-        assert isinstance(uu := units.force_roman_unit(unit), u.NamedUnit) and not isinstance(uu, units.Unit)
-
-        # Powers
-        assert isinstance(units.force_roman_unit(unit**-1), u.CompositeUnit) and not isinstance(uu, units.CompositeUnit)
-
-        # Division
-        assert isinstance(units.force_roman_unit(unit / u.s), u.CompositeUnit) and not isinstance(uu, units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(u.s / unit), u.CompositeUnit) and not isinstance(uu, units.CompositeUnit)
-
-        # Multiplication
-        assert isinstance(units.force_roman_unit(unit * u.s), u.CompositeUnit) and not isinstance(uu, units.CompositeUnit)
-        assert isinstance(units.force_roman_unit(u.s * unit), u.CompositeUnit) and not isinstance(uu, units.CompositeUnit)
+    buff = yaml_to_asdf(yaml)
+    with asdf.open(buff) as af:
+        assert af["unit"] == u.Unit(unit, parse_strict="silent")

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -14,7 +14,7 @@ def test_units(unit):
 
 @pytest.mark.parametrize("unit", units.__all__)
 def test_base_roman_unit(unit):
-    """Test deserialization of a base Roman units"""
+    """Test deserialization of a base legacy Roman units"""
     yaml = f"""
 unit: !<asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0> {unit}
     """
@@ -34,3 +34,20 @@ unit: !<asdf://stsci.edu/datamodels/roman/tags/unit-1.0.0> {unit}
     buff = yaml_to_asdf(yaml)
     with asdf.open(buff) as af:
         assert af["unit"] == u.Unit(unit, parse_strict="silent")
+
+
+@pytest.mark.parametrize("unit", [u.electron, u.DN, u.electron / u.s, u.electron**2 / u.s**2, u.electron / u.DN])
+def test_non_vounit(unit, tmp_path):
+    """Test deserialization of a non-VOUnits used by Roman"""
+
+    file_path = tmp_path / "test.asdf"
+    with asdf.AsdfFile() as af:
+        af["unit"] = unit
+        af.write_to(file_path)
+
+    with asdf.open(file_path) as af:
+        assert af["unit"] == unit
+
+    with asdf.open(file_path, _force_raw_types=True) as af:
+        assert isinstance(af["unit"], asdf.tagged.TaggedString)
+        assert af["unit"]._tag.startswith("tag:astropy.org:astropy/units/unit-")


### PR DESCRIPTION
astropy/asdf-astropy#142 introduced the ability to serialize non-VOunits defined within `astropy` to a special ASDF tag. All of the non-VOunits needed by Roman fall under this category. Because serialization of non-VOunits was previously possible, #109 created a wrapper "hack" around the `astropy` non-VOunits needed by Roman to enable support for serialization to a special ASDF tag created in `rad` (see spacetelescope/rad#168).

This PR in conjunction with spacetelescope/rad#220, switches `roman_datamodels` to directly use the non-VOunit support now in `asdf-astropy` for writing new Roman files.

Note @schlafly requested, that we continue support for the ability to read Roman files written with the Roman non-VOunit tags because right now it would be burdensome to have to regenerate all the current Roman files. This PR specifically makes efforts to preserve the ability to read/validate these existing files. However, this support is limited only to reading these tags. Once this PR is merged, no new files will be written including the Roman non-VOunit tag, and any files read/resaved will have these tags changed to the astropy ones.

This means that this PR is an intermediate solution until we reach a point where it is convenient to regenerate all existing Roman files, at which time the remaining parts of the `roman_datamodels.units` can be removed.

Additionally, a deprecation warning has been added to the `roman_datamodels.units` module which now only re-exports the `electron` and `DN` units from `astropy.units` directly. This is to allow some flexibility to those who have gotten used to using the `roman_datamodels` forms of those units.