### PR TITLE
Cleanup the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,20 +25,15 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: test-py39-oldestdeps-cov
-          python-version: 3.9
-        - linux: test-py39
-          python-version: 3.9
-        - linux: test-py310
-          python-version: 3.10
-        - linux: test-py311
-          python-version: 3.11
-        - macos: test-py311
-          python-version: 3.11
-        - linux: test-cov
+        - linux: py39-oldestdeps-cov
+        - linux: py39
+        - linux: py310
+        - linux: py311
+        - macos: py311
+        - linux: cov
           coverage: codecov
   test_upstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: test-rad
+        - linux: rad

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -4,11 +4,20 @@ on:
   schedule:
     # Weekly Monday 6AM build
     - cron: "0 0 * * 1"
+  pull_request:
+    # We also want this workflow triggered if the `Weekly CI` label is
+    # added or present when PR is updated
+    types:
+      - synchronize
+      - labeled
+  push:
+    tags: "*"
   workflow_dispatch:
 
 jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    if: (github.repository == 'spacetelescope/roman_datamodels' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     with:
       envs: |
         - macos: py39

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -11,10 +11,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       envs: |
-        - macos: test-py39
-          python-version: 3.9
-        - macos: test-py310
-          python-version: 3.10
-        - macos: test-py311
-          python-version: 3.11
-        - linux: test-devdeps
+        - macos: py39
+        - macos: py310
+        - macos: py311
+        - linux: devdeps


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses the issue noted here: https://github.com/spacetelescope/roman_datamodels/pull/187#issuecomment-1561852480

The `test` option does not have to be passed to tox, `testenv` is defined to be the "default" which is aways used unless otherwise specified. It exists only for cases where you do indeed just want to run the default with no extra options.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
