### PR TITLE
Add `datamodel` maker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Add constructor for ``RampModel`` from the ``ScienceRawModel``. [#202]
 
+- Add ``maker_utils`` for all the datamodels. [#198]
+
 0.15.0 (2023-05-15)
 ===================
 

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -86,8 +86,8 @@ class DataModel:
             self._asdf = asdffile
             self._instance = asdffile.tree["roman"]
         elif isinstance(init, stnode.TaggedObjectNode):
-            if not isinstance(self, model_registry.get(init.__class__)):
-                expected = {mdl: node for node, mdl in model_registry.items()}[self.__class__].__name__
+            if not isinstance(self, MODEL_REGISTRY.get(init.__class__)):
+                expected = {mdl: node for node, mdl in MODEL_REGISTRY.items()}[self.__class__].__name__
                 raise ValidationError(
                     f"TaggedObjectNode: {init.__class__.__name__} is not of the type expected. Expected {expected}"
                 )
@@ -106,7 +106,7 @@ class DataModel:
         if "roman" not in asdffile_instance.tree:
             raise ValueError('ASDF file does not have expected "roman" attribute')
         topnode = asdffile_instance.tree["roman"]
-        if model_registry[topnode.__class__] != self.__class__:
+        if MODEL_REGISTRY[topnode.__class__] != self.__class__:
             return False
         return True
 
@@ -690,8 +690,8 @@ def open(init, memmap=False, target=None, **kwargs):
                     file_to_close.close()
                 raise TypeError("Roman datamodels does not accept FITS files or objects")
         modeltype = type(asdffile.tree["roman"])
-        if modeltype in model_registry:
-            rmodel = model_registry[modeltype](asdffile, **kwargs)
+        if modeltype in MODEL_REGISTRY:
+            rmodel = MODEL_REGISTRY[modeltype](asdffile, **kwargs)
             if target is not None:
                 if not issubclass(rmodel.__class__, target):
                     if file_to_close is not None:
@@ -703,7 +703,7 @@ def open(init, memmap=False, target=None, **kwargs):
             return DataModel(asdffile, **kwargs)
 
 
-model_registry = {
+MODEL_REGISTRY = {
     stnode.WfiMosaic: MosaicModel,
     stnode.WfiImage: ImageModel,
     stnode.WfiScienceRaw: ScienceRawModel,

--- a/src/roman_datamodels/maker_utils/__init__.py
+++ b/src/roman_datamodels/maker_utils/__init__.py
@@ -1,3 +1,5 @@
+from roman_datamodels.datamodels import MODEL_REGISTRY as _MODEL_REGISTRY  # Hide from public API
+
 from ._basic_meta import *  # noqa: F403
 from ._common_meta import *  # noqa: F403
 from ._datamodels import *  # noqa: F403
@@ -10,8 +12,26 @@ SPECIAL_MAKERS = {
     "WfiMosaic": "mk_level3_mosaic",
 }
 
+# This is static at runtime, so we might as well compute it once
+NODE_REGISTRY = {mdl: node for node, mdl in _MODEL_REGISTRY.items()}
+
 
 def mk_node(node_class, **kwargs):
+    """
+    Create a dummy node of the specified class with valid values
+    for attributes required by the schema.
+
+    Parameters
+    ----------
+    node_class : type
+        Node class (from stnode).
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    `roman_datamodels.stnode.TaggedObjectNode`
+    """
     from roman_datamodels.testing.factories import _camel_case_to_snake_case
 
     if node_class.__name__ in SPECIAL_MAKERS:
@@ -26,3 +46,22 @@ def mk_node(node_class, **kwargs):
         if method_name not in globals():
             raise ValueError(f"Maker utility: {method_name} not implemented for class {node_class.__name__}")
     return globals()[method_name](**kwargs)
+
+
+def mk_datamodel(model_class, **kwargs):
+    """
+    Create a dummy datamodel of the specified class with valid values
+    for all attributes required by the schema.
+
+    Parameters
+    ----------
+    model_class : type
+        One of the datamodel subclasses from datamodel
+    **kwargs
+        Additional or overridden attributes.
+
+    Returns
+    -------
+    `roman_datamodels.datamodels.Datamodel`
+    """
+    return model_class(mk_node(NODE_REGISTRY[model_class], **kwargs))

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -76,3 +76,15 @@ def test_deprecated():
 
     with pytest.warns(DeprecationWarning):
         maker_utils.mk_rampfitoutput()
+
+
+@pytest.mark.parametrize("model_class", [mdl for mdl in maker_utils.NODE_REGISTRY])
+def test_datamodel_maker(model_class):
+    """
+    Test that the datamodel maker utility creates a valid datamodel.
+    """
+
+    model = maker_utils.mk_datamodel(model_class)
+
+    assert isinstance(model, model_class)
+    model.validate()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -828,8 +828,8 @@ def test_modelcontainer_init():
 
 
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
-@pytest.mark.parametrize("node", datamodels.model_registry.keys())
-@pytest.mark.parametrize("correct, model", datamodels.model_registry.items())
+@pytest.mark.parametrize("node", datamodels.MODEL_REGISTRY.keys())
+@pytest.mark.parametrize("correct, model", datamodels.MODEL_REGISTRY.items())
 def test_model_only_init_with_correct_node(node, correct, model):
     """
     Datamodels should only be initializable with the correct node in the model_registry.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,7 +52,7 @@ def iter_subclasses(model_class, include_base_model=True):
 
 
 def test_model_schemas():
-    dmodels = datamodels.model_registry.keys()
+    dmodels = datamodels.MODEL_REGISTRY.keys()
     for model in dmodels:
         schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags if t._tag_uri == model._tag).schema_uris[0]
         asdf.schema.load_schema(schema_uri)

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -38,11 +38,11 @@ def test_copy(node_class):
         assert_node_is_copy(node, node_copy, deepcopy=True)
 
 
-@pytest.mark.parametrize("node_class", datamodels.model_registry.keys())
+@pytest.mark.parametrize("node_class", datamodels.MODEL_REGISTRY.keys())
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
 def test_deepcopy_model(node_class):
     node = create_node(node_class)
-    model = datamodels.model_registry[node_class](node)
+    model = datamodels.MODEL_REGISTRY[node_class](node)
     model_copy = model.copy()
 
     # There is no assert equal for models, but the data inside is what we care about.


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
When developing tests in `romancal` it was a little annoying to construct the `datamodel` you needed, as the `maker_utils`/`testing.factories` all construct the `stnode` objects, not the actual `datamodels` themselves.

This PR provides a convenience function (`maker_utils.mk_datamodel`) to do this for you. For any `datamodel` `type` (in the `MODEL_REGISTRY`) it automatically grabs the correct `maker_util` and then uses the it to construct data which it then feeds into the `datamodel` class to construct a full fledged `datamodel` of the desired type.

For example if one wants a `RampModel` the following will construct a `RampModel` filled with dummy data:

```python
from roman_datamodels.datamodels import RampModel
from roman_datamodels.maker_utils import mk_datamodel

model = mk_datamodel(RampModel)
```

Note that this is based on #193 and so it will remain a draft for now.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-devdeps/310/
