### PR TITLE
Suppress erfa warnings for future times

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
 - Begin process of removing ``roman_datamodels.units`` for non-VOUnit support in favor
   of non-VOUnit support coming directly via ``asdf-astropy``. [#131]
 
+- Suppress erfa warnings for randomly generated future times [#138]
 
 0.14.1 (2023-01-31)
 ===================

--- a/src/roman_datamodels/random_utils.py
+++ b/src/roman_datamodels/random_utils.py
@@ -6,8 +6,8 @@ import math
 import random
 import secrets
 import sys
-from datetime import datetime
 import warnings
+from datetime import datetime
 
 import numpy as np
 from astropy import units as u
@@ -62,7 +62,7 @@ def generate_astropy_time(time_format="unix", ignore_erfa_warnings=True):
     if ignore_erfa_warnings:
         # catch and ignore erfa warnings:
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', ErfaWarning)
+            warnings.simplefilter("ignore", ErfaWarning)
             timeobj = Time(generate_utc_timestamp(), format="unix")
     else:
         timeobj = Time(generate_utc_timestamp(), format="unix")

--- a/src/roman_datamodels/random_utils.py
+++ b/src/roman_datamodels/random_utils.py
@@ -7,10 +7,12 @@ import random
 import secrets
 import sys
 from datetime import datetime
+import warnings
 
 import numpy as np
 from astropy import units as u
 from astropy.time import Time
+from erfa.core import ErfaWarning
 
 
 def generate_float(min=None, max=None):
@@ -56,8 +58,14 @@ def generate_string_time():
     return datetime.utcfromtimestamp(generate_utc_timestamp()).strftime("%H:%M:%S.%f")[0:12]
 
 
-def generate_astropy_time(time_format="unix"):
-    timeobj = Time(generate_utc_timestamp(), format="unix")
+def generate_astropy_time(time_format="unix", ignore_erfa_warnings=True):
+    if ignore_erfa_warnings:
+        # catch and ignore erfa warnings:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', ErfaWarning)
+            timeobj = Time(generate_utc_timestamp(), format="unix")
+    else:
+        timeobj = Time(generate_utc_timestamp(), format="unix")
 
     if time_format == "unix":
         return timeobj


### PR DESCRIPTION
Methods for synthetic datamodels like `create_wfi_image` generate metadata (`create_meta`) with exposures (`create_exposure`). Exposures contain times represented with `astropy.time.Time` objects, which have limited support for times sufficiently far in the future. This stems from uncertainty due to upcoming leap seconds, which may (or may not) be added between now and far-ish future times. Far-ish future times can be initialized without a problem in some formats/scales, but if you translate them to some other formats, you get an ERFA warning about a "dubious year", like this:

```python
In [1]: from astropy.time import Time

In [2]: Time(1893456000, format='unix')  # no problems
Out[2]: <Time object: scale='utc' format='unix' value=1893456000.0>

In [3]: Time(1893456000, format='unix').iso  # problems
/Users/bmmorris/miniconda3/envs/jdaviz-only/lib/python3.10/site-packages/erfa/core.py:154: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)"
  warnings.warn('ERFA function "{}" yielded {}'.format(func_name, wmsg),
Out[3]: '2030-01-01 00:00:00.000'
```

The unix time chosen in the example above is the upper limit on the randomly drawn times used by `roman_datamodels`:

https://github.com/spacetelescope/roman_datamodels/blob/086dd88abeca00439cee2d69a0881b8eea3fe270/src/roman_datamodels/random_utils.py#L42-L44

so the later randomly drawn times within the range will throw an erfa warning. We can dodge the warning by suppressing it directly or by changing the time range. Since the time range is meant to mimic Roman's mission duration, I opted for the former, and put in a switch (`ignore_erfa_warnings`) to recover the old behavior.

This PR is in support of spacetelescope/jdaviz#1822.