### PR TITLE
Refactor `random_utils` to allow seeding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 
 - Remove ``source_type_apt`` from ``target-1.0.0`` related datamodels. [#152]
 
+- Enable seeding for ``random_utils`` functions. [#148]
+
 0.14.2 (2023-03-31)
 ===================
 

--- a/src/roman_datamodels/random_utils.py
+++ b/src/roman_datamodels/random_utils.py
@@ -2,7 +2,7 @@
 Utility file containing random value generation routines.
 """
 
-import secrets
+import string
 import warnings
 from datetime import datetime
 
@@ -10,6 +10,8 @@ import numpy as np
 from astropy import units as u
 from astropy.time import Time
 from erfa.core import ErfaWarning
+
+_HEX_ALPHABET = np.array(list(string.hexdigits))
 
 
 def generate_float(min=None, max=None, seed=None):
@@ -106,13 +108,18 @@ def generate_choices(*args, seed=None, k=1, **kwargs):
     return [args[i] for i in indices]
 
 
-def generate_string(prefix="", max_length=None):
+def generate_string(prefix="", max_length=None, seed=None):
     if max_length is not None:
-        random_length = min(16, max_length - len(prefix))
+        size = 2 * min(16, max_length - len(prefix))
     else:
-        random_length = 16
+        size = 2 * 16
 
-    return prefix + secrets.token_hex(random_length)
+    if size > 0:
+        suffix = str(np.random.default_rng(seed).choice(_HEX_ALPHABET, size=size).view(f"U{size}")[0])
+    else:
+        suffix = ""
+
+    return prefix + suffix
 
 
 def generate_bool(seed=None):

--- a/src/roman_datamodels/random_utils.py
+++ b/src/roman_datamodels/random_utils.py
@@ -2,10 +2,7 @@
 Utility file containing random value generation routines.
 """
 
-import math
-import random
 import secrets
-import sys
 import warnings
 from datetime import datetime
 
@@ -15,52 +12,53 @@ from astropy.time import Time
 from erfa.core import ErfaWarning
 
 
-def generate_float(min=None, max=None):
+def generate_float(min=None, max=None, seed=None):
+    # Assume 32-bit range for now, 64-bit range tends to overflow
     if min is None:
-        min = sys.float_info.max * -1.0
+        min = -1e38
     if max is None:
-        max = sys.float_info.max
-    value = random.random()
-    return min + max * value - min * value
+        max = 1e38
+
+    return np.random.default_rng(seed).uniform(low=min, high=max)
 
 
-def generate_positive_float(max=None):
-    return generate_float(min=0.0, max=max)
+def generate_positive_float(max=None, seed=None):
+    return generate_float(min=0.0, max=max, seed=seed)
 
 
-def generate_angle_radians():
-    return generate_float(0.0, 2.0 * math.pi)
+def generate_angle_radians(seed=None):
+    return generate_float(0.0, 2.0 * np.pi, seed=seed)
 
 
-def generate_angle_degrees():
-    return generate_float(0.0, 360.0)
+def generate_angle_degrees(seed=None):
+    return generate_float(0.0, 360.0, seed=seed)
 
 
-def generate_mjd_timestamp():
+def generate_mjd_timestamp(seed=None):
     # Random timestamp between 2020-01-01 and 2030-01-01
-    return generate_float(58849.0, 62502.0)
+    return generate_float(58849.0, 62502.0, seed=seed)
 
 
-def generate_utc_timestamp():
+def generate_utc_timestamp(seed=None):
     # Random timestamp between 2020-01-01 and 2030-01-01
-    return generate_float(1577836800.0, 1893456000.0)
+    return generate_float(1577836800.0, 1893456000.0, seed=seed)
 
 
-def generate_string_timestamp():
-    return datetime.utcfromtimestamp(generate_utc_timestamp()).strftime("%Y-%m-%dT%H:%M:%S.%f")[0:23]
+def generate_string_timestamp(seed=None):
+    return datetime.utcfromtimestamp(generate_utc_timestamp(seed=seed)).strftime("%Y-%m-%dT%H:%M:%S.%f")[0:23]
 
 
-def generate_string_date():
-    return datetime.utcfromtimestamp(generate_utc_timestamp()).strftime("%Y-%m-%d")
+def generate_string_date(seed=None):
+    return datetime.utcfromtimestamp(generate_utc_timestamp(seed=seed)).strftime("%Y-%m-%d")
 
 
-def generate_string_time():
-    return datetime.utcfromtimestamp(generate_utc_timestamp()).strftime("%H:%M:%S.%f")[0:12]
+def generate_string_time(seed=None):
+    return datetime.utcfromtimestamp(generate_utc_timestamp(seed=seed)).strftime("%H:%M:%S.%f")[0:12]
 
 
-def generate_astropy_time(time_format="unix", ignore_erfa_warnings=True):
+def generate_astropy_time(time_format="unix", ignore_erfa_warnings=True, seed=None):
     def _gen_time():
-        timeobj = Time(generate_utc_timestamp(), format="unix")
+        timeobj = Time(generate_utc_timestamp(seed=seed), format="unix")
 
         if time_format == "unix":
             return timeobj
@@ -78,25 +76,34 @@ def generate_astropy_time(time_format="unix", ignore_erfa_warnings=True):
         return _gen_time()
 
 
-def generate_int(min=None, max=None):
+def generate_int(min=None, max=None, size=None, seed=None):
     # Assume 32-bit signed integers for now
     if min is None:
         min = -1 * 2**31
     if max is None:
         max = 2**31 - 1
-    return random.randint(min, max)
+
+    return np.random.default_rng(seed).integers(low=min, high=max, size=size, dtype=int)
 
 
-def generate_positive_int(max=None):
-    return generate_int(0, max)
+def generate_positive_int(max=None, size=None, seed=None):
+    return generate_int(0, max, size=size, seed=seed)
 
 
-def generate_choice(*args):
-    return random.choice(args)
+def generate_choice(*args, seed=None):
+    if len(args) == 1:
+        args = args[0]
+
+    index = generate_positive_int(max=len(args) - 1, seed=seed)
+    return args[index]
 
 
-def generate_choices(*args, **kwargs):
-    return random.choices(args, **kwargs)
+def generate_choices(*args, seed=None, k=1, **kwargs):
+    if len(args) == 1:
+        args = args[0]
+
+    indices = generate_positive_int(max=len(args) - 1, size=k, seed=seed).tolist()
+    return [args[i] for i in indices]
 
 
 def generate_string(prefix="", max_length=None):
@@ -108,56 +115,56 @@ def generate_string(prefix="", max_length=None):
     return prefix + secrets.token_hex(random_length)
 
 
-def generate_bool():
-    return generate_choice(*[True, False])
+def generate_bool(seed=None):
+    return bool(generate_choice(*[True, False], seed=seed))
 
 
-def generate_array_float32(size=(4096, 4096), min=None, max=None, units=None):
+def generate_array_float32(size=(4096, 4096), min=None, max=None, units=None, seed=None):
     if min is None:
         min = np.finfo("float32").min
     if max is None:
         max = np.finfo("float32").max
 
-    array = np.random.default_rng().uniform(low=min, high=max, size=size).astype(np.float32)
+    array = np.random.default_rng(seed).uniform(low=min, high=max, size=size).astype(np.float32)
     if units:
         array = u.Quantity(array, units, dtype=np.float32)
     return array
 
 
-def generate_array_uint8(size=(4096, 4096), min=None, max=None, units=None):
+def generate_array_uint8(size=(4096, 4096), min=None, max=None, units=None, seed=None):
     if min is None:
         min = np.iinfo("uint8").min
     if max is None:
         max = np.iinfo("uint8").max
-    array = np.random.randint(min, high=max, size=size, dtype=np.uint8)
+    array = np.random.default_rng(seed).integers(low=min, high=max, size=size, dtype=np.uint8)
     if units:
         array = u.Quantity(array, units, dtype=np.uint8)
     return array
 
 
-def generate_array_uint16(size=(4096, 4096), min=None, max=None, units=None):
+def generate_array_uint16(size=(4096, 4096), min=None, max=None, units=None, seed=None):
     if min is None:
         min = np.iinfo("uint16").min
     if max is None:
         max = np.iinfo("uint16").max
-    array = np.random.randint(min, high=max, size=size, dtype=np.uint16)
+    array = np.random.default_rng(seed).integers(min, high=max, size=size, dtype=np.uint16)
     if units:
         array = u.Quantity(array, units, dtype=np.uint16)
     return array
 
 
-def generate_array_uint32(size=(4096, 4096), min=None, max=None, units=None):
+def generate_array_uint32(size=(4096, 4096), min=None, max=None, units=None, seed=None):
     if min is None:
         min = np.iinfo("uint32").min
     if max is None:
         max = np.iinfo("uint32").max
-    array = np.random.randint(min, high=max, size=size, dtype=np.uint32)
+    array = np.random.default_rng(seed).integers(min, high=max, size=size, dtype=np.uint32)
     if units:
         array = u.Quantity(array, units, dtype=np.uint32)
     return array
 
 
-def generate_exposure_type():
+def generate_exposure_type(seed=None):
     return generate_choice(
         "WFI_DARK",
         "WFI_FLAT",
@@ -165,10 +172,11 @@ def generate_exposure_type():
         "WFI_IMAGE",
         "WFI_PRISM",
         "WFI_WFSC",
+        seed=seed,
     )
 
 
-def generate_detector():
+def generate_detector(seed=None):
     return generate_choice(
         "WFI01",
         "WFI02",
@@ -188,10 +196,11 @@ def generate_detector():
         "WFI16",
         "WFI17",
         "WFI18",
+        seed=seed,
     )
 
 
-def generate_optical_element():
+def generate_optical_element(seed=None):
     return generate_choice(
         "F062",
         "F087",
@@ -204,12 +213,10 @@ def generate_optical_element():
         "GRISM",
         "PRISM",
         "DARK",
+        seed=seed,
     )
 
 
-def generate_software_version():
-    return "{}.{}.{}".format(
-        generate_positive_int(100),
-        generate_positive_int(100),
-        generate_positive_int(100),
-    )
+def generate_software_version(seed=None):
+    vals = generate_positive_int(100, size=3, seed=seed)
+    return f"{vals[0]}.{vals[1]}.{vals[2]}"

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -18,73 +18,93 @@ def _min_max(min, max):
 
 
 @pytest.mark.parametrize("min, max", [(None, None), (-1, 1), (-30, 10), (-5, 100), (-100, 1000)])
-def test_generate_float(min, max):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_float(min, max, seed):
     t_min, t_max = _min_max(min, max)
 
-    value = random_utils.generate_float(min=min, max=max)
-    assert isinstance(value, float)
-    assert t_min <= value <= t_max
+    value = random_utils.generate_float(min=min, max=max, seed=seed)
+    for _ in range(50 if seed is None else 1):
+        assert isinstance(value, float)
+        assert t_min <= value <= t_max
 
 
 @pytest.mark.parametrize("max", [None, 1, 10, 100, 1000])
-def test_generate_positive_float(max):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_positive_float(max, seed):
     t_min, t_max = _min_max(0, max)
 
-    value = random_utils.generate_positive_float(max=max)
-    assert isinstance(value, float)
-    assert t_min <= value <= t_max
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_positive_float(max=max, seed=seed)
+        assert isinstance(value, float)
+        assert t_min <= value <= t_max
 
 
-def test_generate_angle_radians():
-    value = random_utils.generate_angle_radians()
-    assert 0 <= value <= 2 * np.pi
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_angle_radians(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_angle_radians(seed=seed)
+        assert 0 <= value <= 2 * np.pi
 
 
-def test_generate_angle_degrees():
-    value = random_utils.generate_angle_degrees()
-    assert 0 <= value <= 360
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_angle_degrees(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_angle_degrees(seed=seed)
+        assert 0 <= value <= 360
 
 
-def test_generate_mjd_timestamp():
-    value = random_utils.generate_mjd_timestamp()
-    assert 58849 <= value <= 62502
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_mjd_timestamp(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_mjd_timestamp(seed=seed)
+        assert 58849 <= value <= 62502
 
 
-def test_generate_utc_timestamp():
-    value = random_utils.generate_utc_timestamp()
-    assert 1577836800.0 <= value <= 1893456000.0
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_utc_timestamp(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_utc_timestamp(seed=seed)
+        assert 1577836800.0 <= value <= 1893456000.0
 
 
-def test_genrate_string_timestamp():
-    value = random_utils.generate_string_timestamp()
-    assert isinstance(value, str)
-    assert len(value) == 23
-    pattern = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}")
-    assert pattern.match(value)
+@pytest.mark.parametrize("seed", [None, 42])
+def test_genrate_string_timestamp(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_string_timestamp(seed=seed)
+        assert isinstance(value, str)
+        assert len(value) == 23
+        pattern = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}")
+        assert pattern.match(value)
 
 
-def test_generate_string_date():
-    value = random_utils.generate_string_date()
-    assert isinstance(value, str)
-    assert len(value) == 10
-    pattern = re.compile(r"\d{4}-\d{2}-\d{2}")
-    assert pattern.match(value)
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_string_date(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_string_date(seed=seed)
+        assert isinstance(value, str)
+        assert len(value) == 10
+        pattern = re.compile(r"\d{4}-\d{2}-\d{2}")
+        assert pattern.match(value)
 
 
-def test_generate_string_time():
-    value = random_utils.generate_string_time()
-    assert isinstance(value, str)
-    assert len(value) == 12
-    pattern = re.compile(r"\d{2}:\d{2}:\d{2}.\d{3}")
-    assert pattern.match(value)
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_string_time(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_string_time(seed=seed)
+        assert isinstance(value, str)
+        assert len(value) == 12
+        pattern = re.compile(r"\d{2}:\d{2}:\d{2}.\d{3}")
+        assert pattern.match(value)
 
 
 @pytest.mark.parametrize("time_format", ["unix", "isot"])
-def test_generate_astropy_time(time_format):
-    value = random_utils.generate_astropy_time(time_format=time_format)
-    assert isinstance(value, Time)
-    assert 1577836800.0 <= value.unix <= 1893456000.0
-    assert value.format == time_format
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_astropy_time(time_format, seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_astropy_time(time_format=time_format, seed=seed)
+        assert isinstance(value, Time)
+        assert 1577836800.0 <= value.unix <= 1893456000.0
+        assert value.format == time_format
 
 
 def _int_min_max(min, max):
@@ -97,43 +117,49 @@ def _int_min_max(min, max):
 
 
 @pytest.mark.parametrize("min, max", [(None, None), (-1, 1), (-30, 10), (-5, 100), (-100, 1000)])
-def test_generate_int(min, max):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_int(min, max, seed):
     t_min, t_max = _int_min_max(min, max)
 
-    value = random_utils.generate_int(min=min, max=max)
-    assert isinstance(value, int)
-    assert t_min <= value <= t_max
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_int(min=min, max=max, seed=seed)
+        assert isinstance(value, int)
+        assert t_min <= value <= t_max
 
 
 @pytest.mark.parametrize("max", [None, 1, 10, 100, 1000])
-def test_generate_positive_int(max):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_positive_int(max, seed):
     t_min, t_max = _int_min_max(0, max)
 
-    value = random_utils.generate_positive_int(max=max)
-    assert isinstance(value, int)
-    assert t_min <= value <= t_max
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_positive_int(max=max, seed=seed)
+        assert isinstance(value, int)
+        assert t_min <= value <= t_max
 
 
 @pytest.mark.parametrize("choices", [[1, 2, 3], ["a", "b", "c"], [1, "a", 2, "b", 3, "c"]])
 @pytest.mark.parametrize("unpack", [True, False])
-def test_generate_choice(choices, unpack):
-    for _ in range(50):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_choice(choices, unpack, seed):
+    for _ in range(50 if seed is None else 1):
         if unpack:
-            value = random_utils.generate_choice(*choices)
+            value = random_utils.generate_choice(*choices, seed=seed)
         else:
-            value = random_utils.generate_choice(choices)
+            value = random_utils.generate_choice(choices, seed=seed)
         assert value in choices
 
 
 @pytest.mark.parametrize("choices", [[1, 2, 3], ["a", "b", "c"], [1, "a", 2, "b", 3, "c"]])
 @pytest.mark.parametrize("size", [2, 3, 4, 5])
 @pytest.mark.parametrize("unpack", [True, False])
-def test_generate_choices(choices, size, unpack):
-    for _ in range(50):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_choices(choices, size, unpack, seed):
+    for _ in range(50 if seed is None else 1):
         if unpack:
-            value = random_utils.generate_choices(*choices, k=size)
+            value = random_utils.generate_choices(*choices, k=size, seed=seed)
         else:
-            value = random_utils.generate_choices(choices, k=size)
+            value = random_utils.generate_choices(choices, k=size, seed=seed)
 
         assert isinstance(value, list)
         assert len(value) == size
@@ -143,16 +169,19 @@ def test_generate_choices(choices, size, unpack):
 
 @pytest.mark.parametrize("prefix", ["", "this", "is", "a", "test"])
 @pytest.mark.parametrize("max_length", [None, 4, 5, 6, 7, 8, 9, 10])
-def test_generate_string(prefix, max_length):
-    value = random_utils.generate_string(prefix=prefix, max_length=max_length)
-    assert isinstance(value, str)
-    assert value.startswith(prefix)
-    assert len(value) <= (2 * max_length if max_length is not None else 32) + len(prefix)
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_string(prefix, max_length, seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_string(prefix=prefix, max_length=max_length, seed=seed)
+        assert isinstance(value, str)
+        assert value.startswith(prefix)
+        assert len(value) <= (2 * max_length if max_length is not None else 32) + len(prefix)
 
 
-def test_generate_bool():
-    for _ in range(100):
-        value = random_utils.generate_bool()
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_bool(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_bool(seed=seed)
         assert isinstance(value, bool)
         assert value in [True, False]
 
@@ -169,10 +198,11 @@ def _float32_min_max(min, max):
 @pytest.mark.parametrize("size", [(4096, 4096), (2048, 2048), (1024, 1024), (512, 512), (256, 256)])
 @pytest.mark.parametrize("min, max", [(None, None), (-1, 1), (-30, 10), (-5, 100), (-100, 1000)])
 @pytest.mark.parametrize("units", [None, u.m, u.electron, u.DN])
-def test_generate_array_float32(size, min, max, units):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_array_float32(size, min, max, units, seed):
     t_min, t_max = _float32_min_max(min, max)
 
-    value = random_utils.generate_array_float32(size=size, min=min, max=max, units=units)
+    value = random_utils.generate_array_float32(size=size, min=min, max=max, units=units, seed=seed)
     assert isinstance(value, np.ndarray)
     assert value.dtype == np.float32
     assert value.shape == size
@@ -199,10 +229,11 @@ def _uint8_min_max(min, max):
 @pytest.mark.parametrize("size", [(4096, 4096), (2048, 2048), (1024, 1024), (512, 512), (256, 256)])
 @pytest.mark.parametrize("min, max", [(None, None), (0, 1), (5, 10), (10, 100), (100, 255)])
 @pytest.mark.parametrize("units", [None, u.m, u.electron, u.DN])
-def test_generate_array_uint8(size, min, max, units):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_array_uint8(size, min, max, units, seed):
     t_min, t_max = _uint8_min_max(min, max)
 
-    value = random_utils.generate_array_uint8(size=size, min=min, max=max, units=units)
+    value = random_utils.generate_array_uint8(size=size, min=min, max=max, units=units, seed=seed)
     assert isinstance(value, np.ndarray)
     assert value.dtype == np.uint8
     assert value.shape == size
@@ -229,10 +260,11 @@ def _uint16_min_max(min, max):
 @pytest.mark.parametrize("size", [(4096, 4096), (2048, 2048), (1024, 1024), (512, 512), (256, 256)])
 @pytest.mark.parametrize("min, max", [(None, None), (0, 1), (5, 10), (10, 100), (100, 1000)])
 @pytest.mark.parametrize("units", [None, u.m, u.electron, u.DN])
-def test_generate_array_uint16(size, min, max, units):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_array_uint16(size, min, max, units, seed):
     t_min, t_max = _uint16_min_max(min, max)
 
-    value = random_utils.generate_array_uint16(size=size, min=min, max=max, units=units)
+    value = random_utils.generate_array_uint16(size=size, min=min, max=max, units=units, seed=seed)
     assert isinstance(value, np.ndarray)
     assert value.dtype == np.uint16
     assert value.shape == size
@@ -259,10 +291,11 @@ def _uint32_min_max(min, max):
 @pytest.mark.parametrize("size", [(4096, 4096), (2048, 2048), (1024, 1024), (512, 512), (256, 256)])
 @pytest.mark.parametrize("min, max", [(None, None), (0, 1), (5, 10), (10, 100), (100, 1000)])
 @pytest.mark.parametrize("units", [None, u.m, u.electron, u.DN])
-def test_generate_array_uint32(size, min, max, units):
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_array_uint32(size, min, max, units, seed):
     t_min, t_max = _uint32_min_max(min, max)
 
-    value = random_utils.generate_array_uint32(size=size, min=min, max=max, units=units)
+    value = random_utils.generate_array_uint32(size=size, min=min, max=max, units=units, seed=seed)
     assert isinstance(value, np.ndarray)
     assert value.dtype == np.uint32
     assert value.shape == size
@@ -277,7 +310,8 @@ def test_generate_array_uint32(size, min, max, units):
     assert (val <= t_max).all()
 
 
-def test_generate_exposure_type():
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_exposure_type(seed):
     t_values = [
         "WFI_DARK",
         "WFI_FLAT",
@@ -286,13 +320,14 @@ def test_generate_exposure_type():
         "WFI_PRISM",
         "WFI_WFSC",
     ]
-    for _ in range(100):
-        value = random_utils.generate_exposure_type()
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_exposure_type(seed=seed)
         assert isinstance(value, str)
         assert value in t_values
 
 
-def test_generate_detector():
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_detector(seed):
     t_values = [
         "WFI01",
         "WFI02",
@@ -313,13 +348,14 @@ def test_generate_detector():
         "WFI17",
         "WFI18",
     ]
-    for _ in range(100):
-        value = random_utils.generate_detector()
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_detector(seed=seed)
         assert isinstance(value, str)
         assert value in t_values
 
 
-def test_generate_optical_element():
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_optical_element(seed):
     t_values = [
         "F062",
         "F087",
@@ -333,15 +369,16 @@ def test_generate_optical_element():
         "PRISM",
         "DARK",
     ]
-    for _ in range(100):
-        value = random_utils.generate_optical_element()
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_optical_element(seed=seed)
         assert isinstance(value, str)
         assert value in t_values
 
 
-def test_generate_software_version():
-    for _ in range(100):
-        value = random_utils.generate_software_version()
+@pytest.mark.parametrize("seed", [None, 42])
+def test_generate_software_version(seed):
+    for _ in range(50 if seed is None else 1):
+        value = random_utils.generate_software_version(seed=seed)
         assert isinstance(value, str)
         pattern = re.compile(r"([0-9]+)\.([0-9]+)\.([0-9]+)")
         assert pattern.match(value)

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -1,0 +1,341 @@
+import re
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.time import Time
+
+from roman_datamodels import random_utils
+
+
+def _min_max(min, max):
+    if min is None:
+        min = np.finfo("float").min
+    if max is None:
+        max = np.finfo("float").max
+
+    return min, max
+
+
+@pytest.mark.parametrize("min, max", [(None, None), (-1, 1), (-30, 10), (-5, 100), (-100, 1000)])
+def test_generate_float(min, max):
+    t_min, t_max = _min_max(min, max)
+
+    value = random_utils.generate_float(min=min, max=max)
+    assert isinstance(value, float)
+    assert t_min <= value <= t_max
+
+
+@pytest.mark.parametrize("max", [None, 1, 10, 100, 1000])
+def test_generate_positive_float(max):
+    t_min, t_max = _min_max(0, max)
+
+    value = random_utils.generate_positive_float(max=max)
+    assert isinstance(value, float)
+    assert t_min <= value <= t_max
+
+
+def test_generate_angle_radians():
+    value = random_utils.generate_angle_radians()
+    assert 0 <= value <= 2 * np.pi
+
+
+def test_generate_angle_degrees():
+    value = random_utils.generate_angle_degrees()
+    assert 0 <= value <= 360
+
+
+def test_generate_mjd_timestamp():
+    value = random_utils.generate_mjd_timestamp()
+    assert 58849 <= value <= 62502
+
+
+def test_generate_utc_timestamp():
+    value = random_utils.generate_utc_timestamp()
+    assert 1577836800.0 <= value <= 1893456000.0
+
+
+def test_genrate_string_timestamp():
+    value = random_utils.generate_string_timestamp()
+    assert isinstance(value, str)
+    assert len(value) == 23
+    pattern = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}")
+    assert pattern.match(value)
+
+
+def test_generate_string_date():
+    value = random_utils.generate_string_date()
+    assert isinstance(value, str)
+    assert len(value) == 10
+    pattern = re.compile(r"\d{4}-\d{2}-\d{2}")
+    assert pattern.match(value)
+
+
+def test_generate_string_time():
+    value = random_utils.generate_string_time()
+    assert isinstance(value, str)
+    assert len(value) == 12
+    pattern = re.compile(r"\d{2}:\d{2}:\d{2}.\d{3}")
+    assert pattern.match(value)
+
+
+@pytest.mark.parametrize("time_format", ["unix", "isot"])
+def test_generate_astropy_time(time_format):
+    value = random_utils.generate_astropy_time(time_format=time_format)
+    assert isinstance(value, Time)
+    assert 1577836800.0 <= value.unix <= 1893456000.0
+    assert value.format == time_format
+
+
+def _int_min_max(min, max):
+    if min is None:
+        min = -1 * 2**31
+    if max is None:
+        max = 2**31 - 1
+
+    return min, max
+
+
+@pytest.mark.parametrize("min, max", [(None, None), (-1, 1), (-30, 10), (-5, 100), (-100, 1000)])
+def test_generate_int(min, max):
+    t_min, t_max = _int_min_max(min, max)
+
+    value = random_utils.generate_int(min=min, max=max)
+    assert isinstance(value, int)
+    assert t_min <= value <= t_max
+
+
+@pytest.mark.parametrize("max", [None, 1, 10, 100, 1000])
+def test_generate_positive_int(max):
+    t_min, t_max = _int_min_max(0, max)
+
+    value = random_utils.generate_positive_int(max=max)
+    assert isinstance(value, int)
+    assert t_min <= value <= t_max
+
+
+@pytest.mark.parametrize("choices", [[1, 2, 3], ["a", "b", "c"], [1, "a", 2, "b", 3, "c"]])
+def test_generate_choice(choices):
+    value = random_utils.generate_choice(*choices)
+    assert value in choices
+
+
+@pytest.mark.parametrize("choices", [[1, 2, 3], ["a", "b", "c"], [1, "a", 2, "b", 3, "c"]])
+@pytest.mark.parametrize("size", [2, 3, 4, 5])
+def test_generate_choices(choices, size):
+    value = random_utils.generate_choices(*choices, k=size)
+    assert isinstance(value, list)
+    assert len(value) == size
+    for v in value:
+        assert v in choices
+
+
+@pytest.mark.parametrize("prefix", ["", "this", "is", "a", "test"])
+@pytest.mark.parametrize("max_length", [None, 4, 5, 6, 7, 8, 9, 10])
+def test_generate_string(prefix, max_length):
+    value = random_utils.generate_string(prefix=prefix, max_length=max_length)
+    assert isinstance(value, str)
+    assert value.startswith(prefix)
+    assert len(value) <= (2 * max_length if max_length is not None else 32) + len(prefix)
+
+
+def test_generate_bool():
+    for _ in range(100):
+        value = random_utils.generate_bool()
+        assert isinstance(value, bool)
+        assert value in [True, False]
+
+
+def _float32_min_max(min, max):
+    if min is None:
+        min = np.finfo("float32").min
+    if max is None:
+        max = np.finfo("float32").max
+
+    return min, max
+
+
+@pytest.mark.parametrize("size", [(4096, 4096), (2048, 2048), (1024, 1024), (512, 512), (256, 256)])
+@pytest.mark.parametrize("min, max", [(None, None), (-1, 1), (-30, 10), (-5, 100), (-100, 1000)])
+@pytest.mark.parametrize("units", [None, u.m, u.electron, u.DN])
+def test_generate_array_float32(size, min, max, units):
+    t_min, t_max = _float32_min_max(min, max)
+
+    value = random_utils.generate_array_float32(size=size, min=min, max=max, units=units)
+    assert isinstance(value, np.ndarray)
+    assert value.dtype == np.float32
+    assert value.shape == size
+
+    if units is not None:
+        assert isinstance(value, u.Quantity)
+        assert value.unit == units
+        val = value.value
+    else:
+        val = value
+    assert (t_min <= val).all()
+    assert (val <= t_max).all()
+
+
+def _uint8_min_max(min, max):
+    if min is None:
+        min = np.iinfo("uint8").min
+    if max is None:
+        max = np.iinfo("uint8").max
+
+    return min, max
+
+
+@pytest.mark.parametrize("size", [(4096, 4096), (2048, 2048), (1024, 1024), (512, 512), (256, 256)])
+@pytest.mark.parametrize("min, max", [(None, None), (0, 1), (5, 10), (10, 100), (100, 255)])
+@pytest.mark.parametrize("units", [None, u.m, u.electron, u.DN])
+def test_generate_array_uint8(size, min, max, units):
+    t_min, t_max = _uint8_min_max(min, max)
+
+    value = random_utils.generate_array_uint8(size=size, min=min, max=max, units=units)
+    assert isinstance(value, np.ndarray)
+    assert value.dtype == np.uint8
+    assert value.shape == size
+
+    if units is not None:
+        assert isinstance(value, u.Quantity)
+        assert value.unit == units
+        val = value.value
+    else:
+        val = value
+    assert (t_min <= val).all()
+    assert (val <= t_max).all()
+
+
+def _uint16_min_max(min, max):
+    if min is None:
+        min = np.iinfo("uint16").min
+    if max is None:
+        max = np.iinfo("uint16").max
+
+    return min, max
+
+
+@pytest.mark.parametrize("size", [(4096, 4096), (2048, 2048), (1024, 1024), (512, 512), (256, 256)])
+@pytest.mark.parametrize("min, max", [(None, None), (0, 1), (5, 10), (10, 100), (100, 1000)])
+@pytest.mark.parametrize("units", [None, u.m, u.electron, u.DN])
+def test_generate_array_uint16(size, min, max, units):
+    t_min, t_max = _uint16_min_max(min, max)
+
+    value = random_utils.generate_array_uint16(size=size, min=min, max=max, units=units)
+    assert isinstance(value, np.ndarray)
+    assert value.dtype == np.uint16
+    assert value.shape == size
+
+    if units is not None:
+        assert isinstance(value, u.Quantity)
+        assert value.unit == units
+        val = value.value
+    else:
+        val = value
+    assert (t_min <= val).all()
+    assert (val <= t_max).all()
+
+
+def _uint32_min_max(min, max):
+    if min is None:
+        min = np.iinfo("uint32").min
+    if max is None:
+        max = np.iinfo("uint32").max
+
+    return min, max
+
+
+@pytest.mark.parametrize("size", [(4096, 4096), (2048, 2048), (1024, 1024), (512, 512), (256, 256)])
+@pytest.mark.parametrize("min, max", [(None, None), (0, 1), (5, 10), (10, 100), (100, 1000)])
+@pytest.mark.parametrize("units", [None, u.m, u.electron, u.DN])
+def test_generate_array_uint32(size, min, max, units):
+    t_min, t_max = _uint32_min_max(min, max)
+
+    value = random_utils.generate_array_uint32(size=size, min=min, max=max, units=units)
+    assert isinstance(value, np.ndarray)
+    assert value.dtype == np.uint32
+    assert value.shape == size
+
+    if units is not None:
+        assert isinstance(value, u.Quantity)
+        assert value.unit == units
+        val = value.value
+    else:
+        val = value
+    assert (t_min <= val).all()
+    assert (val <= t_max).all()
+
+
+def test_generate_exposure_type():
+    t_values = [
+        "WFI_DARK",
+        "WFI_FLAT",
+        "WFI_GRISM",
+        "WFI_IMAGE",
+        "WFI_PRISM",
+        "WFI_WFSC",
+    ]
+    for _ in range(100):
+        value = random_utils.generate_exposure_type()
+        assert isinstance(value, str)
+        assert value in t_values
+
+
+def test_generate_detector():
+    t_values = [
+        "WFI01",
+        "WFI02",
+        "WFI03",
+        "WFI04",
+        "WFI05",
+        "WFI06",
+        "WFI07",
+        "WFI08",
+        "WFI09",
+        "WFI10",
+        "WFI11",
+        "WFI12",
+        "WFI13",
+        "WFI14",
+        "WFI15",
+        "WFI16",
+        "WFI17",
+        "WFI18",
+    ]
+    for _ in range(100):
+        value = random_utils.generate_detector()
+        assert isinstance(value, str)
+        assert value in t_values
+
+
+def test_generate_optical_element():
+    t_values = [
+        "F062",
+        "F087",
+        "F106",
+        "F129",
+        "F146",
+        "F158",
+        "F184",
+        "F213",
+        "GRISM",
+        "PRISM",
+        "DARK",
+    ]
+    for _ in range(100):
+        value = random_utils.generate_optical_element()
+        assert isinstance(value, str)
+        assert value in t_values
+
+
+def test_generate_software_version():
+    for _ in range(100):
+        value = random_utils.generate_software_version()
+        assert isinstance(value, str)
+        pattern = re.compile(r"([0-9]+)\.([0-9]+)\.([0-9]+)")
+        assert pattern.match(value)
+
+        ints = value.split(".")
+        ints = np.array([int(i) for i in ints])
+        assert (0 <= ints).all()
+        assert (ints <= 100).all()

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -115,19 +115,30 @@ def test_generate_positive_int(max):
 
 
 @pytest.mark.parametrize("choices", [[1, 2, 3], ["a", "b", "c"], [1, "a", 2, "b", 3, "c"]])
-def test_generate_choice(choices):
-    value = random_utils.generate_choice(*choices)
-    assert value in choices
+@pytest.mark.parametrize("unpack", [True, False])
+def test_generate_choice(choices, unpack):
+    for _ in range(50):
+        if unpack:
+            value = random_utils.generate_choice(*choices)
+        else:
+            value = random_utils.generate_choice(choices)
+        assert value in choices
 
 
 @pytest.mark.parametrize("choices", [[1, 2, 3], ["a", "b", "c"], [1, "a", 2, "b", 3, "c"]])
 @pytest.mark.parametrize("size", [2, 3, 4, 5])
-def test_generate_choices(choices, size):
-    value = random_utils.generate_choices(*choices, k=size)
-    assert isinstance(value, list)
-    assert len(value) == size
-    for v in value:
-        assert v in choices
+@pytest.mark.parametrize("unpack", [True, False])
+def test_generate_choices(choices, size, unpack):
+    for _ in range(50):
+        if unpack:
+            value = random_utils.generate_choices(*choices, k=size)
+        else:
+            value = random_utils.generate_choices(choices, k=size)
+
+        assert isinstance(value, list)
+        assert len(value) == size
+        for v in value:
+            assert v in choices
 
 
 @pytest.mark.parametrize("prefix", ["", "this", "is", "a", "test"])


### PR DESCRIPTION
Refactor's `random_utils` to only use `numpy.random` for random number generation, and enable users to seed random numbers.

Fixes #144