### PR TITLE
Remove use of `pytest-openfiles`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.15.0 (unreleased)
+===================
+
+- Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
+  catching ``ResourceWarning`` s. [#142]
+
 0.14.2 (2023-03-31)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dynamic = ['version']
 test = [
     'pytest >=6.0.0',
     'pytest-doctestplus',
-    'pytest-openfiles >=0.5.0',
     'pytest-doctestplus >=0.10.0',
 ]
 aws = [
@@ -65,8 +64,11 @@ minversion = 4.6
 doctest_plus = true
 doctest_rst = true
 text_file_format = 'rst'
-addopts = '--show-capture=no --open-files'
+addopts = '--show-capture=no'
 testpaths = ['tests']
+filterwarnings = [
+    "error::ResourceWarning",
+]
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
`pytest-openfiles` has been deprecated and is interfering with the use of fixtures in our test code (ones that handle files). This PR switches `ResourceWarnings` into errors which will catch almost all cases of files left open. The only cases it does not catch is if an open file handle is assigned to a global variable as the "warning" will not be emitted until python stops running, which occurs after pytest has completed.

Similar to spacetelescope/romancal#666