### PR TITLE
when calling Datamodel.validate use a schema if available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@
 
 - update minimum version of ``numpy`` to ``1.20`` and add minimum dependency testing to CI [#114]
 
+- Use available tag schema if available during datamodels.validate [#140]
+
 0.14.1 (2023-01-31)
 ===================
 

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -33,7 +33,7 @@ def value_change(value, pass_invalid_values, strict_validation):
         if pass_invalid_values:
             update = True
         if strict_validation:
-            raise jsonschema.ValidationError(errmsg)
+            raise errmsg
         else:
             warnings.warn(errmsg, ValidationWarning)
     return update
@@ -61,7 +61,10 @@ def _check_value(value):
 
     validator_context = AsdfFile()
 
-    temp_schema = {"$schema": "http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema"}
+    if hasattr(value, "_schema"):
+        temp_schema = value._schema()
+    else:
+        temp_schema = {"$schema": "http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema"}
     validator = asdf_schema.get_validator(temp_schema, validator_context, validators=validator_callbacks)
 
     value = yamlutil.custom_tree_to_tagged_tree(value, validator_context)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -750,3 +750,17 @@ def test_crds_parameters(tmp_path):
 
     crds_pars = ramp.get_crds_parameters()
     assert "roman.meta.exposure.start_time" in crds_pars
+
+
+def test_model_validate_without_save():
+    # regression test for rcal-538
+    img = utils.mk_level1_science_raw()
+    m = datamodels.ImageModel(img)
+
+    # invalidate pointing without using the
+    # data model/node api to avoid a validation
+    # failure here
+    m.meta["pointing"] = {}
+
+    with pytest.raises(ValidationError):
+        m.validate()


### PR DESCRIPTION
fixes RCAL-538

A call to Datamodel.validate results in a call to _check_value which appears to use a default schema to check that a new value is valid.
https://github.com/spacetelescope/roman_datamodels/blob/36b556ec83c2f5530a78237bd6669739383bf4c9/src/roman_datamodels/validate.py#L64-L69

However, as described in RCAL-538, an issue can arise if sub-contents of a node are changed (for example if meta is accessed like a dictionary and a value is changed, see the test added to this PR). This sub-content change will not trigger validation (as there's no way to know that the sub-contents have changed). Furthermore, the default schema provided during the call to validator.validate above will take precedence over any tag associated schema. This results in failure to catch invalid objects if the sub-content was changed (probably only for the first children but I did not test this).

This PR addresses the issue by looking for an available schema when validate is called which will be used in place of the temp_schema (the temp_schema will still be used if no instance schema is found).