### PR TITLE
GH178_test_models update guide windown utilities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.15.0 (unreleased)
 ===================
 
+- Updates the maker utilities for guide windows to include gw_science_file_source  [#179]
+
 - Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
   catching ``ResourceWarning`` s. [#142]
 

--- a/src/roman_datamodels/maker_utils.py
+++ b/src/roman_datamodels/maker_utils.py
@@ -1161,6 +1161,7 @@ def mk_guidewindow(shape=(2, 8, 16, 32, 32), filepath=None):
     guidewindow["meta"]["pedestal_resultant_exp_time"] = NONUM
     guidewindow["meta"]["signal_resultant_exp_time"] = NONUM
     guidewindow["meta"]["gw_acq_number"] = NONUM
+    guidewindow["meta"]["gw_science_file_source"] = NOSTR
     guidewindow["meta"]["gw_mode"] = "WIM-ACQ"
     guidewindow["meta"]["gw_window_xstart"] = NONUM
     guidewindow["meta"]["gw_window_ystart"] = NONUM

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -1096,6 +1096,7 @@ def create_guidewindow(**kwargs):
     raw["meta"]["pedestal_resultant_exp_time"] = random_utils.generate_float()
     raw["meta"]["signal_resultant_exp_time"] = random_utils.generate_float()
     raw["meta"]["gw_acq_number"] = random_utils.generate_int()
+    raw["meta"]["gw_science_file_source"] = "filename"
     raw["meta"]["gw_mode"] = "WIM-ACQ"
     raw["meta"]["gw_window_xstart"] = random_utils.generate_positive_int(4000)
     raw["meta"]["gw_window_ystart"] = random_utils.generate_positive_int(4000)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #178 

<!-- describe the changes comprising this PR here -->
This PR updates the maker utilities for guide windows to include gw_science_file_source
the unit tests are passing

pytest tests/
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.11.0, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/ddavis/src/Roman/roman_datamodels
configfile: pyproject.toml
plugins: remotedata-0.4.0, hypothesis-6.75.1, asdf-2.15.0, mock-3.10.0, filter-subpackage-0.1.2, astropy-header-0.2.2, doctestplus-0.12.1, astropy-0.10.0, cov-4.0.0, ci-watson-0.6.1, openfiles-0.5.0, arraydiff-0.5.0
collected 1215 items

tests/test_factories.py ..........................................................................................s                                 [  7%]
tests/test_filetype.py ..                                                                                                                           [  7%]
tests/test_models.py ....................................................                                                                           [ 11%]
tests/test_open.py ........                                                                                                                         [ 12%]
tests/test_random_utils.py ........................................................................................................................ [ 22%]
................................................................................................................................................... [ 34%]
................................................................................................................................................... [ 46%]
................................................................................................................................................... [ 58%]
................................................................................................................................................... [ 70%]
................................................................................................................................................... [ 82%]
................................................................................................................................................... [ 95%]
......                                                                                                                                              [ 95%]
tests/test_stnode.py ..................................................                                                                             [ 99%]
tests/test_stuserdict.py ....                                                                                                                       [100%]

======================================================= 1214 passed, 1 skipped in 94.97s (0:01:34)

Note: the regression tests are failing until we have updated input files from INS

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
