### PR TITLE
Update ModelContainer to comply with stpipe's ABC pseudo-protocol.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.15.1 (unreleased)
+===================
+
+- ModelContainer is now compliant with stpipe's AbstractDataModel. [#192]
+
 0.15.0 (2023-05-15)
 ===================
 

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -519,6 +519,29 @@ class ModelContainer(Iterable):
     def to_association(self):
         pass
 
+    @property
+    def crds_observatory(self):
+        """
+        Get the CRDS observatory for this container.  Used when selecting
+        step/pipeline parameter files when the container is a pipeline input.
+
+        Returns
+        -------
+        str
+        """
+        return DataModel().crds_observatory
+
+    @property
+    def get_crds_parameters(self):
+        """
+        Get parameters used by CRDS to select references for this model.
+
+        Returns
+        -------
+        dict
+        """
+        return DataModel().get_crds_parameters()
+
 
 class FlatRefModel(DataModel):
     pass


### PR DESCRIPTION
Resolves:
- [RCAL-568](https://jira.stsci.edu/browse/RCAL-568);
- [AL-743](https://jira.stsci.edu/browse/AL-743).

This PR addresses updates to `roman_datamodels.datamodels.ModelContainer` in order to make it compliant with `stpipe`'s `AbstractDataModel` pseudo-protocol.

**Checklist**
- [X] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
