### PR TITLE
Remove `meta` from `pixelarea` factory.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
 
 - Add Changelog checking CI. [#161]
 
+- Remove ``meta`` from ``pixelarea-1.0.0`` related datamodels. [#157]
+
 0.14.2 (2023-03-31)
 ===================
 

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -841,8 +841,6 @@ def create_pixelarea(**kwargs):
         "area": random_utils.generate_array_float32(min=0.0),
     }
     raw.update(kwargs)
-    raw["meta"] = {}
-    raw["meta"]["photometry"] = {"pixelarea_steradians": 0.3 * u.sr, "pixelarea_arcsecsq": 0.3 * u.arcsec**2}
 
     return stnode.Pixelarea(raw)
 


### PR DESCRIPTION
Given https://github.com/spacetelescope/rad/pull/235#pullrequestreview-1390310337, it the [`pixelarea-1.0.0` schema](https://github.com/spacetelescope/rad/blob/main/src/rad/resources/schemas/pixelarea-1.0.0.yaml) is required, however #151 indicates there is an issue between `pixelarea-1.0.0`'s schema and `roman_datamodels`.

The next plausible fix for this issue is removing the `meta` field added to the `create_pixelarea` function in `factories.py`. This may have been added by mistake in #64.

If this is not a viable fix, then a `meta` field needs to be added to the [`pixelarea-1.0.0` schema](https://github.com/spacetelescope/rad/blob/main/src/rad/resources/schemas/pixelarea-1.0.0.yaml).

Closes spacetelescope/rad#235.