### PR TITLE
Remove the `source_type_apt` keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
   catching ``ResourceWarning`` s. [#142]
 
-- Remove ``source_target_apt`` from ``target-1.0.0`` related datamodels. [#152]
+- Remove ``source_type_apt`` from ``target-1.0.0`` related datamodels. [#152]
 
 0.14.2 (2023-03-31)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
   catching ``ResourceWarning`` s. [#142]
 
+- Remove ``source_target_apt`` from ``target-1.0.0`` related datamodels. [#152]
+
 0.14.2 (2023-03-31)
 ===================
 

--- a/docs/roman_datamodels/datamodels/general_structure.rst
+++ b/docs/roman_datamodels/datamodels/general_structure.rst
@@ -449,7 +449,6 @@ of meta will consist of the same attributes with few variations between data fil
     │ │ ├─proper_motion_epoch (str): J2000 # Target proper motion epoch
     │ │ ├─proposer_ra (float): 84.675 # Proposer's target RA
     │ │ ├─proposer_dec (float): -69.1 # Proposer's target Dec
-    │ │ ├─source_type_apt (str): EXTENDED # Source type from APT (point/extended)
     │ │ └─source_type (str): EXTENDED # Source type used for calibration
     │ ├─telescope (str): ROMAN
     │ ├─velocity_aberration (VelocityAberration) # Velocity aberration correction information

--- a/src/roman_datamodels/maker_utils.py
+++ b/src/roman_datamodels/maker_utils.py
@@ -273,7 +273,6 @@ def mk_target():
     targ["proper_motion_epoch"] = NOSTR
     targ["proposer_ra"] = NONUM
     targ["proposer_dec"] = NONUM
-    targ["source_type_apt"] = "POINT"
     targ["source_type"] = "POINT"
     return targ
 

--- a/src/roman_datamodels/mktest.py
+++ b/src/roman_datamodels/mktest.py
@@ -159,7 +159,6 @@ def mk_level2_image(filepath, outfilepath):
     targ["proper_motion_epoch"] = NOSTR
     targ["proposer_ra"] = NONUM
     targ["proposer_dec"] = NONUM
-    targ["source_type_apt"] = "POINT"  # qqqq
     targ["source_type"] = "POINT"  # qqqq
     for key in imeta["target"].keys():
         targ[key] = imeta["target"][key]

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -1135,7 +1135,6 @@ def create_target(**kwargs):
         "ra": random_utils.generate_angle_degrees(),
         "ra_uncertainty": random_utils.generate_positive_float(),
         "source_type": random_utils.generate_choice("EXTENDED", "POINT", "UNKNOWN"),
-        "source_type_apt": random_utils.generate_choice("EXTENDED", "POINT", "UNKNOWN"),
         "type": random_utils.generate_choice("FIXED", "MOVING", "GENERIC"),
     }
     raw.update(kwargs)


### PR DESCRIPTION
spacetelescope/rad#206 removed `source_type_apt` from the `target-1.0.0` schema. This change was never made in `roman_datamodels` and was discovered in issue #151.

This PR is the matching PR to spacetelescope/rad#206 to remove `source_type_apt` from `roman_datamodels`