### PR TITLE
Update the pytest `addopts` configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ minversion = 4.6
 doctest_plus = true
 doctest_rst = true
 text_file_format = 'rst'
-addopts = '--show-capture=no'
+addopts = '--color=yes --doctest-rst'
 testpaths = ['tests']
 filterwarnings = [
     # This error replaces pytest-openfiles


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
`roman_datamodels` currently does not capture standard out when running its tests. This was configured off for some reason in the pytest configuration and it makes it annoying for debugging simple issues via print statements.

This PR removes that configuration and adds `--color=yes` so the actions output is colored (if possible) and the `--doctest-rst` flag to actually enable doc-tests (though we currently do not have any, but do have the doctest plugin installed).

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
