### PR TITLE
[CI] disable usage of `pytest-xdist` to mitigate GitHub 143 errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,20 +25,20 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: test-oldestdeps-cov-xdist
+        - linux: test-oldestdeps-cov
           python-version: 3.9
-        - linux: test-xdist
+        - linux: test
           python-version: 3.9
-        - linux: test-xdist
+        - linux: test
           python-version: 3.10
-        - linux: test-xdist
+        - linux: test
           python-version: 3.11
-        - macos: test-xdist
+        - macos: test
           python-version: 3.11
-        - linux: test-cov-xdist
+        - linux: test-cov
           coverage: codecov
   test_upstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: test-rad-xdist
+        - linux: test-rad

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: test-oldestdeps-cov
+        - linux: test-py39-oldestdeps-cov
           python-version: 3.9
-        - linux: test
+        - linux: test-py39
           python-version: 3.9
-        - linux: test
+        - linux: test-py310
           python-version: 3.10
-        - linux: test
+        - linux: test-py311
           python-version: 3.11
-        - macos: test
+        - macos: test-py311
           python-version: 3.11
         - linux: test-cov
           coverage: codecov

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -11,11 +11,11 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       envs: |
-        - macos: test-xdist
+        - macos: test
           python-version: 3.9
-        - macos: test-xdist
+        - macos: test
           python-version: 3.10
-        - macos: test-xdist
+        - macos: test
           python-version: 3.11
-        - linux: test-rad-xdist
-        - linux: test-devdeps-xdist
+        - linux: test-rad
+        - linux: test-devdeps

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -11,11 +11,10 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       envs: |
-        - macos: test
+        - macos: test-py39
           python-version: 3.9
-        - macos: test
+        - macos: test-py310
           python-version: 3.10
-        - macos: test
+        - macos: test-py311
           python-version: 3.11
-        - linux: test-rad
         - linux: test-devdeps


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->


<!-- If this PR closes a GitHub issue, reference it here by its number -->
Fixes CI for #186 

<!-- describe the changes comprising this PR here -->
This PR addresses 143 errors when using `pytest-xdist`, such as in https://github.com/spacetelescope/roman_datamodels/actions/runs/5070907470/jobs/9106607652#step:10:81

**Checklist**
- [ ] ~Added entry in `CHANGES.rst` under the corresponding subsection~
- [x] updated relevant tests
- [ ] ~updated relevant documentation~
- [ ] ~Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/~
