### PR TITLE
Fix bug in amp33 shape introduced in #111

### DIFF
--- a/src/roman_datamodels/maker_utils.py
+++ b/src/roman_datamodels/maker_utils.py
@@ -1020,7 +1020,7 @@ def mk_ramp(shape=(8, 4096, 4096), filepath=None):
     ramp["dq_border_ref_pix_bottom"] = np.zeros((4, shape[2]), dtype=np.uint32)
 
     # add amp 33 ref pixel array
-    ramp["amp33"] = u.Quantity(np.full(shape, 1.0, dtype=np.uint16), u.DN, dtype=np.uint16)
+    ramp["amp33"] = u.Quantity(np.zeros((shape[0], shape[1], 128), dtype=np.uint16), u.DN, dtype=np.uint16)
 
     ramp["data"] = u.Quantity(np.full(shape, 1.0, dtype=np.float32), u.DN, dtype=np.float32)
     ramp["pixeldq"] = np.zeros(shape[1:], dtype=np.uint32)


### PR DESCRIPTION
In #111, a small bug was introduced in the shape of the `amp33` shape for the `ramp` model. This PR corrects this.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
