### PR TITLE
Disable `PytestUnraisableExceptionWarning` errors due to #150

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ filterwarnings = [
     # Sometimes turning ResourceWarnings into errors creates an unraisable exception
     #   e.g. when pyest catches another exception, this will block the turning of
     #        ResourceWarnings into errors
-    "error::pytest.PytestUnraisableExceptionWarning",
+    # Disabled until issue #150 is resolved.
+    # "error::pytest.PytestUnraisableExceptionWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
I have seen several instances of the error from #150 come up in the CI. See https://github.com/spacetelescope/roman_datamodels/issues/150#issuecomment-1513842280. The CI log doesn't show the entire log, but I see the error if I watch the job and it occurs.

Since we are getting this flakiness due to the turning `PytestUnraisableExceptionWarning` into errors, I am disabling this feature for now. If anyone happens to notice such a warning output during their tests, please comment with your configuration on #150.