### PR TITLE
Update test that will begin failing in a future version of asdf

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -65,17 +65,24 @@ def test_core_schema(tmp_path):
         af.tree = {"roman": wfi_image}
 
         # Test telescope name
-        af.tree["roman"].meta.telescope = "NOTROMAN"
         with pytest.raises(ValidationError):
+            # The error should be raised by the first statement,
+            # but a bug in asdf is preventing it.  Including both
+            # in the pytest.raises context will allow the test
+            # to pass both before and after the asdf bug is fixed.
+            af.tree["roman"].meta.telescope = "NOTROMAN"
             af.write_to(file_path)
+
         af.tree["roman"].meta["telescope"] = "NOTROMAN"
         with pytest.raises(ValidationError):
             af.write_to(file_path)
         af.tree["roman"].meta.telescope = "ROMAN"
 
         # Test origin name
-        af.tree["roman"].meta.origin = "NOTSTSCI"
         with pytest.raises(ValidationError):
+            # See note above for explanation of why both
+            # statements are included in the context here.
+            af.tree["roman"].meta.origin = "NOTSTSCI"
             af.write_to(file_path)
         af.tree["roman"].meta["origin"] = "NOTIPAC/SSC"
         with pytest.raises(ValidationError):


### PR DESCRIPTION
There's a bug of some kind in asdf that I accidentally fixed today, which will cause this test to fail when released.  If I understand correctly, the validate-on-assignment feature is supposed to be causing these statements to fail:

```python
af.tree["roman"].meta.telescope = "NOTROMAN"
```
```python
af.tree["roman"].meta.origin = "NOTSTSCI"
```

... but they do not under currently released versions of asdf.  This change will allow the test to pass both before and after the bug is fixed.