### PR TITLE
Fix skipped test

### DIFF
--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -653,7 +653,6 @@ def create_guidestar(**kwargs):
         "gs_ura": random_utils.generate_positive_float(),
         "gw_id": random_utils.generate_string("ID ", 20),
         "gw_fgs_mode": "WSM-ACQ-2",
-        "gw_science_file_source": random_utils.generate_string("r", 20) + ".asdf",
         "gs_id": random_utils.generate_string("GS ", 20),
         "gs_catalog_version": random_utils.generate_string("GSC", 20),
         "gw_window_xsize": 16,

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -27,7 +27,7 @@ def test_instance_valid(node_class):
         af.validate()
 
 
-@pytest.mark.parametrize("node_class", [c for c in stnode.NODE_CLASSES if isinstance(c, stnode.TaggedObjectNode)])
+@pytest.mark.parametrize("node_class", [c for c in stnode.NODE_CLASSES if issubclass(c, stnode.TaggedObjectNode)])
 def test_no_extra_fields(node_class, manifest):
     instance = create_node(node_class)
     instance_keys = set(instance.keys())


### PR DESCRIPTION
There is one skipped test in `roman_datamodels` which was being skipped due to a parameterization bug.

This PR corrects that parameterization bug, but cannot be merged until the issues in #151 are addressed.

Fixes #151. 