### PR TITLE
Add constructor for ramp model from science raw model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Remove the ``STUserDict`` class and fix bugs in ``stnode`` related to ``copy``. [#191]
 
+- Add constructor for ``RampModel`` from the ``ScienceRawModel``. [#202]
+
 0.15.0 (2023-05-15)
 ===================
 

--- a/src/roman_datamodels/testing/assertions.py
+++ b/src/roman_datamodels/testing/assertions.py
@@ -3,7 +3,7 @@ from asdf.tags.core import NDArrayType
 from astropy.modeling import Model
 from numpy.testing import assert_array_equal
 
-from ..stnode import TaggedListNode, TaggedObjectNode, TaggedScalarNode
+from ..stnode import DNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode
 
 
 def assert_node_equal(node1, node2):
@@ -26,7 +26,7 @@ def assert_node_equal(node1, node2):
     __tracebackhide__ = True
 
     assert node1.__class__ is node2.__class__
-    if isinstance(node1, TaggedObjectNode):
+    if isinstance(node1, DNode):
         assert set(node1.keys()) == set(node2.keys())
 
         for key, value1 in node1.items():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,12 +7,14 @@ import pytest
 from astropy import units as u
 from astropy.modeling import Model
 from jsonschema import ValidationError
+from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels
 from roman_datamodels import maker_utils as utils
 from roman_datamodels import stnode
 from roman_datamodels.extensions import DATAMODEL_EXTENSIONS
 from roman_datamodels.testing import create_node
+from roman_datamodels.testing.assertions import assert_node_equal
 
 EXPECTED_COMMON_REFERENCE = {"$ref": "ref_common-1.0.0"}
 
@@ -838,3 +840,23 @@ def test_model_only_init_with_correct_node(node, correct, model):
     img = create_node(node)
     with nullcontext() if node is correct else pytest.raises(ValidationError):
         model(img)
+
+
+def test_ramp_from_science_raw():
+    raw = datamodels.ScienceRawModel(utils.mk_level1_science_raw())
+
+    ramp = datamodels.RampModel.from_science_raw(raw)
+    for key in ramp:
+        if not hasattr(raw, key):
+            continue
+
+        ramp_value = getattr(ramp, key)
+        raw_value = getattr(raw, key)
+        if isinstance(ramp_value, np.ndarray):
+            assert_array_equal(ramp_value, raw_value.astype(ramp_value.dtype))
+
+        elif isinstance(ramp_value, stnode.DNode):
+            assert_node_equal(ramp_value, raw_value)
+
+        else:
+            raise ValueError(f"Unexpected type {type(ramp_value)}, {key}")


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This is a follow-on PR to #200. @nden would like a builtin way for converting `ScienceRawModel` to `RampModel`. This is based on this code: https://github.com/spacetelescope/romancal/blob/67639b2a1b2a1502c507dad2af31b3a85ef23cd6/romancal/dq_init/dq_init_step.py#L50-L62

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
