### PR TITLE
RCAL-484: Update datamodels for reference pixel correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@
 
 - Add ``maker_utils`` for all the datamodels. [#198]
 
+- Update ``roman_datamodels`` to support the new reference file for the
+  reference pixel correction. [#190]
+
 0.15.0 (2023-05-15)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'numpy >=1.20',
     'astropy >=5.0.4',
     # 'rad >=0.15.0',
-    'rad @ git+https://github.com/spacetelescope/rad.git@main',
+    'rad @ git+https://github.com/WilliamJamieson/rad.git@ref_pix#egg=rad',
     'asdf-standard >=1.0.3',
 ]
 dynamic = ['version']

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -635,6 +635,10 @@ class WfiImgPhotomRefModel(DataModel):
     pass
 
 
+class RefpixRefModel(DataModel):
+    pass
+
+
 def open(init, memmap=False, target=None, **kwargs):
     """
     Data model factory function
@@ -724,4 +728,5 @@ MODEL_REGISTRY = {
     stnode.SaturationRef: SaturationRefModel,
     stnode.SuperbiasRef: SuperbiasRefModel,
     stnode.WfiImgPhotomRef: WfiImgPhotomRefModel,
+    stnode.RefpixRef: RefpixRefModel,
 }

--- a/src/roman_datamodels/random_utils.py
+++ b/src/roman_datamodels/random_utils.py
@@ -138,7 +138,7 @@ def generate_array_float32(size=(4096, 4096), min=None, max=None, units=None, se
     return array
 
 
-def generate_array_complex128(size=(32, 286721), min=None, max=None, shape="square"):
+def generate_array_complex128(size=(32, 286721), min=None, max=None, shape=None, seed=None):
     """
     Uniformly at random generate a complex array of the specified size.
 
@@ -162,6 +162,8 @@ def generate_array_complex128(size=(32, 286721), min=None, max=None, shape="squa
             - "square": Sample uniformly from a square.
             - "disk": Sample uniformly from a disk.
     """
+    shape = "square" if shape is None else shape
+
     if shape not in ["square", "disk"]:
         raise ValueError(f"Invalid shape: {shape}")
 
@@ -169,13 +171,13 @@ def generate_array_complex128(size=(32, 286721), min=None, max=None, shape="squa
         if shape == "square":
             min = (-1.0, -1.0)
         elif shape == "disk":
-            min = (0.0, 0.0)
+            min = (0.0, -np.pi)
 
     if max is None:
         if shape == "square":
             max = (1.0, 1.0)
         elif shape == "disk":
-            max = (1.0, 2.0 * np.pi)
+            max = (1.0, np.pi)
 
     if len(min) != 2:
         raise ValueError(f"Invalid min: {min}")
@@ -183,7 +185,7 @@ def generate_array_complex128(size=(32, 286721), min=None, max=None, shape="squa
     if len(max) != 2:
         raise ValueError(f"Invalid max: {max}")
 
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed)
     if shape == "square":
         # Generate two arrays of random numbers, one for the real part and one for the imaginary part.
         x = rng.uniform(min[0], max[0], size=size)

--- a/src/roman_datamodels/random_utils.py
+++ b/src/roman_datamodels/random_utils.py
@@ -138,6 +138,67 @@ def generate_array_float32(size=(4096, 4096), min=None, max=None, units=None, se
     return array
 
 
+def generate_array_complex128(size=(32, 286721), min=None, max=None, shape="square"):
+    """
+    Uniformly at random generate a complex array of the specified size.
+
+    Parameters
+    ----------
+    size: tuple
+        The size of the array to generate.
+
+    min: tuple (or None)
+        Min value for the sample axis.
+            - If None and shape is "square", then (-1.0, -1.0).
+            - If None and shape is "disk", then (0.0, 0.0).
+
+    max: tuple (or None)
+        Max value for the sample axis.
+            - If None and shape is "square", then (1.0, 1.0).
+            - If None and shape is "disk", then (1.0, 2pi).
+
+    shape: str
+        The type of sampling to use.  Options are:
+            - "square": Sample uniformly from a square.
+            - "disk": Sample uniformly from a disk.
+    """
+    if shape not in ["square", "disk"]:
+        raise ValueError(f"Invalid shape: {shape}")
+
+    if min is None:
+        if shape == "square":
+            min = (-1.0, -1.0)
+        elif shape == "disk":
+            min = (0.0, 0.0)
+
+    if max is None:
+        if shape == "square":
+            max = (1.0, 1.0)
+        elif shape == "disk":
+            max = (1.0, 2.0 * np.pi)
+
+    if len(min) != 2:
+        raise ValueError(f"Invalid min: {min}")
+
+    if len(max) != 2:
+        raise ValueError(f"Invalid max: {max}")
+
+    rng = np.random.default_rng()
+    if shape == "square":
+        # Generate two arrays of random numbers, one for the real part and one for the imaginary part.
+        x = rng.uniform(min[0], max[0], size=size)
+        y = rng.uniform(min[1], max[1], size=size)
+
+        return (x + 1.0j * y).astype(np.complex128)
+
+    elif shape == "disk":
+        # Generate two arrays of random numbers, one for the radius and one for the angle.
+        r = rng.uniform(min[0], max[0], size=size)
+        theta = rng.uniform(min[1], max[1], size=size)
+
+        return (r * np.exp(1.0j * theta)).astype(np.complex128)
+
+
 def generate_array_uint8(size=(4096, 4096), min=None, max=None, units=None, seed=None):
     if min is None:
         min = np.iinfo("uint8").min

--- a/src/roman_datamodels/random_utils.py
+++ b/src/roman_datamodels/random_utils.py
@@ -150,12 +150,12 @@ def generate_array_complex128(size=(32, 286721), min=None, max=None, shape=None,
     min: tuple (or None)
         Min value for the sample axis.
             - If None and shape is "square", then (-1.0, -1.0).
-            - If None and shape is "disk", then (0.0, 0.0).
+            - If None and shape is "disk", then (0.0, -pi).
 
     max: tuple (or None)
         Max value for the sample axis.
             - If None and shape is "square", then (1.0, 1.0).
-            - If None and shape is "disk", then (1.0, 2pi).
+            - If None and shape is "disk", then (1.0, pi).
 
     shape: str
         The type of sampling to use.  Options are:

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -276,6 +276,27 @@ def create_flat_ref(**kwargs):
     return stnode.FlatRef(raw)
 
 
+def create_ref_pix_ref(**kwargs):
+    """
+    Create a dummy RefPixRef instance with valid values for attributes
+    required by the schemas.
+
+    Returns
+    -------
+    roman_datamodels.stnode.RefPixRef
+    """
+
+    raw = {
+        "gamma": random_utils.generate_array_complex128(),
+        "zeta": random_utils.generate_array_complex128(),
+        "alpha": random_utils.generate_array_complex128(),
+        "meta": create_ref_meta(reftype="REFPIX"),
+    }
+    raw.update(kwargs)
+
+    return stnode.RefPixRef(raw)
+
+
 def create_dark_ref(**kwargs):
     """
     Create a dummy DarkRef instance with valid values for attributes

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -276,9 +276,9 @@ def create_flat_ref(**kwargs):
     return stnode.FlatRef(raw)
 
 
-def create_ref_pix_ref(**kwargs):
+def create_refpix_ref(**kwargs):
     """
-    Create a dummy RefPixRef instance with valid values for attributes
+    Create a dummy RefpixRef instance with valid values for attributes
     required by the schemas.
 
     Returns
@@ -294,7 +294,7 @@ def create_ref_pix_ref(**kwargs):
     }
     raw.update(kwargs)
 
-    return stnode.RefPixRef(raw)
+    return stnode.RefpixRef(raw)
 
 
 def create_dark_ref(**kwargs):

--- a/src/roman_datamodels/testing/factories.py
+++ b/src/roman_datamodels/testing/factories.py
@@ -294,6 +294,9 @@ def create_refpix_ref(**kwargs):
     }
     raw.update(kwargs)
 
+    raw["meta"]["input_units"] = u.DN
+    raw["meta"]["output_units"] = u.DN
+
     return stnode.RefpixRef(raw)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -628,6 +628,32 @@ def test_opening_superbias_ref(tmp_path):
     assert isinstance(superbias, datamodels.SuperbiasRefModel)
 
 
+# Refpix tests
+def test_make_refpix():
+    refpix = utils.mk_refpix(shape=(20, 20))
+    assert refpix.meta.reftype == "REFPIX"
+
+    assert refpix.gamma.dtype == np.complex128
+    assert refpix.zeta.dtype == np.complex128
+    assert refpix.alpha.dtype == np.complex128
+
+    assert refpix.gamma.shape == (20, 20)
+    assert refpix.zeta.shape == (20, 20)
+    assert refpix.alpha.shape == (20, 20)
+
+    assert refpix.meta.input_units == u.DN
+    assert refpix.meta.output_units == u.DN
+
+
+def test_opening_refpix_ref(tmp_path):
+    # First make test reference file
+    file_path = tmp_path / "testrefpix.asdf"
+    utils.mk_refpix(filepath=file_path)
+    refpix = datamodels.open(file_path)
+    assert refpix.meta.instrument.optical_element == "F158"
+    assert isinstance(refpix, datamodels.RefpixRefModel)
+
+
 # WFI Photom tests
 def test_make_wfi_img_photom():
     wfi_img_photom = utils.mk_wfi_img_photom()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-484](https://jira.stsci.edu/browse/RCAL-484)

<!-- describe the changes comprising this PR here -->
This is the matching PR to spacetelescope/rad#270, in that it implements the updates to `roman_datamodels` to support adding the reference pixel correction's reference file.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
