### PR TITLE
RCAL-560: Allow for global validation suppression

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,9 @@
 
 - Bugfix for ``photmjsr`` not being able to be set or validated properly. [#170]
 
+- Add ability to turn off data validation via an environment variable. [#173]
 - Add support for model containers constructed from ``Iterable`` [#164]
+
 
 
 0.14.2 (2023-03-31)

--- a/docs/roman_datamodels/datamodels/using_datamodels.rst
+++ b/docs/roman_datamodels/datamodels/using_datamodels.rst
@@ -128,7 +128,6 @@ page::
 
 	Use this feature at your own risk!
 
-	You have been warned!
 
 	If you are having problems due to validation errors, please contact the the
 	Roman team for help via raising a GitHub issue or sending us an email. We

--- a/docs/roman_datamodels/datamodels/using_datamodels.rst
+++ b/docs/roman_datamodels/datamodels/using_datamodels.rst
@@ -94,3 +94,42 @@ page::
 	42
 	>>> dm2.meta.exposure_start_time_mjd
 	60000.0
+
+
+.. note::
+
+	All datamodels have built in validation against the defining schemas.
+	This means that if you try to assign a value that is not allowed according
+	to one of these schemas, you will get an error. This is a good thing!
+
+	If you are getting validation errors consult the corresponding schema in
+	``rad`` to se what is allowed. If you think the schema is wrong, or you
+	continue to have issues, please contact the Roman team for help.
+
+	As a method of last resort, if you wish to turn off validation, you can do
+	so by setting the environment variable ``ROMAN_VALIDATE`` to false. This is
+	not recommended!
+
+	.. code-block:: bash
+
+		export ROMAN_VALIDATE=false
+
+	To restore validation, set the environment variable to ``true`` or unset it.
+
+
+.. warning::
+
+	We strongly recommend against ever turning off validation. This can lead to
+	a variety of unrecoverable problems. Such as not being able to write out
+	your datamodel or not being able to read it back in. Or worse, the data in
+	the datamodel may not be compatible with operations intended to run on that
+	datamodel. The Roman team will not assist with fixing such problems which
+	occur when validation is turned off.
+
+	Use this feature at your own risk!
+
+	You have been warned!
+
+	If you are having problems due to validation errors, please contact the the
+	Roman team for help via raising a GitHub issue or sending us an email. We
+	will do our best to assist you.

--- a/docs/roman_datamodels/datamodels/using_datamodels.rst
+++ b/docs/roman_datamodels/datamodels/using_datamodels.rst
@@ -108,7 +108,8 @@ page::
 
 	As a method of last resort, if you wish to turn off validation, you can do
 	so by setting the environment variable ``ROMAN_VALIDATE`` to false. This is
-	not recommended!
+	not recommended! Moreover, this feature will be explicitly removed when the
+	datamodels stabilize.
 
 	.. code-block:: bash
 
@@ -128,7 +129,6 @@ page::
 
 	Use this feature at your own risk!
 
-
 	If you are having problems due to validation errors, please contact the the
-	Roman team for help via raising a GitHub issue or sending us an email. We
-	will do our best to assist you.
+	Roman team for help via raising a GitHub issue. We will do our best to assist
+	you.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ test = [
     'pytest >=6.0.0',
     'pytest-doctestplus',
     'pytest-doctestplus >=0.10.0',
+    'pytest-env >= 0.8'
 ]
 aws = [
     'stsci-aws-utils >= 0.1.2',
@@ -76,6 +77,10 @@ filterwarnings = [
     #        ResourceWarnings into errors
     # Disabled until issue #150 is resolved.
     # "error::pytest.PytestUnraisableExceptionWarning",
+]
+env = [
+    "ROMAN_VALIDATE=true",
+    "ROMAN_STRICT_VALIDATION=true",
 ]
 
 [tool.coverage.run]

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -85,9 +85,10 @@ class DataModel:
             self._asdf = asdffile
             self._instance = asdffile.tree["roman"]
         elif isinstance(init, stnode.TaggedObjectNode):
-            self._instance = init
-            asdffile = asdf.AsdfFile()
-            asdffile.tree = {"roman": init}
+            with validate.nuke_validation():
+                self._instance = init
+                asdffile = asdf.AsdfFile()
+                asdffile.tree = {"roman": init}
         else:
             raise OSError("Argument does not appear to be an ASDF file or TaggedObjectNode.")
         self._asdf = asdffile
@@ -169,18 +170,18 @@ class DataModel:
         return output_path
 
     def open_asdf(self, init=None, **kwargs):
-        if isinstance(init, str):
-            asdffile = asdf.open(init)
-        else:
-            asdffile = asdf.AsdfFile(init)
-        return asdffile
+        with validate.nuke_validation():
+            if isinstance(init, str):
+                asdffile = asdf.open(init)
+            else:
+                asdffile = asdf.AsdfFile(init)
+            return asdffile
 
     def to_asdf(self, init, *args, **kwargs):
-        # self.on_save(init)
-
-        asdffile = self.open_asdf(**kwargs)
-        asdffile.tree = {"roman": self._instance}
-        asdffile.write_to(init, *args, **kwargs)
+        with validate.nuke_validation():
+            asdffile = self.open_asdf(**kwargs)
+            asdffile.tree = {"roman": self._instance}
+            asdffile.write_to(init, *args, **kwargs)
 
     def get_primary_array_name(self):
         """
@@ -613,46 +614,47 @@ def open(init, memmap=False, target=None, **kwargs):
     -------
     `DataModel`
     """
-    file_to_close = None
-    if target is not None:
-        if not issubclass(target, DataModel):
-            raise ValueError("Target must be a subclass of DataModel")
-    # Temp fix to catch JWST args before being passed to asdf open
-    if "asn_n_members" in kwargs:
-        del kwargs["asn_n_members"]
-    if isinstance(init, asdf.AsdfFile):
-        asdffile = init
-    elif isinstance(init, DataModel):
+    with validate.nuke_validation():
+        file_to_close = None
         if target is not None:
-            if not isinstance(init, target):
-                raise ValueError("First argument is not an instance of target")
-            else:
-                return init
-        # Copy the object so it knows not to close here
-        return init.copy()
-    else:
-        try:
-            kwargs["copy_arrays"] = not memmap
-            asdffile = asdf.open(init, **kwargs)
-            file_to_close = asdffile
-        except ValueError:
-            raise TypeError("Open requires a filepath, file-like object, or Roman datamodel")
-        if AsdfInFits is not None and isinstance(asdffile, AsdfInFits):
-            if file_to_close is not None:
-                file_to_close.close()
-            raise TypeError("Roman datamodels does not accept FITS files or objects")
-    modeltype = type(asdffile.tree["roman"])
-    if modeltype in model_registry:
-        rmodel = model_registry[modeltype](asdffile, **kwargs)
-        if target is not None:
-            if not issubclass(rmodel.__class__, target):
+            if not issubclass(target, DataModel):
+                raise ValueError("Target must be a subclass of DataModel")
+        # Temp fix to catch JWST args before being passed to asdf open
+        if "asn_n_members" in kwargs:
+            del kwargs["asn_n_members"]
+        if isinstance(init, asdf.AsdfFile):
+            asdffile = init
+        elif isinstance(init, DataModel):
+            if target is not None:
+                if not isinstance(init, target):
+                    raise ValueError("First argument is not an instance of target")
+                else:
+                    return init
+            # Copy the object so it knows not to close here
+            return init.copy()
+        else:
+            try:
+                kwargs["copy_arrays"] = not memmap
+                asdffile = asdf.open(init, **kwargs)
+                file_to_close = asdffile
+            except ValueError:
+                raise TypeError("Open requires a filepath, file-like object, or Roman datamodel")
+            if AsdfInFits is not None and isinstance(asdffile, AsdfInFits):
                 if file_to_close is not None:
                     file_to_close.close()
-                raise ValueError("Referenced ASDF file model type is not subclass of target")
+                raise TypeError("Roman datamodels does not accept FITS files or objects")
+        modeltype = type(asdffile.tree["roman"])
+        if modeltype in model_registry:
+            rmodel = model_registry[modeltype](asdffile, **kwargs)
+            if target is not None:
+                if not issubclass(rmodel.__class__, target):
+                    if file_to_close is not None:
+                        file_to_close.close()
+                    raise ValueError("Referenced ASDF file model type is not subclass of target")
+            else:
+                return rmodel
         else:
-            return rmodel
-    else:
-        return DataModel(asdffile, **kwargs)
+            return DataModel(asdffile, **kwargs)
 
 
 model_registry = {

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -23,7 +23,7 @@ from astropy.time import Time
 from astropy.units import Unit  # noqa: F401
 
 from .stuserdict import STUserDict as UserDict
-from .validate import ValidationWarning, _check_type, _error_message
+from .validate import ValidationWarning, _check_type, _error_message, will_strict_validate, will_validate
 
 if sys.version_info < (3, 9):
     import importlib_resources
@@ -32,7 +32,6 @@ else:
 
 
 __all__ = [
-    "set_validate",
     "WfiMode",
     "NODE_CLASSES",
     "CalLogs",
@@ -43,15 +42,6 @@ __all__ = [
     "TaggedListNode",
     "TaggedScalarNode",
 ]
-
-
-validate = True
-strict_validation = True
-
-
-def set_validate(value):
-    global validate
-    validate = bool(value)
 
 
 validator_callbacks = HashableDict(asdfschema.YAML_VALIDATORS)
@@ -94,7 +84,7 @@ def _check_value(value, schema, validator_context):
 
 def _validate(attr, instance, schema, ctx):
     tagged_tree = yamlutil.custom_tree_to_tagged_tree(instance, ctx)
-    return _value_change(attr, tagged_tree, schema, False, strict_validation, ctx)
+    return _value_change(attr, tagged_tree, schema, False, will_strict_validate(), ctx)
 
 
 def _get_schema_for_property(schema, attr):
@@ -173,7 +163,7 @@ class DNode(UserDict):
         if key[0] != "_":
             value = self._convert_to_scalar(key, value)
             if key in self._data:
-                if validate:
+                if will_validate():
                     schema = _get_schema_for_property(self._schema(), key)
 
                     if schema == {} or _validate(key, value, schema, self.ctx):

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -2,6 +2,7 @@
 Functions that support validation of model changes
 """
 
+import os
 import warnings
 
 import jsonschema
@@ -14,6 +15,27 @@ __all__ = [
     "ValidationWarning",
     "value_change",
 ]
+
+ROMAN_VALIDATE = "ROMAN_VALIDATE"
+ROMAN_STRICT_VALIDATION = "ROMAN_STRICT_VALIDATION"
+
+
+def will_validate():
+    """
+    Determine if validation is enabled.
+    """
+    var = os.getenv(ROMAN_VALIDATE)
+
+    return var is None or var.lower() in ["true", "yes", "1"]
+
+
+def will_strict_validate():
+    """
+    Determine if strict validation is enabled.
+    """
+    var = os.getenv(ROMAN_STRICT_VALIDATION)
+
+    return var is None or var.lower() in ["true", "yes", "1"]
 
 
 class ValidationWarning(Warning):

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -4,6 +4,7 @@ Functions that support validation of model changes
 
 import os
 import warnings
+from textwrap import dedent
 
 import jsonschema
 from asdf import AsdfFile
@@ -20,13 +21,52 @@ ROMAN_VALIDATE = "ROMAN_VALIDATE"
 ROMAN_STRICT_VALIDATION = "ROMAN_STRICT_VALIDATION"
 
 
+def validation_is_disabled():
+    MESSAGE = dedent(
+        """\
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            !!!! VALIDATION HAS BEEN DISABLED        !!!!!
+            !!!! THIS is EXTREMELY DANGEROUS AND MAY !!!!!
+            !!!! RESULT IN SITUATIONS WHERE DATA     !!!!!
+            !!!! CANNOT BE WRITTEN AND/OR READ!      !!!!!
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            We strongly suggest that you do not turn off
+            validation. If you do, you do so at your own
+            risk. YOU HAVE BEEN WARNED!
+
+            To turn validation back on, unsent the
+            environment variable ROMAN_VALIDATE or set it
+            to "true".
+        """
+    )
+    warnings.warn(MESSAGE, ValidationWarning)
+
+
 def will_validate():
     """
     Determine if validation is enabled.
     """
     var = os.getenv(ROMAN_VALIDATE)
 
-    return var is None or var.lower() in ["true", "yes", "1"]
+    if not (validate := var is None or var.lower() in ["true", "yes", "1"]):
+        validation_is_disabled()
+
+    return validate
+
+
+def strict_validation_is_disabled():
+    MESSAGE = dedent(
+        """\
+            Strict validation has been disabled. This may result
+            in validation errors arising when writing data.
+
+            To turn strict validation back on, unset the
+            environment variable ROMAN_STRICT_VALIDATION or set
+            it to "true".
+        """
+    )
+
+    warnings.warn(MESSAGE, ValidationWarning)
 
 
 def will_strict_validate():
@@ -35,7 +75,10 @@ def will_strict_validate():
     """
     var = os.getenv(ROMAN_STRICT_VALIDATION)
 
-    return var is None or var.lower() in ["true", "yes", "1"]
+    if not (validate := var is None or var.lower() in ["true", "yes", "1"]):
+        strict_validation_is_disabled()
+
+    return validate
 
 
 class ValidationWarning(Warning):

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -25,12 +25,12 @@ ROMAN_STRICT_VALIDATION = "ROMAN_STRICT_VALIDATION"
 def validation_is_disabled():
     MESSAGE = dedent(
         """\
-            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            !!!! VALIDATION HAS BEEN DISABLED        !!!!!
-            !!!! THIS is EXTREMELY DANGEROUS AND MAY !!!!!
-            !!!! RESULT IN SITUATIONS WHERE DATA     !!!!!
-            !!!! CANNOT BE WRITTEN AND/OR READ!      !!!!!
-            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            !!!! VALIDATION HAS BEEN DISABLED GLOBALLY !!!!!
+            !!!! THIS is EXTREMELY DANGEROUS AND MAY   !!!!!
+            !!!! RESULT IN SITUATIONS WHERE DATA       !!!!!
+            !!!! CANNOT BE WRITTEN AND/OR READ!        !!!!!
+            !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             We strongly suggest that you do not turn off
             validation. If you do, you do so at your own
             risk. YOU HAVE BEEN WARNED!

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -4,6 +4,7 @@ Functions that support validation of model changes
 
 import os
 import warnings
+from contextlib import contextmanager
 from textwrap import dedent
 
 import jsonschema
@@ -153,3 +154,27 @@ def _error_message(path, error):
     errfmt = "While validating {} the following error occurred:\n{}"
     errmsg = errfmt.format(name, error)
     return errmsg
+
+
+@contextmanager
+def nuke_validation():
+    """
+    Context manager to temporarily turn all ASDF validation off.
+    """
+
+    # Don't nuke validation if we will validate
+    if will_validate():
+        yield
+        return
+
+    # NUKE VALIDATION
+    validate = asdf_schema.validate
+
+    def _no_validation_for_you(*args, **kwargs):
+        pass
+
+    asdf_schema.validate = _no_validation_for_you
+    yield
+
+    # RESTORE VALIDATION
+    asdf_schema.validate = validate

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -162,19 +162,30 @@ def nuke_validation():
     Context manager to temporarily turn all ASDF validation off.
     """
 
-    # Don't nuke validation if we will validate
+    # Don't nuke validation if we validation is enabled
     if will_validate():
         yield
         return
 
-    # NUKE VALIDATION
+    ########################### NUKE VALIDATION ###############################
+    # This is a horrible hack to disable validation, and is quite dangerous.  #
+    # Monkey patching like this is a bad idea, but it is the only way to      #
+    # cleanly turn off validation in ASDF, without refactoring large portions #
+    # of the ASDF code base. The ASDF package has no intention of supporting  #
+    # turning off validation for writing files as this is a bad idea. So,     #
+    # we are left with this.                                                  #
+    ###########################################################################
+
+    # Save validation function to restore it later
     validate = asdf_schema.validate
 
+    # Monkey patch validation with a function that does nothing
     def _no_validation_for_you(*args, **kwargs):
         pass
 
     asdf_schema.validate = _no_validation_for_you
+
     yield
 
-    # RESTORE VALIDATION
+    # Restore validation function upon exit of the context
     asdf_schema.validate = validate

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -5,7 +5,7 @@ import asdf
 import astropy.units as u
 import pytest
 
-from roman_datamodels import stnode, validate
+from roman_datamodels import datamodels, stnode, validate
 from roman_datamodels.testing import assert_node_equal, create_node, factories
 
 
@@ -144,28 +144,29 @@ def test_set_pattern_properties():
 def env_var(request):
     assert os.getenv(validate.ROMAN_VALIDATE) == "true"
     os.environ[validate.ROMAN_VALIDATE] = request.param
-    yield request.param
+    yield request.param, request.param.lower() in ["true", "yes", "1"]
     os.environ[validate.ROMAN_VALIDATE] = "true"
 
 
 def test_will_validate(env_var):
     # Test the fixture passed the value of the environment variable
-    assert os.getenv(validate.ROMAN_VALIDATE) == env_var
+    value = env_var[0]
+    assert os.getenv(validate.ROMAN_VALIDATE) == value
 
     # Test the validate property
-    truth = env_var.lower() in ["true", "yes", "1"]
+    truth = env_var[1]
     context = nullcontext() if truth else pytest.warns(validate.ValidationWarning)
 
     with context:
         assert validate.will_validate() is truth
 
     # Try all uppercase
-    os.environ[validate.ROMAN_VALIDATE] = env_var.upper()
+    os.environ[validate.ROMAN_VALIDATE] = value.upper()
     with context:
         assert validate.will_validate() is truth
 
     # Try all lowercase
-    os.environ[validate.ROMAN_VALIDATE] = env_var.lower()
+    os.environ[validate.ROMAN_VALIDATE] = value.lower()
     with context:
         assert validate.will_validate() is truth
 
@@ -173,6 +174,59 @@ def test_will_validate(env_var):
     del os.environ[validate.ROMAN_VALIDATE]
     assert os.getenv(validate.ROMAN_VALIDATE) is None
     assert validate.will_validate() is True
+
+
+def test_nuke_validation(env_var, tmp_path):
+    context = pytest.raises(asdf.ValidationError) if env_var[1] else pytest.warns(validate.ValidationWarning)
+
+    # Create a broken DNode object
+    mdl = factories.create_wfi_img_photom_ref()
+    mdl["phot_table"] = "THIS IS NOT VALID"
+    with context:
+        datamodels.WfiImgPhotomRefModel(mdl)
+
+    # __setattr__ a broken value
+    mdl = factories.create_wfi_img_photom_ref()
+    with context:
+        mdl.phot_table = "THIS IS NOT VALID"
+
+    # Break model without outside validation
+    with nullcontext() if env_var[1] else pytest.warns(validate.ValidationWarning):
+        mdl = datamodels.WfiImgPhotomRefModel(factories.create_wfi_img_photom_ref())
+    mdl._instance["phot_table"] = "THIS IS NOT VALID"
+
+    # Broken can be written to file
+    broken_save = tmp_path / "broken_save.asdf"
+    with context:
+        mdl.save(broken_save)
+    assert os.path.isfile(broken_save) is not env_var[1]
+
+    broken_to_asdf = tmp_path / "broken_to_asdf.asdf"
+    with context:
+        mdl.to_asdf(broken_to_asdf)
+    assert os.path.isfile(broken_to_asdf) is not env_var[1]
+
+    # Create a broken file for reading if needed
+    if env_var[1]:
+        os.environ[validate.ROMAN_VALIDATE] = "false"
+        with pytest.warns(validate.ValidationWarning):
+            mdl.save(broken_save)
+            mdl.to_asdf(broken_to_asdf)
+        os.environ[validate.ROMAN_VALIDATE] = env_var[0]
+
+    # Read broken files with datamodel object
+    with context:
+        datamodels.WfiImgPhotomRefModel(broken_save)
+    with context:
+        datamodels.WfiImgPhotomRefModel(broken_to_asdf)
+
+    # True to read broken files with rdm.open
+    with context:
+        with datamodels.open(broken_save):
+            pass
+    with context:
+        with datamodels.open(broken_to_asdf):
+            pass
 
 
 @pytest.fixture(scope="function", params=["true", "yes", "1", "True", "Yes", "TrUe", "YeS", "foo", "Bar", "BaZ"])

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import nullcontext
 
 import asdf
 import astropy.units as u
@@ -153,15 +154,20 @@ def test_will_validate(env_var):
 
     # Test the validate property
     truth = env_var.lower() in ["true", "yes", "1"]
-    assert validate.will_validate() is truth
+    context = nullcontext() if truth else pytest.warns(validate.ValidationWarning)
+
+    with context:
+        assert validate.will_validate() is truth
 
     # Try all uppercase
     os.environ[validate.ROMAN_VALIDATE] = env_var.upper()
-    assert validate.will_validate() is truth
+    with context:
+        assert validate.will_validate() is truth
 
     # Try all lowercase
     os.environ[validate.ROMAN_VALIDATE] = env_var.lower()
-    assert validate.will_validate() is truth
+    with context:
+        assert validate.will_validate() is truth
 
     # Remove the environment variable to test the default value
     del os.environ[validate.ROMAN_VALIDATE]
@@ -183,15 +189,20 @@ def test_will_strict_validate(env_strict_var):
 
     # Test the validate property
     truth = env_strict_var.lower() in ["true", "yes", "1"]
-    assert validate.will_strict_validate() is truth
+    context = nullcontext() if truth else pytest.warns(validate.ValidationWarning)
+
+    with context:
+        assert validate.will_strict_validate() is truth
 
     # Try all uppercase
     os.environ[validate.ROMAN_STRICT_VALIDATION] = env_strict_var.upper()
-    assert validate.will_strict_validate() is truth
+    with context:
+        assert validate.will_strict_validate() is truth
 
     # Try all lowercase
     os.environ[validate.ROMAN_STRICT_VALIDATION] = env_strict_var.lower()
-    assert validate.will_strict_validate() is truth
+    with context:
+        assert validate.will_strict_validate() is truth
 
     # Remove the environment variable to test the default value
     del os.environ[validate.ROMAN_STRICT_VALIDATION]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-560](https://jira.stsci.edu/browse/RCAL-560)

<!-- describe the changes comprising this PR here -->
This PR adds a global environment variable which can turn off all validation operations. This has been requested to help
developers deal with times when schemas become out of sync with their development.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
