### PR TITLE
Construct ModelContainer from a Sequence

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@
 
 - Bugfix for ``photmjsr`` not being able to be set or validated properly. [#170]
 
+- Add support for model containers constructed from ``Iterable`` [#164]
+
 
 0.14.2 (2023-03-31)
 ===================

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -405,7 +405,7 @@ class ModelContainer(Sequence):
         if init is None:
             # don't populate container
             pass
-        elif isinstance(init, list):
+        elif isinstance(init, (list, Sequence)):
             # only append list items to self._models if all items are either
             # strings (i.e. path to an ASDF file) or instances of DataModel
             is_all_string = all(isinstance(x, str) for x in init)

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -13,7 +13,7 @@ import os.path
 import sys
 import warnings
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Iterable
 from pathlib import PurePath
 
 import asdf
@@ -337,7 +337,7 @@ class GuidewindowModel(DataModel):
     pass
 
 
-class ModelContainer(Sequence):
+class ModelContainer(Iterable):
     """
     A container for holding DataModels.
 
@@ -405,7 +405,7 @@ class ModelContainer(Sequence):
         if init is None:
             # don't populate container
             pass
-        elif isinstance(init, (list, Sequence)):
+        elif isinstance(init, Iterable):
             # only append list items to self._models if all items are either
             # strings (i.e. path to an ASDF file) or instances of DataModel
             is_all_string = all(isinstance(x, str) for x in init)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -778,3 +778,14 @@ def test_model_validate_without_save():
 
     with pytest.raises(ValidationError):
         m.validate()
+
+
+def test_modelcontainer_init():
+    img = utils.mk_level1_science_raw()
+    m = datamodels.ImageModel(img)
+    mc1 = datamodels.ModelContainer([m])
+
+    # initialize with an instance of ModelContainer
+    mc2 = datamodels.ModelContainer(mc1)
+
+    assert len(mc1) == len(mc2)


### PR DESCRIPTION
It's occasionally convenient to construct a `ModelContainer` with an `init` arg that may be either (1) a string path/`DataModel`; or also (2) an existing `ModelContainer` instance. (1) is currently supported in `roman_datamodels` and `jwst`, while (2) [is supported in `jwst`](https://github.com/spacetelescope/jwst/blob/e1a3fa820d98129e07614d290dff9d9db60a1586/jwst/datamodels/container.py#L165) but not `roman_datamodels`. 

In this tiny PR, I've allowed rdm `ModelContainer`s to be constructed from `list`s or subclasses of `collections.abc.Sequence`, so that the expected behavior is recovered.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
