### PR TITLE
Refactor maker_utils API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@
 
 - Remove the ``util`` and ``mktest`` modules. [#212]
 
+- Refactor the ``maker_utils`` API so that it is uniform across all tests. [#207]
+
 0.15.0 (2023-05-15)
 ===================
 

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -350,7 +350,7 @@ class RampModel(DataModel):
         if isinstance(model, ScienceRawModel):
             from roman_datamodels.maker_utils import mk_ramp
 
-            instance = mk_ramp(model.shape)
+            instance = mk_ramp(shape=model.shape)
 
             # Copy input_model contents into RampModel
             for key in model:

--- a/src/roman_datamodels/maker_utils/__init__.py
+++ b/src/roman_datamodels/maker_utils/__init__.py
@@ -4,6 +4,7 @@ from ._basic_meta import *  # noqa: F403
 from ._common_meta import *  # noqa: F403
 from ._datamodels import *  # noqa: F403
 from ._ref_files import *  # noqa: F403
+from ._tagged_nodes import *  # noqa: F403
 
 # These makers have special names to reflect the nature of their use in the pipeline
 SPECIAL_MAKERS = {

--- a/src/roman_datamodels/maker_utils/_base.py
+++ b/src/roman_datamodels/maker_utils/_base.py
@@ -1,2 +1,4 @@
 NONUM = -999999
 NOSTR = "dummy value"
+
+MESSAGE = "This function assumes shape is 2D, but it was given at least 3 dimensions"

--- a/src/roman_datamodels/maker_utils/_basic_meta.py
+++ b/src/roman_datamodels/maker_utils/_basic_meta.py
@@ -5,7 +5,7 @@ from roman_datamodels import stnode
 from ._base import NOSTR
 
 
-def mk_calibration_software_version():
+def mk_calibration_software_version(**kwargs):
     """
     Create a dummy CalibrationSoftwareVersion object with valid values
 
@@ -13,10 +13,10 @@ def mk_calibration_software_version():
     -------
     roman_datamodels.stnode.CalibrationSoftwareVersion
     """
-    return stnode.CalibrationSoftwareVersion("9.9.0")
+    return stnode.CalibrationSoftwareVersion(kwargs.get("calibration_software_version", "9.9.0"))
 
 
-def mk_sdf_software_version():
+def mk_sdf_software_version(**kwargs):
     """
     Create a dummy SdfSoftwareVersion object with valid values
 
@@ -25,10 +25,10 @@ def mk_sdf_software_version():
     roman_datamodels.stnode.SdfSoftwareVersion
     """
 
-    return stnode.SdfSoftwareVersion("7.7.7")
+    return stnode.SdfSoftwareVersion(kwargs.get("sdf_software_version", "7.7.7"))
 
 
-def mk_filename():
+def mk_filename(**kwargs):
     """
     Create a dummy Filename object with valid values
 
@@ -36,10 +36,10 @@ def mk_filename():
     -------
     roman_datamodels.stnode.Filename
     """
-    return stnode.Filename(NOSTR)
+    return stnode.Filename(kwargs.get("filename", NOSTR))
 
 
-def mk_file_date():
+def mk_file_date(**kwargs):
     """
     Create a dummy FileDate object with valid values
 
@@ -48,10 +48,10 @@ def mk_file_date():
     roman_datamodels.stnode.FileDate
     """
 
-    return stnode.FileDate(time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
+    return stnode.FileDate(kwargs.get("file_date", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")))
 
 
-def mk_model_type():
+def mk_model_type(**kwargs):
     """
     Create a dummy ModelType object with valid values
 
@@ -59,10 +59,10 @@ def mk_model_type():
     -------
     roman_datamodels.stnode.ModelType
     """
-    return stnode.ModelType(NOSTR)
+    return stnode.ModelType(kwargs.get("model_type", NOSTR))
 
 
-def mk_origin():
+def mk_origin(**kwargs):
     """
     Create a dummy Origin object with valid values
 
@@ -71,10 +71,10 @@ def mk_origin():
     roman_datamodels.stnode.Origin
     """
 
-    return stnode.Origin("STSCI")
+    return stnode.Origin(kwargs.get("origin", "STSCI"))
 
 
-def mk_prd_software_version():
+def mk_prd_software_version(**kwargs):
     """
     Create a dummy PrdSoftwareVersion object with valid values
 
@@ -82,10 +82,10 @@ def mk_prd_software_version():
     -------
     roman_datamodels.stnode.PrdSoftwareVersion
     """
-    return stnode.PrdSoftwareVersion("8.8.8")
+    return stnode.PrdSoftwareVersion(kwargs.get("prd_software_version", "8.8.8"))
 
 
-def mk_telescope():
+def mk_telescope(**kwargs):
     """
     Create a dummy Telescope object with valid values
 
@@ -93,26 +93,25 @@ def mk_telescope():
     -------
     roman_datamodels.stnode.Telescope
     """
-    return stnode.Telescope("ROMAN")
+    return stnode.Telescope(kwargs.get("telescope", "ROMAN"))
 
 
-def mk_basic_meta():
+def mk_basic_meta(**kwargs):
     """
     Create a dummy basic metadata dictionary with valid values for attributes
-        TODO: This needs to be updated with constructors for the scalar objects
 
     Returns
     -------
     dict (defined by the basic-1.0.0 schema)
     """
     meta = {}
-    meta["calibration_software_version"] = mk_calibration_software_version()
-    meta["sdf_software_version"] = mk_sdf_software_version()
-    meta["filename"] = mk_filename()
-    meta["file_date"] = mk_file_date()
-    meta["model_type"] = mk_model_type()
-    meta["origin"] = mk_origin()
-    meta["prd_software_version"] = mk_prd_software_version()
-    meta["telescope"] = mk_telescope()
+    meta["calibration_software_version"] = mk_calibration_software_version(**kwargs)
+    meta["sdf_software_version"] = mk_sdf_software_version(**kwargs)
+    meta["filename"] = mk_filename(**kwargs)
+    meta["file_date"] = mk_file_date(**kwargs)
+    meta["model_type"] = mk_model_type(**kwargs)
+    meta["origin"] = mk_origin(**kwargs)
+    meta["prd_software_version"] = mk_prd_software_version(**kwargs)
+    meta["telescope"] = mk_telescope(**kwargs)
 
     return meta

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -492,7 +492,7 @@ def mk_guidewindow_meta(**kwargs):
     return meta
 
 
-def mk_ref_common(reftype="", **kwargs):
+def mk_ref_common(reftype_, **kwargs):
     """
     Create dummy metadata for reference file instances.
 
@@ -508,7 +508,7 @@ def mk_ref_common(reftype="", **kwargs):
     meta["author"] = kwargs.get("author", "test system")
     meta["description"] = kwargs.get("description", "blah blah blah")
     meta["useafter"] = kwargs.get("useafter", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
-    meta["reftype"] = kwargs.get("reftype", reftype)
+    meta["reftype"] = kwargs.get("reftype", reftype_)
 
     return meta
 
@@ -593,7 +593,7 @@ def mk_ref_pixelarea_meta(**kwargs):
     return meta
 
 
-def mk_ref_units_dn_meta(reftype, **kwargs):
+def mk_ref_units_dn_meta(reftype_, **kwargs):
     """
     Create dummy metadata for reference file instances which specify DN as input/output units.
 
@@ -601,7 +601,7 @@ def mk_ref_units_dn_meta(reftype, **kwargs):
     -------
     dict (follows reference_file/ref_common-1.0.0 schema + DN input/output metadata)
     """
-    meta = mk_ref_common(reftype, **kwargs)
+    meta = mk_ref_common(reftype_, **kwargs)
 
     meta["input_units"] = kwargs.get("input_units", u.DN)
     meta["output_units"] = kwargs.get("output_units", u.DN)

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -1,10 +1,11 @@
 from astropy import time
 
 from roman_datamodels import stnode
-from roman_datamodels.random_utils import generate_positive_int
+from roman_datamodels.random_utils import generate_positive_int, generate_string
 
 from ._base import NONUM, NOSTR
 from ._basic_meta import mk_basic_meta
+from ._tagged_nodes import mk_photometry, mk_resample
 
 
 def mk_exposure(**kwargs):
@@ -391,7 +392,7 @@ def mk_common_meta(**kwargs):
     -------
     dict (defined by the common-1.0.0 schema)
     """
-    meta = mk_basic_meta()
+    meta = mk_basic_meta(**kwargs)
     meta["aperture"] = mk_aperture(**kwargs.get("aperture", {}))
     meta["cal_step"] = mk_cal_step(**kwargs.get("cal_step", {}))
     meta["coordinates"] = mk_coordinates(**kwargs.get("coordinates", {}))
@@ -407,6 +408,85 @@ def mk_common_meta(**kwargs):
     meta["velocity_aberration"] = mk_velocity_aberration(**kwargs.get("velocity_aberration", {}))
     meta["visit"] = mk_visit(**kwargs.get("visit", {}))
     meta["wcsinfo"] = mk_wcsinfo(**kwargs.get("wcsinfo", {}))
+
+    return meta
+
+
+def mk_photometry_meta(**kwargs):
+    """
+    Create a dummy common metadata dictionary with valid values for attributes and add
+    the additional photometry metadata
+
+    Returns
+    -------
+    dict (defined by the common-1.0.0 schema with additional photometry metadata)
+    """
+
+    meta = mk_common_meta(**kwargs)
+    meta["photometry"] = mk_photometry(**kwargs.get("photometry", {}))
+
+    return meta
+
+
+def mk_resample_meta(**kwargs):
+    """
+    Create a dummy common metadata dictionary with valid values for attributes and add
+    the additional photometry AND resample metadata
+
+    Returns
+    -------
+    dict (defined by the common-1.0.0 schema with additional photometry and resample metadata)
+    """
+
+    meta = mk_photometry_meta(**kwargs)
+    meta["resample"] = mk_resample(**kwargs.get("resample", {}))
+
+    return meta
+
+
+def mk_guidewindow_meta(**kwargs):
+    """
+    Create a dummy common metadata dictionary with valid values for attributes and add
+    the additional guidewindow metadata
+
+    Returns
+    -------
+    dict (defined by the common-1.0.0 schema with additional guidewindow metadata)
+    """
+
+    meta = mk_common_meta(**kwargs)
+
+    meta["file_creation_time"] = kwargs.get("file_creation_time", time.Time("2020-01-01T20:00:00.0", format="isot", scale="utc"))
+    meta["gw_start_time"] = kwargs.get("gw_start_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
+    meta["gw_end_time"] = kwargs.get("gw_end_time", time.Time("2020-01-01T10:00:00.0", format="isot", scale="utc"))
+    meta["gw_function_start_time"] = kwargs.get(
+        "gw_function_start_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    )
+    meta["gw_function_end_time"] = kwargs.get(
+        "gw_function_end_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    )
+    meta["gw_frame_readout_time"] = kwargs.get("gw_frame_readout_time", NONUM)
+    meta["pedestal_resultant_exp_time"] = kwargs.get("pedestal_resultant_exp_time", NONUM)
+    meta["signal_resultant_exp_time"] = kwargs.get("signal_resultant_exp_time", NONUM)
+    meta["gw_acq_number"] = kwargs.get("gw_acq_number", NONUM)
+    meta["gw_science_file_source"] = kwargs.get("gw_science_file_source", NOSTR)
+    meta["gw_mode"] = kwargs.get("gw_mode", "WIM-ACQ")
+    meta["gw_window_xstart"] = kwargs.get("gw_window_xstart", NONUM)
+    meta["gw_window_ystart"] = kwargs.get("gw_window_ystart", NONUM)
+    meta["gw_window_xstop"] = kwargs.get("gw_window_xstop", meta["gw_window_xstart"] + 170)
+    meta["gw_window_ystop"] = kwargs.get("gw_window_ystop", meta["gw_window_ystart"] + 24)
+    meta["gw_window_xsize"] = kwargs.get("gw_window_xsize", 170)
+    meta["gw_window_ysize"] = kwargs.get("gw_window_ysize", 24)
+
+    meta["gw_function_start_time"] = kwargs.get(
+        "gw_function_start_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    )
+    meta["gw_function_end_time"] = kwargs.get(
+        "gw_function_end_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
+    )
+    meta["data_start"] = kwargs.get("data_start", NONUM)
+    meta["data_end"] = kwargs.get("data_end", NONUM)
+    meta["gw_acq_exec_stat"] = kwargs.get("gw_acq_exec_stat", generate_string("Status ", 15))
 
     return meta
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -7,7 +7,7 @@ from ._base import NONUM, NOSTR
 from ._basic_meta import mk_basic_meta
 
 
-def mk_exposure():
+def mk_exposure(**kwargs):
     """
     Create a dummy Exposure instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -17,40 +17,40 @@ def mk_exposure():
     roman_datamodels.stnode.Exposure
     """
     exp = stnode.Exposure()
-    exp["id"] = NONUM
-    exp["type"] = "WFI_IMAGE"
-    exp["start_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
-    exp["mid_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
-    exp["end_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
-    exp["start_time_mjd"] = NONUM
-    exp["mid_time_mjd"] = NONUM
-    exp["end_time_mjd"] = NONUM
-    exp["start_time_tdb"] = NONUM
-    exp["mid_time_tdb"] = NONUM
-    exp["end_time_tdb"] = NONUM
-    exp["ngroups"] = 6
-    exp["nframes"] = 8
-    exp["data_problem"] = False
-    exp["sca_number"] = NONUM
-    exp["gain_factor"] = NONUM
-    exp["integration_time"] = NONUM
-    exp["elapsed_exposure_time"] = NONUM
-    exp["frame_divisor"] = NONUM
-    exp["groupgap"] = 0
-    exp["frame_time"] = NONUM
-    exp["group_time"] = NONUM
-    exp["exposure_time"] = NONUM
-    exp["effective_exposure_time"] = NONUM
-    exp["duration"] = NONUM
-    exp["ma_table_name"] = NOSTR
-    exp["ma_table_number"] = NONUM
-    exp["level0_compressed"] = True
-    exp["read_pattern"] = [[1], [2, 3], [4], [5, 6, 7, 8], [9, 10], [11]]
+    exp["id"] = kwargs.get("id", NONUM)
+    exp["type"] = kwargs.get("type", "WFI_IMAGE")
+    exp["start_time"] = kwargs.get("start_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
+    exp["mid_time"] = kwargs.get("mid_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
+    exp["end_time"] = kwargs.get("end_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
+    exp["start_time_mjd"] = kwargs.get("start_time_mjd", NONUM)
+    exp["mid_time_mjd"] = kwargs.get("mid_time_mjd", NONUM)
+    exp["end_time_mjd"] = kwargs.get("end_time_mjd", NONUM)
+    exp["start_time_tdb"] = kwargs.get("start_time_tdb", NONUM)
+    exp["mid_time_tdb"] = kwargs.get("mid_time_tdb", NONUM)
+    exp["end_time_tdb"] = kwargs.get("end_time_tdb", NONUM)
+    exp["ngroups"] = kwargs.get("ngroups", 6)
+    exp["nframes"] = kwargs.get("nframes", 8)
+    exp["data_problem"] = kwargs.get("data_problem", False)
+    exp["sca_number"] = kwargs.get("sca_number", NONUM)
+    exp["gain_factor"] = kwargs.get("gain_factor", NONUM)
+    exp["integration_time"] = kwargs.get("integration_time", NONUM)
+    exp["elapsed_exposure_time"] = kwargs.get("elapsed_exposure_time", NONUM)
+    exp["frame_divisor"] = kwargs.get("frame_divisor", NONUM)
+    exp["groupgap"] = kwargs.get("groupgap", 0)
+    exp["frame_time"] = kwargs.get("frame_time", NONUM)
+    exp["group_time"] = kwargs.get("group_time", NONUM)
+    exp["exposure_time"] = kwargs.get("exposure_time", NONUM)
+    exp["effective_exposure_time"] = kwargs.get("effective_exposure_time", NONUM)
+    exp["duration"] = kwargs.get("duration", NONUM)
+    exp["ma_table_name"] = kwargs.get("ma_table_name", NOSTR)
+    exp["ma_table_number"] = kwargs.get("ma_table_number", NONUM)
+    exp["level0_compressed"] = kwargs.get("level0_compressed", True)
+    exp["read_pattern"] = kwargs.get("read_pattern", [[1], [2, 3], [4], [5, 6, 7, 8], [9, 10], [11]])
 
     return exp
 
 
-def mk_wfi_mode():
+def mk_wfi_mode(**kwargs):
     """
     Create a dummy WFI mode instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -60,14 +60,14 @@ def mk_wfi_mode():
     roman_datamodels.stnode.WfiMode
     """
     mode = stnode.WfiMode()
-    mode["name"] = "WFI"
-    mode["detector"] = "WFI01"
-    mode["optical_element"] = "F062"
+    mode["name"] = kwargs.get("name", "WFI")
+    mode["detector"] = kwargs.get("detector", "WFI01")
+    mode["optical_element"] = kwargs.get("optical_element", "F062")
 
     return mode
 
 
-def mk_program():
+def mk_program(**kwargs):
     """
     Create a dummy Program instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -77,17 +77,17 @@ def mk_program():
     roman_datamodels.stnode.Program
     """
     prog = stnode.Program()
-    prog["title"] = NOSTR
-    prog["pi_name"] = NOSTR
-    prog["category"] = NOSTR
-    prog["subcategory"] = NOSTR
-    prog["science_category"] = NOSTR
-    prog["continuation_id"] = NONUM
+    prog["title"] = kwargs.get("title", NOSTR)
+    prog["pi_name"] = kwargs.get("pi_name", NOSTR)
+    prog["category"] = kwargs.get("category", NOSTR)
+    prog["subcategory"] = kwargs.get("subcategory", NOSTR)
+    prog["science_category"] = kwargs.get("science_category", NOSTR)
+    prog["continuation_id"] = kwargs.get("continuation_id", NONUM)
 
     return prog
 
 
-def mk_observation():
+def mk_observation(**kwargs):
     """
     Create a dummy Observation instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -97,26 +97,26 @@ def mk_observation():
     roman_datamodels.stnode.Observation
     """
     obs = stnode.Observation()
-    obs["obs_id"] = NOSTR
-    obs["visit_id"] = NOSTR
-    obs["program"] = str(NONUM)
-    obs["execution_plan"] = NONUM
-    obs["pass"] = NONUM
-    obs["segment"] = NONUM
-    obs["observation"] = NONUM
-    obs["visit"] = NONUM
-    obs["visit_file_group"] = NONUM
-    obs["visit_file_sequence"] = NONUM
-    obs["visit_file_activity"] = NOSTR
-    obs["exposure"] = NONUM
-    obs["template"] = NOSTR
-    obs["observation_label"] = NOSTR
-    obs["survey"] = "N/A"
+    obs["obs_id"] = kwargs.get("obs_id", NOSTR)
+    obs["visit_id"] = kwargs.get("visit_id", NOSTR)
+    obs["program"] = kwargs.get("program", str(NONUM))
+    obs["execution_plan"] = kwargs.get("execution_plan", NONUM)
+    obs["pass"] = kwargs.get("pass", NONUM)
+    obs["segment"] = kwargs.get("segment", NONUM)
+    obs["observation"] = kwargs.get("observation", NONUM)
+    obs["visit"] = kwargs.get("visit", NONUM)
+    obs["visit_file_group"] = kwargs.get("visit_file_group", NONUM)
+    obs["visit_file_sequence"] = kwargs.get("visit_file_sequence", NONUM)
+    obs["visit_file_activity"] = kwargs.get("visit_file_activity", NOSTR)
+    obs["exposure"] = kwargs.get("exposure", NONUM)
+    obs["template"] = kwargs.get("template", NOSTR)
+    obs["observation_label"] = kwargs.get("observation_label", NOSTR)
+    obs["survey"] = kwargs.get("survey", "N/A")
 
     return obs
 
 
-def mk_ephemeris():
+def mk_ephemeris(**kwargs):
     """
     Create a dummy Ephemeris instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -126,23 +126,23 @@ def mk_ephemeris():
     roman_datamodels.stnode.Ephemeris
     """
     ephem = stnode.Ephemeris()
-    ephem["earth_angle"] = NONUM
-    ephem["moon_angle"] = NONUM
-    ephem["ephemeris_reference_frame"] = NOSTR
-    ephem["sun_angle"] = NONUM
-    ephem["type"] = "DEFINITIVE"
-    ephem["time"] = NONUM
-    ephem["spatial_x"] = NONUM
-    ephem["spatial_y"] = NONUM
-    ephem["spatial_z"] = NONUM
-    ephem["velocity_x"] = NONUM
-    ephem["velocity_y"] = NONUM
-    ephem["velocity_z"] = NONUM
+    ephem["earth_angle"] = kwargs.get("earth_angle", NONUM)
+    ephem["moon_angle"] = kwargs.get("moon_angle", NONUM)
+    ephem["ephemeris_reference_frame"] = kwargs.get("ephemeris_reference_frame", NOSTR)
+    ephem["sun_angle"] = kwargs.get("sun_angle", NONUM)
+    ephem["type"] = kwargs.get("type", "DEFINITIVE")
+    ephem["time"] = kwargs.get("time", NONUM)
+    ephem["spatial_x"] = kwargs.get("spatial_x", NONUM)
+    ephem["spatial_y"] = kwargs.get("spatial_y", NONUM)
+    ephem["spatial_z"] = kwargs.get("spatial_z", NONUM)
+    ephem["velocity_x"] = kwargs.get("velocity_x", NONUM)
+    ephem["velocity_y"] = kwargs.get("velocity_y", NONUM)
+    ephem["velocity_z"] = kwargs.get("velocity_z", NONUM)
 
     return ephem
 
 
-def mk_visit():
+def mk_visit(**kwargs):
     """
     Create a dummy Visit instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -152,20 +152,20 @@ def mk_visit():
     roman_datamodels.stnode.Visit
     """
     visit = stnode.Visit()
-    visit["engineering_quality"] = "OK"  # qqqq
-    visit["pointing_engdb_quality"] = "CALCULATED"  # qqqq
-    visit["type"] = NOSTR
-    visit["start_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
-    visit["end_time"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
-    visit["status"] = NOSTR
-    visit["total_exposures"] = NONUM
-    visit["internal_target"] = False
-    visit["target_of_opportunity"] = False
+    visit["engineering_quality"] = kwargs.get("engineering_quality", "OK")
+    visit["pointing_engdb_quality"] = kwargs.get("pointing_engdb_quality", "CALCULATED")
+    visit["type"] = kwargs.get("type", NOSTR)
+    visit["start_time"] = kwargs.get("start_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
+    visit["end_time"] = kwargs.get("end_time", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
+    visit["status"] = kwargs.get("status", NOSTR)
+    visit["total_exposures"] = kwargs.get("total_exposures", NONUM)
+    visit["internal_target"] = kwargs.get("internal_target", False)
+    visit["target_of_opportunity"] = kwargs.get("target_of_opportunity", False)
 
     return visit
 
 
-def mk_source_detection():
+def mk_source_detection(**kwargs):
     """
     Create a dummy Source Detection instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below
@@ -175,12 +175,12 @@ def mk_source_detection():
     roman_datamodels.stnode.SourceDetection
     """
     sd = stnode.SourceDetection()
-    sd["tweakreg_catalog_name"] = "filename_tweakreg_catalog.asdf"
+    sd["tweakreg_catalog_name"] = kwargs.get("tweakreg_catalog_name", "filename_tweakreg_catalog.asdf")
 
     return sd
 
 
-def mk_coordinates():
+def mk_coordinates(**kwargs):
     """
     Create a dummy Coordinates instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -190,12 +190,12 @@ def mk_coordinates():
     roman_datamodels.stnode.Coordinates
     """
     coord = stnode.Coordinates()
-    coord["reference_frame"] = "ICRS"
+    coord["reference_frame"] = kwargs.get("reference_frame", "ICRS")
 
     return coord
 
 
-def mk_aperture():
+def mk_aperture(**kwargs):
     """
     Create a dummy Aperture instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -205,14 +205,13 @@ def mk_aperture():
     roman_datamodels.stnode.Aperture
     """
     aper = stnode.Aperture()
-    aper_number = generate_positive_int(17) + 1
-    aper["name"] = f"WFI_{aper_number:02d}_FULL"
-    aper["position_angle"] = 30.0
+    aper["name"] = kwargs.get("name", f"WFI_{generate_positive_int(17) + 1:02d}_FULL")
+    aper["position_angle"] = kwargs.get("position_angle", 30.0)
 
     return aper
 
 
-def mk_pointing():
+def mk_pointing(**kwargs):
     """
     Create a dummy Pointing instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -222,14 +221,14 @@ def mk_pointing():
     roman_datamodels.stnode.Pointing
     """
     point = stnode.Pointing()
-    point["ra_v1"] = NONUM
-    point["dec_v1"] = NONUM
-    point["pa_v3"] = NONUM
+    point["ra_v1"] = kwargs.get("ra_v1", NONUM)
+    point["dec_v1"] = kwargs.get("dec_v1", NONUM)
+    point["pa_v3"] = kwargs.get("pa_v3", NONUM)
 
     return point
 
 
-def mk_target():
+def mk_target(**kwargs):
     """
     Create a dummy Target instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -239,24 +238,24 @@ def mk_target():
     roman_datamodels.stnode.Target
     """
     targ = stnode.Target()
-    targ["proposer_name"] = NOSTR
-    targ["catalog_name"] = NOSTR
-    targ["type"] = "FIXED"
-    targ["ra"] = NONUM
-    targ["dec"] = NONUM
-    targ["ra_uncertainty"] = NONUM
-    targ["dec_uncertainty"] = NONUM
-    targ["proper_motion_ra"] = NONUM
-    targ["proper_motion_dec"] = NONUM
-    targ["proper_motion_epoch"] = NOSTR
-    targ["proposer_ra"] = NONUM
-    targ["proposer_dec"] = NONUM
-    targ["source_type"] = "POINT"
+    targ["proposer_name"] = kwargs.get("proposer_name", NOSTR)
+    targ["catalog_name"] = kwargs.get("catalog_name", NOSTR)
+    targ["type"] = kwargs.get("type", "FIXED")
+    targ["ra"] = kwargs.get("ra", NONUM)
+    targ["dec"] = kwargs.get("dec", NONUM)
+    targ["ra_uncertainty"] = kwargs.get("ra_uncertainty", NONUM)
+    targ["dec_uncertainty"] = kwargs.get("dec_uncertainty", NONUM)
+    targ["proper_motion_ra"] = kwargs.get("proper_motion_ra", NONUM)
+    targ["proper_motion_dec"] = kwargs.get("proper_motion_dec", NONUM)
+    targ["proper_motion_epoch"] = kwargs.get("proper_motion_epoch", NOSTR)
+    targ["proposer_ra"] = kwargs.get("proposer_ra", NONUM)
+    targ["proposer_dec"] = kwargs.get("proposer_dec", NONUM)
+    targ["source_type"] = kwargs.get("source_type", "POINT")
 
     return targ
 
 
-def mk_velocity_aberration():
+def mk_velocity_aberration(**kwargs):
     """
     Create a dummy Velocity Aberration instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -266,14 +265,14 @@ def mk_velocity_aberration():
     roman_datamodels.stnode.VelocityAberration
     """
     vab = stnode.VelocityAberration()
-    vab["ra_offset"] = NONUM
-    vab["dec_offset"] = NONUM
-    vab["scale_factor"] = NONUM
+    vab["ra_offset"] = kwargs.get("ra_offset", NONUM)
+    vab["dec_offset"] = kwargs.get("dec_offset", NONUM)
+    vab["scale_factor"] = kwargs.get("scale_factor", NONUM)
 
     return vab
 
 
-def mk_wcsinfo():
+def mk_wcsinfo(**kwargs):
     """
     Create a dummy WCS Info instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -283,19 +282,19 @@ def mk_wcsinfo():
     roman_datamodels.stnode.Wcsinfo
     """
     wcsi = stnode.Wcsinfo()
-    wcsi["v2_ref"] = NONUM
-    wcsi["v3_ref"] = NONUM
-    wcsi["vparity"] = NONUM
-    wcsi["v3yangle"] = NONUM
-    wcsi["ra_ref"] = NONUM
-    wcsi["dec_ref"] = NONUM
-    wcsi["roll_ref"] = NONUM
-    wcsi["s_region"] = NOSTR
+    wcsi["v2_ref"] = kwargs.get("v2_ref", NONUM)
+    wcsi["v3_ref"] = kwargs.get("v3_ref", NONUM)
+    wcsi["vparity"] = kwargs.get("vparity", NONUM)
+    wcsi["v3yangle"] = kwargs.get("v3yangle", NONUM)
+    wcsi["ra_ref"] = kwargs.get("ra_ref", NONUM)
+    wcsi["dec_ref"] = kwargs.get("dec_ref", NONUM)
+    wcsi["roll_ref"] = kwargs.get("roll_ref", NONUM)
+    wcsi["s_region"] = kwargs.get("s_region", NOSTR)
 
     return wcsi
 
 
-def mk_cal_step():
+def mk_cal_step(**kwargs):
     """
     Create a dummy Cal Step instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -305,21 +304,21 @@ def mk_cal_step():
     roman_datamodels.stnode.CalStep
     """
     calstep = stnode.CalStep()
-    calstep["flat_field"] = "INCOMPLETE"
-    calstep["dq_init"] = "INCOMPLETE"
-    calstep["assign_wcs"] = "INCOMPLETE"
-    calstep["dark"] = "INCOMPLETE"
-    calstep["jump"] = "INCOMPLETE"
-    calstep["linearity"] = "INCOMPLETE"
-    calstep["photom"] = "INCOMPLETE"
-    calstep["source_detection"] = "INCOMPLETE"
-    calstep["ramp_fit"] = "INCOMPLETE"
-    calstep["saturation"] = "INCOMPLETE"
+    calstep["flat_field"] = kwargs.get("flat_field", "INCOMPLETE")
+    calstep["dq_init"] = kwargs.get("dq_init", "INCOMPLETE")
+    calstep["assign_wcs"] = kwargs.get("assign_wcs", "INCOMPLETE")
+    calstep["dark"] = kwargs.get("dark", "INCOMPLETE")
+    calstep["jump"] = kwargs.get("jump", "INCOMPLETE")
+    calstep["linearity"] = kwargs.get("linearity", "INCOMPLETE")
+    calstep["photom"] = kwargs.get("photom", "INCOMPLETE")
+    calstep["source_detection"] = kwargs.get("source_detection", "INCOMPLETE")
+    calstep["ramp_fit"] = kwargs.get("ramp_fit", "INCOMPLETE")
+    calstep["saturation"] = kwargs.get("saturation", "INCOMPLETE")
 
     return calstep
 
 
-def mk_guidestar():
+def mk_guidestar(**kwargs):
     """
     Create a dummy Guide Star instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -329,38 +328,38 @@ def mk_guidestar():
     roman_datamodels.stnode.Guidestar
     """
     guide = stnode.Guidestar()
-    guide["gw_id"] = NOSTR
-    guide["gs_ra"] = NONUM
-    guide["gs_dec"] = NONUM
-    guide["gs_ura"] = NONUM
-    guide["gs_udec"] = NONUM
-    guide["gs_mag"] = NONUM
-    guide["gs_umag"] = NONUM
-    guide["gw_fgs_mode"] = "WSM-ACQ-2"
-    guide["gs_id"] = NOSTR
-    guide["gs_catalog_version"] = NOSTR
-    guide["data_start"] = NONUM
-    guide["data_end"] = NONUM
-    guide["gs_ctd_x"] = NONUM
-    guide["gs_ctd_y"] = NONUM
-    guide["gs_ctd_ux"] = NONUM
-    guide["gs_ctd_uy"] = NONUM
-    guide["gs_epoch"] = NOSTR
-    guide["gs_mura"] = NONUM
-    guide["gs_mudec"] = NONUM
-    guide["gs_para"] = NONUM
-    guide["gs_pattern_error"] = NONUM
-    guide["gw_window_xstart"] = NONUM
-    guide["gw_window_ystart"] = NONUM
-    guide["gw_window_xstop"] = guide["gw_window_xstart"] + 170
-    guide["gw_window_ystop"] = guide["gw_window_ystart"] + 24
-    guide["gw_window_xsize"] = 170
-    guide["gw_window_ysize"] = 24
+    guide["gw_id"] = kwargs.get("gw_id", NOSTR)
+    guide["gs_ra"] = kwargs.get("gs_ra", NONUM)
+    guide["gs_dec"] = kwargs.get("gs_dec", NONUM)
+    guide["gs_ura"] = kwargs.get("gs_ura", NONUM)
+    guide["gs_udec"] = kwargs.get("gs_udec", NONUM)
+    guide["gs_mag"] = kwargs.get("gs_mag", NONUM)
+    guide["gs_umag"] = kwargs.get("gs_umag", NONUM)
+    guide["gw_fgs_mode"] = kwargs.get("gw_fgs_mode", "WSM-ACQ-2")
+    guide["gs_id"] = kwargs.get("gs_id", NOSTR)
+    guide["gs_catalog_version"] = kwargs.get("gs_catalog_version", NOSTR)
+    guide["data_start"] = kwargs.get("data_start", NONUM)
+    guide["data_end"] = kwargs.get("data_end", NONUM)
+    guide["gs_ctd_x"] = kwargs.get("gs_ctd_x", NONUM)
+    guide["gs_ctd_y"] = kwargs.get("gs_ctd_y", NONUM)
+    guide["gs_ctd_ux"] = kwargs.get("gs_ctd_ux", NONUM)
+    guide["gs_ctd_uy"] = kwargs.get("gs_ctd_uy", NONUM)
+    guide["gs_epoch"] = kwargs.get("gs_epoch", NOSTR)
+    guide["gs_mura"] = kwargs.get("gs_mura", NONUM)
+    guide["gs_mudec"] = kwargs.get("gs_mudec", NONUM)
+    guide["gs_para"] = kwargs.get("gs_para", NONUM)
+    guide["gs_pattern_error"] = kwargs.get("gs_pattern_error", NONUM)
+    guide["gw_window_xstart"] = kwargs.get("gw_window_xstart", NONUM)
+    guide["gw_window_ystart"] = kwargs.get("gw_window_ystart", NONUM)
+    guide["gw_window_xstop"] = kwargs.get("gw_window_xstop", guide["gw_window_xstart"] + 170)
+    guide["gw_window_ystop"] = kwargs.get("gw_window_ystop", guide["gw_window_ystart"] + 24)
+    guide["gw_window_xsize"] = kwargs.get("gw_window_xsize", 170)
+    guide["gw_window_ysize"] = kwargs.get("gw_window_ysize", 24)
 
     return guide
 
 
-def mk_ref_file():
+def mk_ref_file(**kwargs):
     """
     Create a dummy RefFile instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -370,21 +369,21 @@ def mk_ref_file():
     roman_datamodels.stnode.RefFile
     """
     ref_file = stnode.RefFile()
-    ref_file["dark"] = "N/A"
-    ref_file["distortion"] = "N/A"
-    ref_file["flat"] = "N/A"
-    ref_file["gain"] = "N/A"
-    ref_file["linearity"] = "N/A"
-    ref_file["mask"] = "N/A"
-    ref_file["readnoise"] = "N/A"
-    ref_file["saturation"] = "N/A"
-    ref_file["photom"] = "N/A"
-    ref_file["crds"] = {"sw_version": "12.3.1", "context_used": "roman_0815.pmap"}
+    ref_file["dark"] = kwargs.get("dark", "N/A")
+    ref_file["distortion"] = kwargs.get("distortion", "N/A")
+    ref_file["flat"] = kwargs.get("flat", "N/A")
+    ref_file["gain"] = kwargs.get("gain", "N/A")
+    ref_file["linearity"] = kwargs.get("linearity", "N/A")
+    ref_file["mask"] = kwargs.get("mask", "N/A")
+    ref_file["readnoise"] = kwargs.get("readnoise", "N/A")
+    ref_file["saturation"] = kwargs.get("saturation", "N/A")
+    ref_file["photom"] = kwargs.get("photom", "N/A")
+    ref_file["crds"] = kwargs.get("crds", {"sw_version": "12.3.1", "context_used": "roman_0815.pmap"})
 
     return ref_file
 
 
-def mk_common_meta():
+def mk_common_meta(**kwargs):
     """
     Create a dummy common metadata dictionary with valid values for attributes
 
@@ -393,26 +392,26 @@ def mk_common_meta():
     dict (defined by the common-1.0.0 schema)
     """
     meta = mk_basic_meta()
-    meta["aperture"] = mk_aperture()
-    meta["cal_step"] = mk_cal_step()
-    meta["coordinates"] = mk_coordinates()
-    meta["ephemeris"] = mk_ephemeris()
-    meta["exposure"] = mk_exposure()
-    meta["guidestar"] = mk_guidestar()
-    meta["instrument"] = mk_wfi_mode()
-    meta["observation"] = mk_observation()
-    meta["pointing"] = mk_pointing()
-    meta["program"] = mk_program()
-    meta["ref_file"] = mk_ref_file()
-    meta["target"] = mk_target()
-    meta["velocity_aberration"] = mk_velocity_aberration()
-    meta["visit"] = mk_visit()
-    meta["wcsinfo"] = mk_wcsinfo()
+    meta["aperture"] = mk_aperture(**kwargs.get("aperture", {}))
+    meta["cal_step"] = mk_cal_step(**kwargs.get("cal_step", {}))
+    meta["coordinates"] = mk_coordinates(**kwargs.get("coordinates", {}))
+    meta["ephemeris"] = mk_ephemeris(**kwargs.get("ephemeris", {}))
+    meta["exposure"] = mk_exposure(**kwargs.get("exposure", {}))
+    meta["guidestar"] = mk_guidestar(**kwargs.get("guidestar", {}))
+    meta["instrument"] = mk_wfi_mode(**kwargs.get("instrument", {}))
+    meta["observation"] = mk_observation(**kwargs.get("observation", {}))
+    meta["pointing"] = mk_pointing(**kwargs.get("pointing", {}))
+    meta["program"] = mk_program(**kwargs.get("program", {}))
+    meta["ref_file"] = mk_ref_file(**kwargs.get("ref_file", {}))
+    meta["target"] = mk_target(**kwargs.get("target", {}))
+    meta["velocity_aberration"] = mk_velocity_aberration(**kwargs.get("velocity_aberration", {}))
+    meta["visit"] = mk_visit(**kwargs.get("visit", {}))
+    meta["wcsinfo"] = mk_wcsinfo(**kwargs.get("wcsinfo", {}))
 
     return meta
 
 
-def mk_ref_common():
+def mk_ref_common(**kwargs):
     """
     Create dummy metadata for reference file instances.
 
@@ -421,14 +420,13 @@ def mk_ref_common():
     dict (follows reference_file/ref_common-1.0.0 schema)
     """
     meta = {}
-    instrument = {"name": "WFI", "detector": "WFI01", "optical_element": "F158"}
-    meta["telescope"] = "ROMAN"
-    meta["instrument"] = instrument
-    meta["origin"] = "STSCI"
-    meta["pedigree"] = "GROUND"
-    meta["author"] = "test system"
-    meta["description"] = "blah blah blah"
-    meta["useafter"] = time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")
-    meta["reftype"] = ""
+    meta["telescope"] = kwargs.get("telescope", "ROMAN")
+    meta["instrument"] = kwargs.get("instrument", {"name": "WFI", "detector": "WFI01", "optical_element": "F158"})
+    meta["origin"] = kwargs.get("origin", "STSCI")
+    meta["pedigree"] = kwargs.get("pedigree", "GROUND")
+    meta["author"] = kwargs.get("author", "test system")
+    meta["description"] = kwargs.get("description", "blah blah blah")
+    meta["useafter"] = kwargs.get("useafter", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
+    meta["reftype"] = kwargs.get("reftype", "")
 
     return meta

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -64,7 +64,7 @@ def mk_wfi_mode(**kwargs):
     mode = stnode.WfiMode()
     mode["name"] = kwargs.get("name", "WFI")
     mode["detector"] = kwargs.get("detector", "WFI01")
-    mode["optical_element"] = kwargs.get("optical_element", "F062")
+    mode["optical_element"] = kwargs.get("optical_element", "F158")
 
     return mode
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -1,4 +1,5 @@
 from astropy import time
+from astropy import units as u
 
 from roman_datamodels import stnode
 from roman_datamodels.random_utils import generate_positive_int, generate_string
@@ -491,7 +492,7 @@ def mk_guidewindow_meta(**kwargs):
     return meta
 
 
-def mk_ref_common(**kwargs):
+def mk_ref_common(reftype="", **kwargs):
     """
     Create dummy metadata for reference file instances.
 
@@ -507,6 +508,116 @@ def mk_ref_common(**kwargs):
     meta["author"] = kwargs.get("author", "test system")
     meta["description"] = kwargs.get("description", "blah blah blah")
     meta["useafter"] = kwargs.get("useafter", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
-    meta["reftype"] = kwargs.get("reftype", "")
+    meta["reftype"] = kwargs.get("reftype", reftype)
+
+    return meta
+
+
+def _mk_ref_exposure(**kwargs):
+    """
+    Create the general exposure meta data
+    """
+    exposure = {}
+    exposure["type"] = kwargs.get("type", "WFI_IMAGE")
+    exposure["p_exptype"] = kwargs.get("p_exptype", "WFI_IMAGE|WFI_GRISM|WFI_PRISM|")
+
+    return exposure
+
+
+def _mk_ref_dark_exposure(**kwargs):
+    """
+    Create the dark exposure meta data
+    """
+    exposure = _mk_ref_exposure(**kwargs)
+    exposure["ngroups"] = kwargs.get("ngroups", 6)
+    exposure["nframes"] = kwargs.get("nframes", 8)
+    exposure["groupgap"] = kwargs.get("groupgap", 0)
+    exposure["ma_table_name"] = kwargs.get("ma_table_name", NOSTR)
+    exposure["ma_table_number"] = kwargs.get("ma_table_number", NONUM)
+
+    return exposure
+
+
+def mk_ref_dark_meta(**kwargs):
+    """
+    Create dummy metadata for dark reference file instances.
+
+    Returns
+    -------
+    dict (follows reference_file/ref_common-1.0.0 schema + dark reference file metadata)
+    """
+    meta = mk_ref_common("DARK", **kwargs)
+    meta["exposure"] = _mk_ref_dark_exposure(**kwargs.get("exposure", {}))
+
+    return meta
+
+
+def mk_ref_distoriton_meta(**kwargs):
+    """
+    Create dummy metadata for distortion reference file instances.
+
+    Returns
+    -------
+    dict (follows reference_file/ref_common-1.0.0 schema + distortion reference file metadata)
+    """
+    meta = mk_ref_common("DISTORTION", **kwargs)
+
+    meta["input_units"] = kwargs.get("input_units", u.pixel)
+    meta["output_units"] = kwargs.get("output_units", u.arcsec)
+
+    return meta
+
+
+def _mk_ref_photometry_meta(**kwargs):
+    """
+    Create the photometry meta data for pixelarea reference files
+    """
+    meta = {}
+    meta["pixelarea_steradians"] = kwargs.get("pixelarea_steradians", float(NONUM) * u.sr)
+    meta["pixelarea_arcsecsq"] = kwargs.get("pixelarea_arcsecsq", float(NONUM) * u.arcsec**2)
+
+    return meta
+
+
+def mk_ref_pixelarea_meta(**kwargs):
+    """
+    Create dummy metadata for pixelarea reference file instances.
+
+    Returns
+    -------
+    dict (follows reference_file/ref_common-1.0.0 schema + pixelarea reference file metadata)
+    """
+    meta = mk_ref_common("AREA", **kwargs)
+    meta["photometry"] = _mk_ref_photometry_meta(**kwargs.get("photometry", {}))
+
+    return meta
+
+
+def mk_ref_units_dn_meta(reftype, **kwargs):
+    """
+    Create dummy metadata for reference file instances which specify DN as input/output units.
+
+    Returns
+    -------
+    dict (follows reference_file/ref_common-1.0.0 schema + DN input/output metadata)
+    """
+    meta = mk_ref_common(reftype, **kwargs)
+
+    meta["input_units"] = kwargs.get("input_units", u.DN)
+    meta["output_units"] = kwargs.get("output_units", u.DN)
+
+    return meta
+
+
+def mk_ref_readnoise_meta(**kwargs):
+    """
+    Create dummy metadata for readnoise reference file instances.
+
+    Returns
+    -------
+    dict (follows reference_file/ref_common-1.0.0 schema + readnoise reference file metadata)
+    """
+    meta = mk_ref_common("READNOISE", **kwargs)
+    meta["exposure"] = _mk_ref_exposure(**kwargs.get("exposure", {}))
 
     return meta

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -7,6 +7,7 @@ from astropy import units as u
 
 from roman_datamodels import stnode
 
+from ._base import MESSAGE
 from ._common_meta import mk_common_meta, mk_guidewindow_meta, mk_photometry_meta, mk_resample_meta
 from ._tagged_nodes import mk_cal_logs
 
@@ -32,6 +33,10 @@ def mk_level1_science_raw(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.WfiScienceRaw
     """
+    if len(shape) != 3:
+        shape = (8, 4096, 4096)
+        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)")
+
     wfi_science_raw = stnode.WfiScienceRaw()
     wfi_science_raw["meta"] = mk_common_meta(**kwargs.get("meta", {}))
 
@@ -67,6 +72,8 @@ def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
         contain the original border reference pixels (i.e if shape = (10, 10),
         the border reference pixel arrays will have (y, x) dimensions (14, 4)
         and (4, 14)). Default is 4088 x 4088.
+        If shape is a tuple of length 3, the first element is assumed to be the
+        n_groups and will override any settings there.
 
     n_groups : int
         (optional, keyword-only) The level 2 file is flattened, but it contains
@@ -80,6 +87,14 @@ def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.WfiImage
     """
+    if len(shape) > 2:
+        shape = shape[1:3]
+        n_groups = shape[0]
+
+        warnings.warn(
+            f"{MESSAGE} assuming the first entry is n_groups followed by y, x. The remaining is thrown out!", UserWarning
+        )
+
     wfi_image = stnode.WfiImage()
     wfi_image["meta"] = mk_photometry_meta(**kwargs.get("meta", {}))
 
@@ -139,6 +154,8 @@ def mk_level3_mosaic(*, shape=(4088, 4088), n_images=2, filepath=None, **kwargs)
     shape : tuple, int
         (optional, keyword-only) Shape (y, x) of data array in the model (and
         its corresponding dq/err arrays). Default is 4088 x 4088.
+        If shape is a tuple of length 3, the first element is assumed to be
+        n_images and will override the n_images parameter.
 
     n_images : int
         Number of images used to create the level 3 image. Defaults to 2.
@@ -150,6 +167,14 @@ def mk_level3_mosaic(*, shape=(4088, 4088), n_images=2, filepath=None, **kwargs)
     -------
     roman_datamodels.stnode.WfiMosaic
     """
+    if len(shape) > 2:
+        shape = shape[1:3]
+        n_images = shape[0]
+
+        warnings.warn(
+            f"{MESSAGE} assuming the first entry is n_images followed by y, x. The remaining is thrown out!", UserWarning
+        )
+
     wfi_mosaic = stnode.WfiMosaic()
     wfi_mosaic["meta"] = mk_resample_meta(**kwargs.get("meta", {}))
 
@@ -196,6 +221,10 @@ def mk_ramp(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.Ramp
     """
+    if len(shape) != 3:
+        shape = (8, 4096, 4096)
+        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)")
+
     ramp = stnode.Ramp()
     ramp["meta"] = mk_common_meta(**kwargs.get("meta", {}))
 
@@ -252,6 +281,10 @@ def mk_ramp_fit_output(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.RampFitOutput
     """
+    if len(shape) != 3:
+        shape = (8, 4096, 4096)
+        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)")
+
     rampfitoutput = stnode.RampFitOutput()
     rampfitoutput["meta"] = mk_common_meta(**kwargs.get("meta", {}))
 
@@ -368,6 +401,10 @@ def mk_guidewindow(*, shape=(2, 8, 16, 32, 32), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.Guidewindow
     """
+    if len(shape) != 5:
+        shape = (2, 8, 16, 32, 32)
+        warnings.warn("Input shape must be 5D. Defaulting to (2, 8, 16, 32, 32)")
+
     guidewindow = stnode.Guidewindow()
     guidewindow["meta"] = mk_guidewindow_meta(**kwargs.get("meta", {}))
 

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -11,62 +11,7 @@ from roman_datamodels.random_utils import generate_string
 
 from ._base import NONUM, NOSTR
 from ._common_meta import mk_common_meta
-
-
-def mk_photometry():
-    """
-    Create a dummy Photometry instance with valid values for attributes
-    required by the schema. Utilized by the model maker utilities below.
-
-    Returns
-    -------
-    roman_datamodels.stnode.Photometry
-    """
-    phot = stnode.Photometry()
-    phot["conversion_microjanskys"] = NONUM * u.uJy / u.sr
-    phot["conversion_megajanskys"] = NONUM * u.MJy / u.sr
-    phot["pixelarea_steradians"] = NONUM * u.sr
-    phot["pixelarea_arcsecsq"] = NONUM * u.arcsec**2
-    phot["conversion_microjanskys_uncertainty"] = NONUM * u.uJy / u.sr
-    phot["conversion_megajanskys_uncertainty"] = NONUM * u.MJy / u.sr
-
-    return phot
-
-
-def mk_cal_logs():
-    """
-    Create a dummy CalLogs instance with valid values for attributes
-    required by the schema.
-
-    Returns
-    -------
-    roman_datamodels.stnode.CalLogs
-    """
-    return stnode.CalLogs(
-        [
-            "2021-11-15T09:15:07.12Z :: FlatFieldStep :: INFO :: Completed",
-            "2021-11-15T10:22.55.55Z :: RampFittingStep :: WARNING :: Wow, lots of Cosmic Rays detected",
-        ]
-    )
-
-
-def mk_resample():
-    """
-    Create a dummy Resample instance with valid values for attributes
-    required by the schema. Utilized by the model maker utilities below.
-
-    Returns
-    -------
-    roman_datamodels.stnode.Resample
-    """
-    res = stnode.Resample()
-    res["pixel_scale_ratio"] = NONUM
-    res["pixfrac"] = NONUM
-    res["pointings"] = -1 * NONUM
-    res["product_exposure_time"] = -1 * NONUM
-    res["weight_type"] = "exptime"
-
-    return res
+from ._tagged_nodes import mk_cal_logs, mk_photometry, mk_resample
 
 
 def mk_level1_science_raw(shape=(8, 4096, 4096), filepath=None):

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -374,7 +374,7 @@ def mk_guidewindow(shape=(2, 8, 16, 32, 32), filepath=None, **kwargs):
         "pedestal_frames", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
     )
     guidewindow["signal_frames"] = kwargs.get(
-        "pedestal_frames", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
+        "signal_frames", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
     )
     guidewindow["amp33"] = kwargs.get("amp33", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16))
 

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -11,21 +11,22 @@ from ._common_meta import mk_common_meta, mk_guidewindow_meta, mk_photometry_met
 from ._tagged_nodes import mk_cal_logs
 
 
-def mk_level1_science_raw(shape=(8, 4096, 4096), filepath=None, **kwargs):
+def mk_level1_science_raw(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy level 1 ScienceRaw instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy level 1 ScienceRaw instance (or file) with arrays and valid
+    values for attributes required by the schema.
 
     Parameters
     ----------
     shape : tuple, int
-        (optional) (z, y, x) Shape of data array. This includes a four-pixel
-        border representing the reference pixels. Default is (8, 4096, 4096)
+        (optional, keyword-only) (z, y, x) Shape of data array. This includes a
+        four-pixel border representing the reference pixels. Default is
+            (8, 4096, 4096)
         (8 integrations, 4088 x 4088 represent the science pixels, with the
         additional being the border reference pixels).
 
     filepath : str
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -51,7 +52,7 @@ def mk_level1_science_raw(shape=(8, 4096, 4096), filepath=None, **kwargs):
         return wfi_science_raw
 
 
-def mk_level2_image(shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
+def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
     """
     Create a dummy level 2 Image instance (or file) with arrays and valid values
     for attributes required by the schema.
@@ -59,21 +60,21 @@ def mk_level2_image(shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
     Parameters
     ----------
     shape : tuple, int
-        (optional) Shape (y, x) of data array in the model (and its
-        corresponding dq/err arrays). This specified size does NOT include the
-        four-pixel border of reference pixels - those are trimmed at level 2.
-        This size, however, is used to construct the additional arrays that
+        (optional, keyword-only) Shape (y, x) of data array in the model (and
+        its corresponding dq/err arrays). This specified size does NOT include
+        the four-pixel border of reference pixels - those are trimmed at level
+        2.  This size, however, is used to construct the additional arrays that
         contain the original border reference pixels (i.e if shape = (10, 10),
         the border reference pixel arrays will have (y, x) dimensions (14, 4)
         and (4, 14)). Default is 4088 x 4088.
 
     n_groups : int
-        The level 2 file is flattened, but it contains arrays for the original
-        reference pixels which remain 3D. n_groups specifies what the z dimension
-        of these arrays should be. Defaults to 8.
+        (optional, keyword-only) The level 2 file is flattened, but it contains
+        arrays for the original reference pixels which remain 3D. n_groups
+        specifies what the z dimension of these arrays should be. Defaults to 8.
 
     filepath : str
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -128,16 +129,16 @@ def mk_level2_image(shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
         return wfi_image
 
 
-def mk_level3_mosaic(shape=None, n_images=2, filepath=None, **kwargs):
+def mk_level3_mosaic(*, shape=(4088, 4088), n_images=2, filepath=None, **kwargs):
     """
-    Create a dummy level 3 Mosaic instance (or file) with arrays and valid values
-    for attributes required by the schema.
+    Create a dummy level 3 Mosaic instance (or file) with arrays and valid
+    values for attributes required by the schema.
 
     Parameters
     ----------
     shape : tuple, int
-        (optional) Shape (y, x) of data array in the model (and its
-        corresponding dq/err arrays). Default is 4088 x 4088.
+        (optional, keyword-only) Shape (y, x) of data array in the model (and
+        its corresponding dq/err arrays). Default is 4088 x 4088.
 
     n_images : int
         Number of images used to create the level 3 image. Defaults to 2.
@@ -151,8 +152,6 @@ def mk_level3_mosaic(shape=None, n_images=2, filepath=None, **kwargs):
     """
     wfi_mosaic = stnode.WfiMosaic()
     wfi_mosaic["meta"] = mk_resample_meta(**kwargs.get("meta", {}))
-    if not shape:
-        shape = (4088, 4088)
 
     wfi_mosaic["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32))
     wfi_mosaic["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32))
@@ -178,7 +177,7 @@ def mk_level3_mosaic(shape=None, n_images=2, filepath=None, **kwargs):
         return wfi_mosaic
 
 
-def mk_ramp(shape=(8, 4096, 4096), filepath=None, **kwargs):
+def mk_ramp(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Ramp instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -186,12 +185,12 @@ def mk_ramp(shape=(8, 4096, 4096), filepath=None, **kwargs):
     Parameters
     ----------
     shape : tuple, int
-        (optional) Shape (z, y, x) of data array in the model (and its
-        corresponding dq/err arrays). This specified size includes the
+        (optional, keyword-only) Shape (z, y, x) of data array in the model (and
+        its corresponding dq/err arrays). This specified size includes the
         four-pixel border of reference pixels. Default is 8 x 4096 x 4096.
 
     filepath : str
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -236,18 +235,18 @@ def mk_ramp(shape=(8, 4096, 4096), filepath=None, **kwargs):
         return ramp
 
 
-def mk_ramp_fit_output(shape=(8, 4096, 4096), filepath=None, **kwargs):
+def mk_ramp_fit_output(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Rampfit Output instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Rampfit Output instance (or file) with arrays and valid
+    values for attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -290,16 +289,18 @@ def mk_rampfitoutput(**kwargs):
     return mk_ramp_fit_output(**kwargs)
 
 
-def mk_associations(shape=(2, 3, 1), filepath=None, **kwargs):
+def mk_associations(*, shape=(2, 3, 1), filepath=None, **kwargs):
     """
-    Create a dummy Association table instance (or file) with table and valid values for attributes
-    required by the schema.
+    Create a dummy Association table instance (or file) with table and valid
+    values for attributes required by the schema.
+
     Parameters
     ----------
     shape : tuple
-        (optional) The shape of the member elements of products.
+        (optional, keyword-only) The shape of the member elements of products.
     filepath : string
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
+
     Returns
     -------
     roman_datamodels.stnode.AssociationsModel
@@ -350,18 +351,18 @@ def mk_associations(shape=(2, 3, 1), filepath=None, **kwargs):
         return associations
 
 
-def mk_guidewindow(shape=(2, 8, 16, 32, 32), filepath=None, **kwargs):
+def mk_guidewindow(*, shape=(2, 8, 16, 32, 32), filepath=None, **kwargs):
     """
-    Create a dummy Guidewindow instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Guidewindow instance (or file) with arrays and valid values
+    for attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -1,3 +1,5 @@
+import warnings
+
 import asdf
 import numpy as np
 from astropy import units as u
@@ -5,6 +7,7 @@ from astropy.modeling import models
 
 from roman_datamodels import stnode
 
+from ._base import MESSAGE
 from ._common_meta import (
     mk_ref_common,
     mk_ref_dark_meta,
@@ -41,6 +44,7 @@ def mk_flat(*, shape=(4096, 4096), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -49,6 +53,11 @@ def mk_flat(*, shape=(4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.FlatRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     flatref = stnode.FlatRef()
     flatref["meta"] = mk_ref_common("FLAT", **kwargs.get("meta", {}))
 
@@ -81,6 +90,10 @@ def mk_dark(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.DarkRef
     """
+    if len(shape) != 3:
+        shape = (2, 4096, 4096)
+        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)")
+
     darkref = stnode.DarkRef()
     darkref["meta"] = mk_ref_dark_meta(**kwargs.get("meta", {}))
 
@@ -135,6 +148,7 @@ def mk_gain(*, shape=(4096, 4096), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -143,6 +157,11 @@ def mk_gain(*, shape=(4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.GainRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     gainref = stnode.GainRef()
     gainref["meta"] = mk_ref_common("GAIN", **kwargs.get("meta", {}))
 
@@ -165,6 +184,7 @@ def mk_ipc(*, shape=(3, 3), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of array in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -173,6 +193,11 @@ def mk_ipc(*, shape=(3, 3), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.IpcRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     ipcref = stnode.IpcRef()
     ipcref["meta"] = mk_ref_common("IPC", **kwargs.get("meta", {}))
 
@@ -207,6 +232,10 @@ def mk_linearity(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.LinearityRef
     """
+    if len(shape) != 3:
+        shape = (2, 4096, 4096)
+        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)")
+
     linearityref = stnode.LinearityRef()
     linearityref["meta"] = mk_ref_units_dn_meta("LINEARITY", **kwargs.get("meta", {}))
 
@@ -238,6 +267,10 @@ def mk_inverse_linearity(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.InverseLinearityRef
     """
+    if len(shape) != 3:
+        shape = (2, 4096, 4096)
+        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)")
+
     inverselinearityref = stnode.InverseLinearityRef()
     inverselinearityref["meta"] = mk_ref_units_dn_meta("INVERSELINEARITY", **kwargs.get("meta", {}))
 
@@ -261,6 +294,7 @@ def mk_mask(*, shape=(4096, 4096), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -269,6 +303,11 @@ def mk_mask(*, shape=(4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.MaskRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     maskref = stnode.MaskRef()
     maskref["meta"] = mk_ref_common("MASK", **kwargs.get("meta", {}))
 
@@ -291,6 +330,7 @@ def mk_pixelarea(*, shape=(4096, 4096), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -299,6 +339,11 @@ def mk_pixelarea(*, shape=(4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.PixelareaRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     pixelarearef = stnode.PixelareaRef()
     pixelarearef["meta"] = mk_ref_pixelarea_meta(**kwargs.get("meta", {}))
 
@@ -377,6 +422,7 @@ def mk_readnoise(*, shape=(4096, 4096), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -385,6 +431,11 @@ def mk_readnoise(*, shape=(4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.ReadnoiseRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     readnoiseref = stnode.ReadnoiseRef()
     readnoiseref["meta"] = mk_ref_readnoise_meta(**kwargs.get("meta", {}))
 
@@ -407,6 +458,7 @@ def mk_saturation(*, shape=(4096, 4096), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -415,6 +467,11 @@ def mk_saturation(*, shape=(4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.SaturationRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     saturationref = stnode.SaturationRef()
     saturationref["meta"] = mk_ref_common("SATURATION", **kwargs.get("meta", {}))
 
@@ -438,6 +495,7 @@ def mk_superbias(*, shape=(4096, 4096), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -446,6 +504,11 @@ def mk_superbias(*, shape=(4096, 4096), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.SuperbiasRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     superbiasref = stnode.SuperbiasRef()
     superbiasref["meta"] = mk_ref_common("BIAS", **kwargs.get("meta", {}))
 
@@ -484,6 +547,7 @@ def mk_refpix(*, shape=(32, 286721), filepath=None, **kwargs):
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+        If shape is greater than 2D, the first two dimensions are used.
 
     filepath
         (optional, keyword-only) File name and path to write model to.
@@ -492,6 +556,11 @@ def mk_refpix(*, shape=(32, 286721), filepath=None, **kwargs):
     -------
     roman_datamodels.stnode.RefPixRef
     """
+    if len(shape) > 2:
+        shape = shape[:2]
+
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+
     refpix = stnode.RefpixRef()
     refpix["meta"] = mk_ref_units_dn_meta("REFPIX", **kwargs.get("meta", {}))
 

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -32,18 +32,18 @@ __all__ = [
 ]
 
 
-def mk_flat(shape=(4096, 4096), filepath=None, **kwargs):
+def mk_flat(*, shape=(4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Flat instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Flat instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -64,18 +64,18 @@ def mk_flat(shape=(4096, 4096), filepath=None, **kwargs):
         return flatref
 
 
-def mk_dark(shape=(2, 4096, 4096), filepath=None, **kwargs):
+def mk_dark(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Dark Current instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Dark Current instance (or file) with arrays and valid values
+    for attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -96,16 +96,16 @@ def mk_dark(shape=(2, 4096, 4096), filepath=None, **kwargs):
         return darkref
 
 
-def mk_distortion(filepath=None, **kwargs):
+def mk_distortion(*, filepath=None, **kwargs):
     """
-    Create a dummy Distortion instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Distortion instance (or file) with arrays and valid values
+    for attributes required by the schema.
 
     Parameters
     ----------
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -126,18 +126,18 @@ def mk_distortion(filepath=None, **kwargs):
         return distortionref
 
 
-def mk_gain(shape=(4096, 4096), filepath=None, **kwargs):
+def mk_gain(*, shape=(4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Gain instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Gain instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -156,18 +156,18 @@ def mk_gain(shape=(4096, 4096), filepath=None, **kwargs):
         return gainref
 
 
-def mk_ipc(shape=(3, 3), filepath=None, **kwargs):
+def mk_ipc(*, shape=(3, 3), filepath=None, **kwargs):
     """
-    Create a dummy IPC instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy IPC instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of array in the model.
+        (optional, keyword-only) Shape of array in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -190,18 +190,18 @@ def mk_ipc(shape=(3, 3), filepath=None, **kwargs):
         return ipcref
 
 
-def mk_linearity(shape=(2, 4096, 4096), filepath=None, **kwargs):
+def mk_linearity(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Linearity instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Linearity instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -221,7 +221,7 @@ def mk_linearity(shape=(2, 4096, 4096), filepath=None, **kwargs):
         return linearityref
 
 
-def mk_inverse_linearity(shape=(2, 4096, 4096), filepath=None, **kwargs):
+def mk_inverse_linearity(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy InverseLinearity instance (or file) with arrays and valid
     values for attributes required by the schema.
@@ -229,10 +229,10 @@ def mk_inverse_linearity(shape=(2, 4096, 4096), filepath=None, **kwargs):
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -252,18 +252,18 @@ def mk_inverse_linearity(shape=(2, 4096, 4096), filepath=None, **kwargs):
         return inverselinearityref
 
 
-def mk_mask(shape=(4096, 4096), filepath=None, **kwargs):
+def mk_mask(*, shape=(4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Mask instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Mask instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -282,18 +282,18 @@ def mk_mask(shape=(4096, 4096), filepath=None, **kwargs):
         return maskref
 
 
-def mk_pixelarea(shape=(4096, 4096), filepath=None, **kwargs):
+def mk_pixelarea(*, shape=(4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Pixelarea instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Pixelarea instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -341,15 +341,15 @@ def _mk_phot_table(**kwargs):
     return {entry: _mk_phot_table_entry(entry, **kwargs.get(entry, {})) for entry in entries}
 
 
-def mk_wfi_img_photom(filepath=None, **kwargs):
+def mk_wfi_img_photom(*, filepath=None, **kwargs):
     """
-    Create a dummy WFI Img Photom instance (or file) with dictionary and valid values for attributes
-    required by the schema.
+    Create a dummy WFI Img Photom instance (or file) with dictionary and valid
+    values for attributes required by the schema.
 
     Parameters
     ----------
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -368,18 +368,18 @@ def mk_wfi_img_photom(filepath=None, **kwargs):
         return wfi_img_photomref
 
 
-def mk_readnoise(shape=(4096, 4096), filepath=None, **kwargs):
+def mk_readnoise(*, shape=(4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Readnoise instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Readnoise instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -398,18 +398,18 @@ def mk_readnoise(shape=(4096, 4096), filepath=None, **kwargs):
         return readnoiseref
 
 
-def mk_saturation(shape=(4096, 4096), filepath=None, **kwargs):
+def mk_saturation(*, shape=(4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Saturation instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Saturation instance (or file) with arrays and valid values
+    for attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -429,18 +429,18 @@ def mk_saturation(shape=(4096, 4096), filepath=None, **kwargs):
         return saturationref
 
 
-def mk_superbias(shape=(4096, 4096), filepath=None, **kwargs):
+def mk_superbias(*, shape=(4096, 4096), filepath=None, **kwargs):
     """
-    Create a dummy Superbias instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Superbias instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------
@@ -461,30 +461,32 @@ def mk_superbias(shape=(4096, 4096), filepath=None, **kwargs):
         return superbiasref
 
 
-def mk_refpix(shape=(32, 286721), filepath=None, **kwargs):
+def mk_refpix(*, shape=(32, 286721), filepath=None, **kwargs):
     """
-    Create a dummy Refpix instance (or file) with arrays and valid values for attributes
-    required by the schema.
+    Create a dummy Refpix instance (or file) with arrays and valid values for
+    attributes required by the schema.
 
-    Note the default shape is intrinically connected to the FFT combined with specifics
-    of the detector:
-        - 32: is the number of detector channels (amp33 is a non-observation channel).
+    Note the default shape is intrinically connected to the FFT combined with
+    specifics of the detector:
+        - 32: is the number of detector channels (amp33 is a non-observation
+            channel).
         - 286721 is more complex:
-            There are 128 columns of the detector per channel, and for time read alignment
-            purposes, these columns are padded by 12 additional columns. That is 140 columns
-            per row. There are 4096 rows per channel. Each channel is then flattened into a
-            1D array of 140 * 4096 = 573440 elements. Since the length is even the FFT of
+            There are 128 columns of the detector per channel, and for time read
+            alignment purposes, these columns are padded by 12 additional
+            columns. That is 140 columns per row. There are 4096 rows per
+            channel. Each channel is then flattened into a 1D array of
+            140 * 4096 = 573440 elements. Since the length is even the FFT of
             this array will be of length (573440 / 2) + 1 = 286721.
-    Also, note the FFT gives a complex value and we are carrying full numerical precision
-    which means it is a complex128.
+    Also, note the FFT gives a complex value and we are carrying full numerical
+    precision which means it is a complex128.
 
     Parameters
     ----------
     shape
-        (optional) Shape of arrays in the model.
+        (optional, keyword-only) Shape of arrays in the model.
 
     filepath
-        (optional) File name and path to write model to.
+        (optional, keyword-only) File name and path to write model to.
 
     Returns
     -------

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -5,8 +5,14 @@ from astropy.modeling import models
 
 from roman_datamodels import stnode
 
-from ._base import NONUM, NOSTR
-from ._common_meta import mk_ref_common
+from ._common_meta import (
+    mk_ref_common,
+    mk_ref_dark_meta,
+    mk_ref_distoriton_meta,
+    mk_ref_pixelarea_meta,
+    mk_ref_readnoise_meta,
+    mk_ref_units_dn_meta,
+)
 
 __all__ = [
     "mk_flat",
@@ -26,7 +32,7 @@ __all__ = [
 ]
 
 
-def mk_flat(shape=(4096, 4096), filepath=None):
+def mk_flat(shape=(4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Flat instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -43,14 +49,12 @@ def mk_flat(shape=(4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.FlatRef
     """
-    meta = mk_ref_common()
     flatref = stnode.FlatRef()
-    meta["reftype"] = "FLAT"
-    flatref["meta"] = meta
+    flatref["meta"] = mk_ref_common("FLAT", **kwargs.get("meta", {}))
 
-    flatref["data"] = np.zeros(shape, dtype=np.float32)
-    flatref["dq"] = np.zeros(shape, dtype=np.uint32)
-    flatref["err"] = np.zeros(shape, dtype=np.float32)
+    flatref["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
+    flatref["dq"] = kwargs.get("dq", np.zeros(shape, dtype=np.uint32))
+    flatref["err"] = kwargs.get("err", np.zeros(shape, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -60,7 +64,7 @@ def mk_flat(shape=(4096, 4096), filepath=None):
         return flatref
 
 
-def mk_dark(shape=(2, 4096, 4096), filepath=None):
+def mk_dark(shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Dark Current instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -77,23 +81,12 @@ def mk_dark(shape=(2, 4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.DarkRef
     """
-    meta = mk_ref_common()
     darkref = stnode.DarkRef()
-    meta["reftype"] = "DARK"
-    darkref["meta"] = meta
-    exposure = {}
-    exposure["ngroups"] = 6
-    exposure["nframes"] = 8
-    exposure["groupgap"] = 0
-    exposure["type"] = "WFI_IMAGE"
-    exposure["p_exptype"] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
-    exposure["ma_table_name"] = NOSTR
-    exposure["ma_table_number"] = NONUM
-    darkref["meta"]["exposure"] = exposure
+    darkref["meta"] = mk_ref_dark_meta(**kwargs.get("meta", {}))
 
-    darkref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
-    darkref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
-    darkref["err"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
+    darkref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
+    darkref["dq"] = kwargs.get("dq", np.zeros(shape[1:], dtype=np.uint32))
+    darkref["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -103,7 +96,7 @@ def mk_dark(shape=(2, 4096, 4096), filepath=None):
         return darkref
 
 
-def mk_distortion(filepath=None):
+def mk_distortion(filepath=None, **kwargs):
     """
     Create a dummy Distortion instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -118,15 +111,12 @@ def mk_distortion(filepath=None):
     -------
     roman_datamodels.stnode.DistortionRef
     """
-    meta = mk_ref_common()
     distortionref = stnode.DistortionRef()
-    meta["reftype"] = "DISTORTION"
-    distortionref["meta"] = meta
+    distortionref["meta"] = mk_ref_distoriton_meta(**kwargs.get("meta", {}))
 
-    distortionref["meta"]["input_units"] = u.pixel
-    distortionref["meta"]["output_units"] = u.arcsec
-
-    distortionref["coordinate_distortion_transform"] = models.Shift(1) & models.Shift(2)
+    distortionref["coordinate_distortion_transform"] = kwargs.get(
+        "coordinate_distortion_transform", models.Shift(1) & models.Shift(2)
+    )
 
     if filepath:
         af = asdf.AsdfFile()
@@ -136,7 +126,7 @@ def mk_distortion(filepath=None):
         return distortionref
 
 
-def mk_gain(shape=(4096, 4096), filepath=None):
+def mk_gain(shape=(4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Gain instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -153,12 +143,10 @@ def mk_gain(shape=(4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.GainRef
     """
-    meta = mk_ref_common()
     gainref = stnode.GainRef()
-    meta["reftype"] = "GAIN"
-    gainref["meta"] = meta
+    gainref["meta"] = mk_ref_common("GAIN", **kwargs.get("meta", {}))
 
-    gainref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.DN, dtype=np.float32)
+    gainref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.DN, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -168,7 +156,7 @@ def mk_gain(shape=(4096, 4096), filepath=None):
         return gainref
 
 
-def mk_ipc(shape=(3, 3), filepath=None):
+def mk_ipc(shape=(3, 3), filepath=None, **kwargs):
     """
     Create a dummy IPC instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -185,13 +173,14 @@ def mk_ipc(shape=(3, 3), filepath=None):
     -------
     roman_datamodels.stnode.IpcRef
     """
-    meta = mk_ref_common()
     ipcref = stnode.IpcRef()
-    meta["reftype"] = "IPC"
-    ipcref["meta"] = meta
+    ipcref["meta"] = mk_ref_common("IPC", **kwargs.get("meta", {}))
 
-    ipcref["data"] = np.zeros(shape, dtype=np.float32)
-    ipcref["data"][int(np.floor(shape[0] / 2))][int(np.floor(shape[1] / 2))] = 1.0
+    if "data" in kwargs:
+        ipcref["data"] = kwargs["data"]
+    else:
+        ipcref["data"] = np.zeros(shape, dtype=np.float32)
+        ipcref["data"][int(np.floor(shape[0] / 2))][int(np.floor(shape[1] / 2))] = 1.0
 
     if filepath:
         af = asdf.AsdfFile()
@@ -201,7 +190,7 @@ def mk_ipc(shape=(3, 3), filepath=None):
         return ipcref
 
 
-def mk_linearity(shape=(2, 4096, 4096), filepath=None):
+def mk_linearity(shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Linearity instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -218,16 +207,11 @@ def mk_linearity(shape=(2, 4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.LinearityRef
     """
-    meta = mk_ref_common()
     linearityref = stnode.LinearityRef()
-    meta["reftype"] = "LINEARITY"
-    linearityref["meta"] = meta
+    linearityref["meta"] = mk_ref_units_dn_meta("LINEARITY", **kwargs.get("meta", {}))
 
-    linearityref["meta"]["input_units"] = u.DN
-    linearityref["meta"]["output_units"] = u.DN
-
-    linearityref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
-    linearityref["coeffs"] = np.zeros(shape, dtype=np.float32)
+    linearityref["dq"] = kwargs.get("dq", np.zeros(shape[1:], dtype=np.uint32))
+    linearityref["coeffs"] = kwargs.get("dq", np.zeros(shape, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -237,7 +221,7 @@ def mk_linearity(shape=(2, 4096, 4096), filepath=None):
         return linearityref
 
 
-def mk_inverse_linearity(shape=(2, 4096, 4096), filepath=None):
+def mk_inverse_linearity(shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy InverseLinearity instance (or file) with arrays and valid
     values for attributes required by the schema.
@@ -254,16 +238,11 @@ def mk_inverse_linearity(shape=(2, 4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.InverseLinearityRef
     """
-    meta = mk_ref_common()
     inverselinearityref = stnode.InverseLinearityRef()
-    meta["reftype"] = "INVERSELINEARITY"
-    inverselinearityref["meta"] = meta
+    inverselinearityref["meta"] = mk_ref_units_dn_meta("INVERSELINEARITY", **kwargs.get("meta", {}))
 
-    inverselinearityref["meta"]["input_units"] = u.DN
-    inverselinearityref["meta"]["output_units"] = u.DN
-
-    inverselinearityref["dq"] = np.zeros(shape[1:], dtype=np.uint32)
-    inverselinearityref["coeffs"] = np.zeros(shape, dtype=np.float32)
+    inverselinearityref["dq"] = kwargs.get("dq", np.zeros(shape[1:], dtype=np.uint32))
+    inverselinearityref["coeffs"] = kwargs.get("coeffs", np.zeros(shape, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -273,7 +252,7 @@ def mk_inverse_linearity(shape=(2, 4096, 4096), filepath=None):
         return inverselinearityref
 
 
-def mk_mask(shape=(4096, 4096), filepath=None):
+def mk_mask(shape=(4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Mask instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -290,12 +269,10 @@ def mk_mask(shape=(4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.MaskRef
     """
-    meta = mk_ref_common()
     maskref = stnode.MaskRef()
-    meta["reftype"] = "MASK"
-    maskref["meta"] = meta
+    maskref["meta"] = mk_ref_common("MASK", **kwargs.get("meta", {}))
 
-    maskref["dq"] = np.zeros(shape, dtype=np.uint32)
+    maskref["dq"] = kwargs.get("dq", np.zeros(shape, dtype=np.uint32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -305,7 +282,7 @@ def mk_mask(shape=(4096, 4096), filepath=None):
         return maskref
 
 
-def mk_pixelarea(shape=(4096, 4096), filepath=None):
+def mk_pixelarea(shape=(4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Pixelarea instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -322,16 +299,10 @@ def mk_pixelarea(shape=(4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.PixelareaRef
     """
-    meta = mk_ref_common()
     pixelarearef = stnode.PixelareaRef()
-    meta["reftype"] = "AREA"
-    meta["photometry"] = {
-        "pixelarea_steradians": float(NONUM) * u.sr,
-        "pixelarea_arcsecsq": float(NONUM) * u.arcsec**2,
-    }
-    pixelarearef["meta"] = meta
+    pixelarearef["meta"] = mk_ref_pixelarea_meta(**kwargs.get("meta", {}))
 
-    pixelarearef["data"] = np.zeros(shape, dtype=np.float32)
+    pixelarearef["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -341,7 +312,36 @@ def mk_pixelarea(shape=(4096, 4096), filepath=None):
         return pixelarearef
 
 
-def mk_wfi_img_photom(filepath=None):
+def _mk_phot_table_entry(key, **kwargs):
+    """
+    Create single phot_table entry for a given key.
+    """
+    if key in ("GRISM", "PRISM", "DARK"):
+        entry = {
+            "photmjsr": kwargs.get("photmjsr"),
+            "uncertainty": kwargs.get("uncertainty"),
+        }
+    else:
+        entry = {
+            "photmjsr": kwargs.get("photmjsr", 1.0e-15 * np.random.random() * u.megajansky / u.steradian),
+            "uncertainty": kwargs.get("uncertainty", 1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+        }
+
+    entry["pixelareasr"] = kwargs.get("pixelareasr", 1.0e-13 * u.steradian)
+
+    return entry
+
+
+def _mk_phot_table(**kwargs):
+    """
+    Create the phot_table for the photom reference file.
+    """
+    entries = ("F062", "F087", "F106", "F129", "F146", "F158", "F184", "F213", "GRISM", "PRISM", "DARK")
+
+    return {entry: _mk_phot_table_entry(entry, **kwargs.get(entry, {})) for entry in entries}
+
+
+def mk_wfi_img_photom(filepath=None, **kwargs):
     """
     Create a dummy WFI Img Photom instance (or file) with dictionary and valid values for attributes
     required by the schema.
@@ -355,57 +355,10 @@ def mk_wfi_img_photom(filepath=None):
     -------
     roman_datamodels.stnode.WfiImgPhotomRef
     """
-    meta = mk_ref_common()
     wfi_img_photomref = stnode.WfiImgPhotomRef()
-    meta["reftype"] = "PHOTOM"
-    wfi_img_photomref["meta"] = meta
+    wfi_img_photomref["meta"] = mk_ref_common("PHOTOM", **kwargs.get("meta", {}))
 
-    wfi_img_photo_dict = {
-        "F062": {
-            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
-            "pixelareasr": 1.0e-13 * u.steradian,
-        },
-        "F087": {
-            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
-            "pixelareasr": 1.0e-13 * u.steradian,
-        },
-        "F106": {
-            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
-            "pixelareasr": 1.0e-13 * u.steradian,
-        },
-        "F129": {
-            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
-            "pixelareasr": 1.0e-13 * u.steradian,
-        },
-        "F146": {
-            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
-            "pixelareasr": 1.0e-13 * u.steradian,
-        },
-        "F158": {
-            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
-            "pixelareasr": 1.0e-13 * u.steradian,
-        },
-        "F184": {
-            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
-            "pixelareasr": 1.0e-13 * u.steradian,
-        },
-        "F213": {
-            "photmjsr": (1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": (1.0e-16 * np.random.random() * u.megajansky / u.steradian),
-            "pixelareasr": 1.0e-13 * u.steradian,
-        },
-        "GRISM": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
-        "PRISM": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
-        "DARK": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1.0e-13 * u.steradian},
-    }
-    wfi_img_photomref["phot_table"] = wfi_img_photo_dict
+    wfi_img_photomref["phot_table"] = _mk_phot_table(**kwargs.get("phot_table", {}))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -415,7 +368,7 @@ def mk_wfi_img_photom(filepath=None):
         return wfi_img_photomref
 
 
-def mk_readnoise(shape=(4096, 4096), filepath=None):
+def mk_readnoise(shape=(4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Readnoise instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -432,16 +385,10 @@ def mk_readnoise(shape=(4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.ReadnoiseRef
     """
-    meta = mk_ref_common()
     readnoiseref = stnode.ReadnoiseRef()
-    meta["reftype"] = "READNOISE"
-    readnoiseref["meta"] = meta
-    exposure = {}
-    exposure["type"] = "WFI_IMAGE"
-    exposure["p_exptype"] = "WFI_IMAGE|WFI_GRISM|WFI_PRISM|"
-    readnoiseref["meta"]["exposure"] = exposure
+    readnoiseref["meta"] = mk_ref_readnoise_meta(**kwargs.get("meta", {}))
 
-    readnoiseref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
+    readnoiseref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -451,7 +398,7 @@ def mk_readnoise(shape=(4096, 4096), filepath=None):
         return readnoiseref
 
 
-def mk_saturation(shape=(4096, 4096), filepath=None):
+def mk_saturation(shape=(4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Saturation instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -468,13 +415,11 @@ def mk_saturation(shape=(4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.SaturationRef
     """
-    meta = mk_ref_common()
     saturationref = stnode.SaturationRef()
-    meta["reftype"] = "SATURATION"
-    saturationref["meta"] = meta
+    saturationref["meta"] = mk_ref_common("SATURATION", **kwargs.get("meta", {}))
 
-    saturationref["dq"] = np.zeros(shape, dtype=np.uint32)
-    saturationref["data"] = u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32)
+    saturationref["dq"] = kwargs.get("dq", np.zeros(shape, dtype=np.uint32))
+    saturationref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -484,7 +429,7 @@ def mk_saturation(shape=(4096, 4096), filepath=None):
         return saturationref
 
 
-def mk_superbias(shape=(4096, 4096), filepath=None):
+def mk_superbias(shape=(4096, 4096), filepath=None, **kwargs):
     """
     Create a dummy Superbias instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -501,14 +446,12 @@ def mk_superbias(shape=(4096, 4096), filepath=None):
     -------
     roman_datamodels.stnode.SuperbiasRef
     """
-    meta = mk_ref_common()
     superbiasref = stnode.SuperbiasRef()
-    meta["reftype"] = "BIAS"
-    superbiasref["meta"] = meta
+    superbiasref["meta"] = mk_ref_common("BIAS", **kwargs.get("meta", {}))
 
-    superbiasref["data"] = np.zeros(shape, dtype=np.float32)
-    superbiasref["dq"] = np.zeros(shape, dtype=np.uint32)
-    superbiasref["err"] = np.zeros(shape, dtype=np.float32)
+    superbiasref["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
+    superbiasref["dq"] = kwargs.get("dq", np.zeros(shape, dtype=np.uint32))
+    superbiasref["err"] = kwargs.get("err", np.zeros(shape, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()
@@ -518,7 +461,7 @@ def mk_superbias(shape=(4096, 4096), filepath=None):
         return superbiasref
 
 
-def mk_refpix(shape=(32, 286721), filepath=None):
+def mk_refpix(shape=(32, 286721), filepath=None, **kwargs):
     """
     Create a dummy Refpix instance (or file) with arrays and valid values for attributes
     required by the schema.
@@ -547,16 +490,12 @@ def mk_refpix(shape=(32, 286721), filepath=None):
     -------
     roman_datamodels.stnode.RefPixRef
     """
-    meta = mk_ref_common()
     refpix = stnode.RefpixRef()
-    meta["reftype"] = "REFPIX"
-    meta["input_units"] = u.DN
-    meta["output_units"] = u.DN
-    refpix["meta"] = meta
+    refpix["meta"] = mk_ref_units_dn_meta("REFPIX", **kwargs.get("meta", {}))
 
-    refpix["gamma"] = np.zeros(shape, dtype=np.complex128)
-    refpix["zeta"] = np.zeros(shape, dtype=np.complex128)
-    refpix["alpha"] = np.zeros(shape, dtype=np.complex128)
+    refpix["gamma"] = kwargs.get("gamma", np.zeros(shape, dtype=np.complex128))
+    refpix["zeta"] = kwargs.get("zeta", np.zeros(shape, dtype=np.complex128))
+    refpix["alpha"] = kwargs.get("alpha", np.zeros(shape, dtype=np.complex128))
 
     if filepath:
         af = asdf.AsdfFile()

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -211,7 +211,7 @@ def mk_linearity(shape=(2, 4096, 4096), filepath=None, **kwargs):
     linearityref["meta"] = mk_ref_units_dn_meta("LINEARITY", **kwargs.get("meta", {}))
 
     linearityref["dq"] = kwargs.get("dq", np.zeros(shape[1:], dtype=np.uint32))
-    linearityref["coeffs"] = kwargs.get("dq", np.zeros(shape, dtype=np.float32))
+    linearityref["coeffs"] = kwargs.get("coeffs", np.zeros(shape, dtype=np.float32))
 
     if filepath:
         af = asdf.AsdfFile()

--- a/src/roman_datamodels/maker_utils/_tagged_nodes.py
+++ b/src/roman_datamodels/maker_utils/_tagged_nodes.py
@@ -1,0 +1,61 @@
+from astropy import units as u
+
+from roman_datamodels import stnode
+
+from ._base import NONUM
+
+
+def mk_photometry():
+    """
+    Create a dummy Photometry instance with valid values for attributes
+    required by the schema. Utilized by the model maker utilities below.
+
+    Returns
+    -------
+    roman_datamodels.stnode.Photometry
+    """
+    phot = stnode.Photometry()
+    phot["conversion_microjanskys"] = NONUM * u.uJy / u.sr
+    phot["conversion_megajanskys"] = NONUM * u.MJy / u.sr
+    phot["pixelarea_steradians"] = NONUM * u.sr
+    phot["pixelarea_arcsecsq"] = NONUM * u.arcsec**2
+    phot["conversion_microjanskys_uncertainty"] = NONUM * u.uJy / u.sr
+    phot["conversion_megajanskys_uncertainty"] = NONUM * u.MJy / u.sr
+
+    return phot
+
+
+def mk_cal_logs():
+    """
+    Create a dummy CalLogs instance with valid values for attributes
+    required by the schema.
+
+    Returns
+    -------
+    roman_datamodels.stnode.CalLogs
+    """
+    return stnode.CalLogs(
+        [
+            "2021-11-15T09:15:07.12Z :: FlatFieldStep :: INFO :: Completed",
+            "2021-11-15T10:22.55.55Z :: RampFittingStep :: WARNING :: Wow, lots of Cosmic Rays detected",
+        ]
+    )
+
+
+def mk_resample():
+    """
+    Create a dummy Resample instance with valid values for attributes
+    required by the schema. Utilized by the model maker utilities below.
+
+    Returns
+    -------
+    roman_datamodels.stnode.Resample
+    """
+    res = stnode.Resample()
+    res["pixel_scale_ratio"] = NONUM
+    res["pixfrac"] = NONUM
+    res["pointings"] = -1 * NONUM
+    res["product_exposure_time"] = -1 * NONUM
+    res["weight_type"] = "exptime"
+
+    return res

--- a/src/roman_datamodels/maker_utils/_tagged_nodes.py
+++ b/src/roman_datamodels/maker_utils/_tagged_nodes.py
@@ -5,7 +5,7 @@ from roman_datamodels import stnode
 from ._base import NONUM
 
 
-def mk_photometry():
+def mk_photometry(**kwargs):
     """
     Create a dummy Photometry instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -15,17 +15,17 @@ def mk_photometry():
     roman_datamodels.stnode.Photometry
     """
     phot = stnode.Photometry()
-    phot["conversion_microjanskys"] = NONUM * u.uJy / u.sr
-    phot["conversion_megajanskys"] = NONUM * u.MJy / u.sr
-    phot["pixelarea_steradians"] = NONUM * u.sr
-    phot["pixelarea_arcsecsq"] = NONUM * u.arcsec**2
-    phot["conversion_microjanskys_uncertainty"] = NONUM * u.uJy / u.sr
-    phot["conversion_megajanskys_uncertainty"] = NONUM * u.MJy / u.sr
+    phot["conversion_microjanskys"] = kwargs.get("conversion_microjanskys", NONUM * u.uJy / u.sr)
+    phot["conversion_megajanskys"] = kwargs.get("conversion_megajanskys", NONUM * u.MJy / u.sr)
+    phot["pixelarea_steradians"] = kwargs.get("pixelarea_steradians", NONUM * u.sr)
+    phot["pixelarea_arcsecsq"] = kwargs.get("pixelarea_arcsecsq", NONUM * u.arcsec**2)
+    phot["conversion_microjanskys_uncertainty"] = kwargs.get("conversion_microjanskys_muncertainty", NONUM * u.uJy / u.sr)
+    phot["conversion_megajanskys_uncertainty"] = kwargs.get("conversion_megajanskys_uncertainty", NONUM * u.MJy / u.sr)
 
     return phot
 
 
-def mk_cal_logs():
+def mk_cal_logs(**kwargs):
     """
     Create a dummy CalLogs instance with valid values for attributes
     required by the schema.
@@ -42,7 +42,7 @@ def mk_cal_logs():
     )
 
 
-def mk_resample():
+def mk_resample(**kwargs):
     """
     Create a dummy Resample instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
@@ -52,10 +52,10 @@ def mk_resample():
     roman_datamodels.stnode.Resample
     """
     res = stnode.Resample()
-    res["pixel_scale_ratio"] = NONUM
-    res["pixfrac"] = NONUM
-    res["pointings"] = -1 * NONUM
-    res["product_exposure_time"] = -1 * NONUM
-    res["weight_type"] = "exptime"
+    res["pixel_scale_ratio"] = kwargs.get("pixel_scale_ratio", NONUM)
+    res["pixfrac"] = kwargs.get("pixfrac", NONUM)
+    res["pointings"] = kwargs.get("pointings", -1 * NONUM)
+    res["product_exposure_time"] = kwargs.get("product_exposure_time", -1 * NONUM)
+    res["weight_type"] = kwargs.get("weight_type", "exptime")
 
     return res

--- a/src/roman_datamodels/maker_utils/_tagged_nodes.py
+++ b/src/roman_datamodels/maker_utils/_tagged_nodes.py
@@ -25,23 +25,6 @@ def mk_photometry(**kwargs):
     return phot
 
 
-def mk_cal_logs(**kwargs):
-    """
-    Create a dummy CalLogs instance with valid values for attributes
-    required by the schema.
-
-    Returns
-    -------
-    roman_datamodels.stnode.CalLogs
-    """
-    return stnode.CalLogs(
-        [
-            "2021-11-15T09:15:07.12Z :: FlatFieldStep :: INFO :: Completed",
-            "2021-11-15T10:22.55.55Z :: RampFittingStep :: WARNING :: Wow, lots of Cosmic Rays detected",
-        ]
-    )
-
-
 def mk_resample(**kwargs):
     """
     Create a dummy Resample instance with valid values for attributes
@@ -59,3 +42,23 @@ def mk_resample(**kwargs):
     res["weight_type"] = kwargs.get("weight_type", "exptime")
 
     return res
+
+
+def mk_cal_logs(**kwargs):
+    """
+    Create a dummy CalLogs instance with valid values for attributes
+    required by the schema.
+
+    Returns
+    -------
+    roman_datamodels.stnode.CalLogs
+    """
+    return stnode.CalLogs(
+        kwargs.get(
+            "cal_logs",
+            [
+                "2021-11-15T09:15:07.12Z :: FlatFieldStep :: INFO :: Completed",
+                "2021-11-15T10:22.55.55Z :: RampFittingStep :: WARNING :: Wow, lots of Cosmic Rays detected",
+            ],
+        )
+    )

--- a/src/roman_datamodels/testing/assertions.py
+++ b/src/roman_datamodels/testing/assertions.py
@@ -29,8 +29,9 @@ def assert_node_equal(node1, node2):
     if isinstance(node1, DNode):
         assert set(node1.keys()) == set(node2.keys())
 
-        for key, value1 in node1.items():
-            value2 = node2[key]
+        for key in node1:
+            value1 = getattr(node1, key)
+            value2 = getattr(node2, key)
             _assert_value_equal(value1, value2)
     elif isinstance(node1, TaggedListNode):
         assert len(node1) == len(node2)
@@ -47,7 +48,7 @@ def assert_node_equal(node1, node2):
 
 
 def _assert_value_equal(value1, value2):
-    if isinstance(value1, (TaggedObjectNode, TaggedListNode, TaggedScalarNode)):
+    if isinstance(value1, (TaggedObjectNode, TaggedListNode, TaggedScalarNode, DNode)):
         assert_node_equal(value1, value2)
     elif isinstance(value1, (np.ndarray, NDArrayType)):
         assert_array_equal(value1, value2)

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -15,25 +15,31 @@ from roman_datamodels.testing import assert_node_equal
 def test_maker_utility_implemented(node_class):
     """
     Confirm that a subclass of TaggedObjectNode has a maker utility.
+
+    (note: will be using full defaults for this one)
     """
     instance = maker_utils.mk_node(node_class)
     assert isinstance(instance, node_class)
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
 def test_instance_valid(node_class):
     """
     Confirm that a class's maker utility creates an object that
     is valid against its schema.
     """
     with asdf.AsdfFile() as af:
-        af["node"] = maker_utils.mk_node(node_class)
+        af["node"] = maker_utils.mk_node(node_class, shape=(8, 8, 8))
         af.validate()
 
 
 @pytest.mark.parametrize("node_class", [c for c in stnode.NODE_CLASSES if issubclass(c, stnode.TaggedObjectNode)])
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
 def test_no_extra_fields(node_class, manifest):
-    instance = maker_utils.mk_node(node_class)
+    instance = maker_utils.mk_node(node_class, shape=(8, 8, 8))
     instance_keys = set(instance.keys())
 
     schema_uri = next(t["schema_uri"] for t in manifest["tags"] if t["tag_uri"] == instance.tag)
@@ -88,22 +94,26 @@ def test_deprecated():
     """
 
     with pytest.warns(DeprecationWarning):
-        maker_utils.mk_rampfitoutput()
+        maker_utils.mk_rampfitoutput(shape=(8, 8, 8))
 
 
 @pytest.mark.parametrize("model_class", [mdl for mdl in maker_utils.NODE_REGISTRY])
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
 def test_datamodel_maker(model_class):
     """
     Test that the datamodel maker utility creates a valid datamodel.
     """
 
-    model = maker_utils.mk_datamodel(model_class)
+    model = maker_utils.mk_datamodel(model_class, shape=(8, 8, 8))
 
     assert isinstance(model, model_class)
     model.validate()
 
 
 @pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
 def test_override_data(node_class):
     """
     Test that we can override data in any maker, all makers are part included in some datamodel,
@@ -163,7 +173,7 @@ def test_override_data(node_class):
             return mutate_value(node)
 
     # Create a node then mutate it.
-    node = maker_utils.mk_node(node_class)
+    node = maker_utils.mk_node(node_class, shape=(8, 8, 8))
     kwargs = mutate_node(node)
 
     # Create a new node using the recorded mutation data. Then check it is equal to the mutated object.

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -1,7 +1,7 @@
 import asdf
 import pytest
 
-from roman_datamodels import maker_utils, stnode
+from roman_datamodels import datamodels, maker_utils, stnode
 from roman_datamodels.maker_utils import _ref_files as ref_files
 
 
@@ -55,16 +55,22 @@ def test_ref_files_all(name):
     assert method_name[:-4] in ref_files.__all__
 
 
-@pytest.mark.parametrize("util", ref_files.__all__)
-def test_make_ref_tests(util):
+@pytest.mark.parametrize("util", [c.__name__ for c in datamodels.MODEL_REGISTRY])
+def test_make_datamodel_tests(util):
     """
-    Meta test to confirm that correct tests exist for each maker utility.
+    Meta test to confirm that correct tests exist for each datamodel maker utility.
     """
+    from roman_datamodels.testing.factories import _camel_case_to_snake_case
+
     from . import test_models as tests
 
-    name = util[3:]
+    name = maker_utils.SPECIAL_MAKERS.get(util, _camel_case_to_snake_case(util))
+    if name.startswith("mk_"):
+        name = name[3:]
+    if name.endswith("_ref"):
+        name = name[:-4]
 
-    assert hasattr(tests, f"test_make_{name}")
+    assert hasattr(tests, f"test_make_{name}"), name
     assert hasattr(tests, f"test_opening_{name}_ref")
 
 

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -84,7 +84,6 @@ def test_make_datamodel_tests(node_class):
         name = name[:-4]
 
     assert hasattr(tests, f"test_make_{name}"), name
-    assert hasattr(tests, f"test_opening_{name}_ref")
 
 
 def test_deprecated():

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -1,8 +1,13 @@
+from unittest import mock
+
 import asdf
 import pytest
+from astropy import units as u
+from astropy.time import Time
 
 from roman_datamodels import datamodels, maker_utils, stnode
 from roman_datamodels.maker_utils import _ref_files as ref_files
+from roman_datamodels.testing import assert_node_equal
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
@@ -55,8 +60,8 @@ def test_ref_files_all(name):
     assert method_name[:-4] in ref_files.__all__
 
 
-@pytest.mark.parametrize("util", [c.__name__ for c in datamodels.MODEL_REGISTRY])
-def test_make_datamodel_tests(util):
+@pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
+def test_make_datamodel_tests(node_class):
     """
     Meta test to confirm that correct tests exist for each datamodel maker utility.
     """
@@ -64,7 +69,8 @@ def test_make_datamodel_tests(util):
 
     from . import test_models as tests
 
-    name = maker_utils.SPECIAL_MAKERS.get(util, _camel_case_to_snake_case(util))
+    name = node_class.__name__
+    name = maker_utils.SPECIAL_MAKERS.get(name, _camel_case_to_snake_case(name))
     if name.startswith("mk_"):
         name = name[3:]
     if name.endswith("_ref"):
@@ -94,3 +100,72 @@ def test_datamodel_maker(model_class):
 
     assert isinstance(model, model_class)
     model.validate()
+
+
+@pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
+def test_override_data(node_class):
+    """
+    Test that we can override data in any maker, all makers are part included in some datamodel,
+    so it is sufficient to work over just the datamodel node classes.
+
+    Note:
+        This test is a bit involved because we need to figure out all the possible overrides on the
+        fly. The way we do this is to run the maker utility, then walk the resulting node object mutating
+        everything along the way. We record the nested dictionary of mutated values and then pass that
+        to the maker utility as the override data.
+
+        Note that we use MagicMock objects to create mutated data, this is because they are very
+        simple to generate new distinct instances that are easy to check. However, they will not
+        pass validation. Because of the way all the maker utilities are implemented, they do not
+        themselves validate the data as they make the object, so this is fine. The above tests
+        explicitly validate all the maker utility outputs, so we don't need to worry about it here.
+        The purpose here is just to inject unique non-default data into the maker utility to override
+        its default values.
+    """
+
+    def mutate_value(value):
+        """
+        Generate a mutated value for a given value.
+            Note:
+                - Time is a special case because it's constructor is picky.
+                - Pure lists need to be preserved.
+                - TaggedScalarNodes need their type preserved.
+        """
+        if isinstance(value, Time):
+            return value + 1 * u.day
+
+        if isinstance(value, list):
+            return [mock.MagicMock()]
+
+        if isinstance(value, stnode.TaggedScalarNode):
+            return value.__class__(mutate_value(value.__class__.__bases__[0](value)))
+
+        return mock.MagicMock()
+
+    def mutate_node(node):
+        """
+        Walk the node object and mutate all its values, returning a dict of the mutated values.
+        """
+        if isinstance(node, stnode.DNode):
+            dict_ = {}
+            for key in node:
+                value = mutate_node(getattr(node, key))
+                node[key] = value
+                dict_[key] = value
+
+            return node.__class__(dict_)
+
+        elif isinstance(node, stnode.LNode):
+            return node.__class__([mutate_node(value) for value in node])
+
+        else:
+            return mutate_value(node)
+
+    # Create a node then mutate it.
+    node = maker_utils.mk_node(node_class)
+    kwargs = mutate_node(node)
+
+    # Create a new node using the recorded mutation data. Then check it is equal to the mutated object.
+    new_node = maker_utils.mk_node(node_class, **kwargs)
+    assert new_node is not node
+    assert_node_equal(new_node, node)

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -1,3 +1,4 @@
+import inspect
 from unittest import mock
 
 import asdf
@@ -169,3 +170,21 @@ def test_override_data(node_class):
     new_node = maker_utils.mk_node(node_class, **kwargs)
     assert new_node is not node
     assert_node_equal(new_node, node)
+
+
+@pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
+def test_keyword_only(node_class):
+    """
+    Ensure all the maker utils at the top level are keyword only.
+    """
+
+    maker = maker_utils._get_node_maker(node_class)
+    sig = inspect.signature(maker)
+
+    assert "kwargs" in sig.parameters
+
+    for param in sig.parameters.values():
+        if param.name == "kwargs":
+            assert param.kind == inspect.Parameter.VAR_KEYWORD
+        else:
+            assert param.kind == inspect.Parameter.KEYWORD_ONLY

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,15 +104,6 @@ def test_make_ramp():
     assert ramp.validate() is None
 
 
-def test_opening_ramp_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testramp.asdf"
-    utils.mk_ramp(filepath=file_path)
-    ramp = datamodels.open(file_path)
-    assert ramp.meta.instrument.optical_element == "F062"
-    assert isinstance(ramp, datamodels.RampModel)
-
-
 # RampFitOutput tests
 def test_make_ramp_fit_output():
     rampfitoutput = utils.mk_ramp_fit_output(shape=(2, 8, 8))
@@ -143,15 +134,6 @@ def test_make_ramp_fit_output():
     assert rampfitoutput_model.validate() is None
 
 
-def test_opening_ramp_fit_output_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testrampfitoutput.asdf"
-    utils.mk_ramp_fit_output(filepath=file_path)
-    rampfitoutput = datamodels.open(file_path)
-    assert rampfitoutput.meta.instrument.optical_element == "F062"
-    assert isinstance(rampfitoutput, datamodels.RampFitOutputModel)
-
-
 # Associations tests
 def test_make_associations():
     member_shapes = (3, 8, 5, 2)
@@ -179,15 +161,6 @@ def test_make_associations():
     # Test validation
     association_model = datamodels.AssociationsModel(association)
     assert association_model.validate() is None
-
-
-def test_opening_associations_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testassociations.asdf"
-    utils.mk_associations(filepath=file_path)
-    association = datamodels.open(file_path)
-    assert association.program == 1
-    assert isinstance(association, datamodels.AssociationsModel)
 
 
 @pytest.mark.parametrize(
@@ -244,15 +217,6 @@ def test_make_guidewindow():
     assert guidewindow_model.validate() is None
 
 
-def test_opening_guidewindow_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testguidewindow.asdf"
-    utils.mk_guidewindow(filepath=file_path)
-    guidewindow = datamodels.open(file_path)
-    assert guidewindow.meta.gw_mode == "WIM-ACQ"
-    assert isinstance(guidewindow, datamodels.GuidewindowModel)
-
-
 # Testing all reference file schemas
 def test_reference_file_model_base(tmp_path):
     # Set temporary asdf file
@@ -285,15 +249,6 @@ def test_make_flat():
     assert flat_model.validate() is None
 
 
-def test_opening_flat_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testflat.asdf"
-    utils.mk_flat(filepath=file_path)
-    flat = datamodels.open(file_path)
-    assert flat.meta.instrument.optical_element == "F158"
-    assert isinstance(flat, datamodels.FlatRefModel)
-
-
 def test_flat_model(tmp_path):
     # Set temporary asdf file
     file_path = tmp_path / "test.asdf"
@@ -301,7 +256,7 @@ def test_flat_model(tmp_path):
     meta = utils.mk_ref_common("FLAT")
     flatref = stnode.FlatRef()
     flatref["meta"] = meta
-    flatref.meta.instrument["optical_element"] = "F062"
+    flatref.meta.instrument["optical_element"] = "F158"
     shape = (4096, 4096)
     flatref["data"] = np.zeros(shape, dtype=np.float32)
     flatref["dq"] = np.zeros(shape, dtype=np.uint32)
@@ -336,15 +291,6 @@ def test_make_dark():
     assert dark_model.validate() is None
 
 
-def test_opening_dark_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testdark.asdf"
-    utils.mk_dark(filepath=file_path)
-    dark = datamodels.open(file_path)
-    assert dark.meta.instrument.optical_element == "F158"
-    assert isinstance(dark, datamodels.DarkRefModel)
-
-
 # Distortion tests
 def test_make_distortion():
     distortion = utils.mk_distortion()
@@ -358,15 +304,6 @@ def test_make_distortion():
     assert distortion_model.validate() is None
 
 
-def test_opening_distortion_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testdistortion.asdf"
-    utils.mk_distortion(filepath=file_path)
-    distortion = datamodels.open(file_path)
-    assert distortion.meta.instrument.optical_element == "F158"
-    assert isinstance(distortion, datamodels.DistortionRefModel)
-
-
 # Gain tests
 def test_make_gain():
     gain = utils.mk_gain(shape=(8, 8))
@@ -377,15 +314,6 @@ def test_make_gain():
     # Test validation
     gain_model = datamodels.GainRefModel(gain)
     assert gain_model.validate() is None
-
-
-def test_opening_gain_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testgain.asdf"
-    utils.mk_gain(filepath=file_path)
-    gain = datamodels.open(file_path)
-    assert gain.meta.instrument.optical_element == "F158"
-    assert isinstance(gain, datamodels.GainRefModel)
 
 
 # Gain tests
@@ -401,17 +329,6 @@ def test_make_ipc():
     assert ipc_model.validate() is None
 
 
-def test_opening_ipc_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testipc.asdf"
-    utils.mk_ipc(filepath=file_path)
-    ipc = datamodels.open(file_path)
-    assert ipc.data[1, 1] == 1.0
-    assert np.sum(ipc.data) == 1.0
-    assert ipc.meta.instrument.optical_element == "F158"
-    assert isinstance(ipc, datamodels.IpcRefModel)
-
-
 # Linearity tests
 def test_make_linearity():
     linearity = utils.mk_linearity(shape=(2, 8, 8))
@@ -422,15 +339,6 @@ def test_make_linearity():
     # Test validation
     linearity_model = datamodels.LinearityRefModel(linearity)
     assert linearity_model.validate() is None
-
-
-def test_opening_linearity_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testlinearity.asdf"
-    utils.mk_linearity(filepath=file_path)
-    linearity = datamodels.open(file_path)
-    assert linearity.meta.instrument.optical_element == "F158"
-    assert isinstance(linearity, datamodels.LinearityRefModel)
 
 
 # InverseLinearity tests
@@ -445,15 +353,6 @@ def test_make_inverse_linearity():
     assert inverselinearity_model.validate() is None
 
 
-def test_opening_inverse_linearity_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testlinearity.asdf"
-    utils.mk_inverse_linearity(filepath=file_path)
-    inverselinearity = datamodels.open(file_path)
-    assert inverselinearity.meta.instrument.optical_element == "F158"
-    assert isinstance(inverselinearity, datamodels.InverseLinearityRefModel)
-
-
 # Mask tests
 def test_make_mask():
     mask = utils.mk_mask(shape=(8, 8))
@@ -463,15 +362,6 @@ def test_make_mask():
     # Test validation
     mask_model = datamodels.MaskRefModel(mask)
     assert mask_model.validate() is None
-
-
-def test_opening_mask_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testmask.asdf"
-    utils.mk_mask(filepath=file_path)
-    mask = datamodels.open(file_path)
-    assert mask.meta.instrument.optical_element == "F158"
-    assert isinstance(mask, datamodels.MaskRefModel)
 
 
 # Pixel Area tests
@@ -487,15 +377,6 @@ def test_make_pixelarea():
     assert pixearea_model.validate() is None
 
 
-def test_opening_pixelarea_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testpixelarea.asdf"
-    utils.mk_pixelarea(filepath=file_path)
-    pixelarea = datamodels.open(file_path)
-    assert pixelarea.meta.instrument.optical_element == "F158"
-    assert isinstance(pixelarea, datamodels.PixelareaRefModel)
-
-
 # Read Noise tests
 def test_make_readnoise():
     readnoise = utils.mk_readnoise(shape=(8, 8))
@@ -506,15 +387,6 @@ def test_make_readnoise():
     # Test validation
     readnoise_model = datamodels.ReadnoiseRefModel(readnoise)
     assert readnoise_model.validate() is None
-
-
-def test_opening_readnoise_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testreadnoise.asdf"
-    utils.mk_readnoise(filepath=file_path)
-    readnoise = datamodels.open(file_path)
-    assert readnoise.meta.instrument.optical_element == "F158"
-    assert isinstance(readnoise, datamodels.ReadnoiseRefModel)
 
 
 def test_add_model_attribute(tmp_path):
@@ -549,15 +421,6 @@ def test_make_saturation():
     assert saturation_model.validate() is None
 
 
-def test_opening_saturation_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testsaturation.asdf"
-    utils.mk_saturation(filepath=file_path)
-    saturation = datamodels.open(file_path)
-    assert saturation.meta.instrument.optical_element == "F158"
-    assert isinstance(saturation, datamodels.SaturationRefModel)
-
-
 # Super Bias tests
 def test_make_superbias():
     superbias = utils.mk_superbias(shape=(8, 8))
@@ -570,15 +433,6 @@ def test_make_superbias():
     # Test validation
     superbias_model = datamodels.SuperbiasRefModel(superbias)
     assert superbias_model.validate() is None
-
-
-def test_opening_superbias_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testsuperbias.asdf"
-    utils.mk_superbias(filepath=file_path)
-    superbias = datamodels.open(file_path)
-    assert superbias.meta.instrument.optical_element == "F158"
-    assert isinstance(superbias, datamodels.SuperbiasRefModel)
 
 
 # Refpix tests
@@ -596,15 +450,6 @@ def test_make_refpix():
 
     assert refpix.meta.input_units == u.DN
     assert refpix.meta.output_units == u.DN
-
-
-def test_opening_refpix_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testrefpix.asdf"
-    utils.mk_refpix(filepath=file_path)
-    refpix = datamodels.open(file_path)
-    assert refpix.meta.instrument.optical_element == "F158"
-    assert isinstance(refpix, datamodels.RefpixRefModel)
 
 
 # WFI Photom tests
@@ -633,16 +478,6 @@ def test_make_wfi_img_photom():
     assert wfi_img_photom_model.validate() is None
 
 
-def test_opening_wfi_img_photom_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testwfi_img_photom.asdf"
-    utils.mk_wfi_img_photom(filepath=file_path)
-    wfi_img_photom = datamodels.open(file_path)
-
-    assert wfi_img_photom.meta.instrument.optical_element == "F158"
-    assert isinstance(wfi_img_photom, datamodels.WfiImgPhotomRefModel)
-
-
 # WFI Level 1 Science Raw tests
 def test_make_level1_science_raw():
     wfi_science_raw = utils.mk_level1_science_raw(shape=(2, 8, 8))
@@ -653,16 +488,6 @@ def test_make_level1_science_raw():
     # Test validation
     wfi_science_raw_model = datamodels.ScienceRawModel(wfi_science_raw)
     assert wfi_science_raw_model.validate() is None
-
-
-def test_opening_level1_science_raw_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testwfi_science_raw.asdf"
-    utils.mk_level1_science_raw(filepath=file_path)
-    wfi_science_raw = datamodels.open(file_path)
-
-    assert wfi_science_raw.meta.instrument.optical_element == "F062"
-    assert isinstance(wfi_science_raw, datamodels.ScienceRawModel)
 
 
 # WFI Level 2 Image tests
@@ -684,16 +509,6 @@ def test_make_level2_image():
     # Test validation
     wfi_image_model = datamodels.ImageModel(wfi_image)
     assert wfi_image_model.validate() is None
-
-
-def test_opening_level2_image_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testwfi_image.asdf"
-    utils.mk_level2_image(filepath=file_path)
-    wfi_image = datamodels.open(file_path)
-
-    assert wfi_image.meta.instrument.optical_element == "F062"
-    assert isinstance(wfi_image, datamodels.ImageModel)
 
 
 # WFI Level 3 Mosaic tests
@@ -719,16 +534,6 @@ def test_make_level3_mosaic():
     assert wfi_mosaic_model.validate() is None
 
 
-def test_opening_level3_mosaic_ref(tmp_path):
-    # First make test reference file
-    file_path = tmp_path / "testwfi_mosaic.asdf"
-    utils.mk_level3_mosaic(filepath=file_path)
-    wfi_mosaic = datamodels.open(file_path)
-
-    assert wfi_mosaic.meta.instrument.optical_element == "F062"
-    assert isinstance(wfi_mosaic, datamodels.MosaicModel)
-
-
 def test_datamodel_info_search(capsys):
     wfi_science_raw = utils.mk_level1_science_raw(shape=(2, 8, 8))
     af = asdf.AsdfFile()
@@ -738,8 +543,8 @@ def test_datamodel_info_search(capsys):
     captured = capsys.readouterr()
     assert "optical_element" in captured.out
     result = dm.search("optical_element")
-    assert "F062" in repr(result)
-    assert result.node == "F062"
+    assert "F158" in repr(result)
+    assert result.node == "F158"
 
 
 def test_datamodel_schema_info():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,8 +13,7 @@ from roman_datamodels import datamodels
 from roman_datamodels import maker_utils as utils
 from roman_datamodels import stnode
 from roman_datamodels.extensions import DATAMODEL_EXTENSIONS
-from roman_datamodels.testing import create_node
-from roman_datamodels.testing.assertions import assert_node_equal
+from roman_datamodels.testing import assert_node_equal
 
 EXPECTED_COMMON_REFERENCE = {"$ref": "ref_common-1.0.0"}
 
@@ -30,7 +29,7 @@ def iter_subclasses(model_class, include_base_model=True):
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
 @pytest.mark.parametrize("node, model", datamodels.MODEL_REGISTRY.items())
 def test_model_schemas(node, model):
-    instance = model(create_node(node))
+    instance = model(utils.mk_node(node))
     asdf.schema.load_schema(instance.schema_uri)
 
 
@@ -817,7 +816,7 @@ def test_model_only_init_with_correct_node(node, correct, model):
     This checks that it can be initiallized with the correct node, and that it cannot be
     with any other node.
     """
-    img = create_node(node)
+    img = utils.mk_node(node)
     with nullcontext() if node is correct else pytest.raises(ValidationError):
         model(img)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -115,7 +115,7 @@ def test_opening_ramp_ref(tmp_path):
 
 
 # RampFitOutput tests
-def test_make_rampfitoutput():
+def test_make_ramp_fit_output():
     rampfitoutput = utils.mk_ramp_fit_output(shape=(2, 20, 20))
 
     assert rampfitoutput.meta.exposure.type == "WFI_IMAGE"
@@ -144,7 +144,7 @@ def test_make_rampfitoutput():
     assert rampfitoutput_model.validate() is None
 
 
-def test_opening_rampfitoutput_ref(tmp_path):
+def test_opening_ramp_fit_output_ref(tmp_path):
     # First make test reference file
     file_path = tmp_path / "testrampfitoutput.asdf"
     utils.mk_ramp_fit_output(filepath=file_path)
@@ -153,8 +153,8 @@ def test_opening_rampfitoutput_ref(tmp_path):
     assert isinstance(rampfitoutput, datamodels.RampFitOutputModel)
 
 
-# Association tests
-def test_make_association():
+# Associations tests
+def test_make_associations():
     member_shapes = (3, 8, 5, 2)
     association = utils.mk_associations(shape=member_shapes)
 
@@ -182,7 +182,7 @@ def test_make_association():
     assert association_model.validate() is None
 
 
-def test_opening_association_ref(tmp_path):
+def test_opening_associations_ref(tmp_path):
     # First make test reference file
     file_path = tmp_path / "testassociations.asdf"
     utils.mk_associations(filepath=file_path)
@@ -646,7 +646,7 @@ def test_opening_wfi_img_photom_ref(tmp_path):
 
 
 # WFI Level 1 Science Raw tests
-def test_level1_science_raw():
+def test_make_level1_science_raw():
     wfi_science_raw = utils.mk_level1_science_raw()
 
     assert wfi_science_raw.data.dtype == np.uint16
@@ -657,7 +657,7 @@ def test_level1_science_raw():
     assert wfi_science_raw_model.validate() is None
 
 
-def test_opening_level1_science_raw(tmp_path):
+def test_opening_level1_science_raw_ref(tmp_path):
     # First make test reference file
     file_path = tmp_path / "testwfi_science_raw.asdf"
     utils.mk_level1_science_raw(filepath=file_path)
@@ -668,7 +668,7 @@ def test_opening_level1_science_raw(tmp_path):
 
 
 # WFI Level 2 Image tests
-def test_level2_image():
+def test_make_level2_image():
     wfi_image = utils.mk_level2_image()
 
     assert wfi_image.data.dtype == np.float32
@@ -688,7 +688,7 @@ def test_level2_image():
     assert wfi_image_model.validate() is None
 
 
-def test_opening_level2_image(tmp_path):
+def test_opening_level2_image_ref(tmp_path):
     # First make test reference file
     file_path = tmp_path / "testwfi_image.asdf"
     utils.mk_level2_image(filepath=file_path)
@@ -699,7 +699,7 @@ def test_opening_level2_image(tmp_path):
 
 
 # WFI Level 3 Mosaic tests
-def test_level3_mosaic():
+def test_make_level3_mosaic():
     wfi_mosaic = utils.mk_level3_mosaic()
 
     assert wfi_mosaic.data.dtype == np.float32
@@ -721,7 +721,7 @@ def test_level3_mosaic():
     assert wfi_mosaic_model.validate() is None
 
 
-def test_opening_level3_mosaic(tmp_path):
+def test_opening_level3_mosaic_ref(tmp_path):
     # First make test reference file
     file_path = tmp_path / "testwfi_mosaic.asdf"
     utils.mk_level3_mosaic(filepath=file_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,7 +38,7 @@ def test_core_schema(tmp_path):
     # Set temporary asdf file
     file_path = tmp_path / "test.asdf"
 
-    wfi_image = utils.mk_level2_image(shape=(10, 10))
+    wfi_image = utils.mk_level2_image(shape=(8, 8))
     with asdf.AsdfFile() as af:
         af.tree = {"roman": wfi_image}
 
@@ -87,16 +87,16 @@ def test_core_schema(tmp_path):
 
 # RampFitOutput tests
 def test_make_ramp():
-    ramp = utils.mk_ramp(shape=(2, 20, 20))
+    ramp = utils.mk_ramp(shape=(2, 8, 8))
 
     assert ramp.meta.exposure.type == "WFI_IMAGE"
     assert ramp.data.dtype == np.float32
     assert ramp.data.unit == u.DN
     assert ramp.pixeldq.dtype == np.uint32
-    assert ramp.pixeldq.shape == (20, 20)
+    assert ramp.pixeldq.shape == (8, 8)
     assert ramp.groupdq.dtype == np.uint8
     assert ramp.err.dtype == np.float32
-    assert ramp.err.shape == (2, 20, 20)
+    assert ramp.err.shape == (2, 8, 8)
     assert ramp.err.unit == u.DN
 
     # Test validation
@@ -115,7 +115,7 @@ def test_opening_ramp_ref(tmp_path):
 
 # RampFitOutput tests
 def test_make_ramp_fit_output():
-    rampfitoutput = utils.mk_ramp_fit_output(shape=(2, 20, 20))
+    rampfitoutput = utils.mk_ramp_fit_output(shape=(2, 8, 8))
 
     assert rampfitoutput.meta.exposure.type == "WFI_IMAGE"
     assert rampfitoutput.slope.dtype == np.float32
@@ -135,8 +135,8 @@ def test_make_ramp_fit_output():
     assert rampfitoutput.var_poisson.unit == u.electron**2 / u.s**2
     assert rampfitoutput.var_rnoise.dtype == np.float32
     assert rampfitoutput.var_rnoise.unit == u.electron**2 / u.s**2
-    assert rampfitoutput.var_poisson.shape == (2, 20, 20)
-    assert rampfitoutput.pedestal.shape == (20, 20)
+    assert rampfitoutput.var_poisson.shape == (2, 8, 8)
+    assert rampfitoutput.pedestal.shape == (8, 8)
 
     # Test validation
     rampfitoutput_model = datamodels.RampFitOutputModel(rampfitoutput)
@@ -226,7 +226,7 @@ def test_read_pattern():
 
 # Guide Window tests
 def test_make_guidewindow():
-    guidewindow = utils.mk_guidewindow(shape=(2, 8, 16, 32, 32))
+    guidewindow = utils.mk_guidewindow(shape=(2, 2, 2, 2, 2))
 
     assert guidewindow.meta.exposure.type == "WFI_IMAGE"
     assert guidewindow.pedestal_frames.dtype == np.uint16
@@ -235,9 +235,9 @@ def test_make_guidewindow():
     assert guidewindow.signal_frames.unit == u.DN
     assert guidewindow.amp33.dtype == np.uint16
     assert guidewindow.amp33.unit == u.DN
-    assert guidewindow.pedestal_frames.shape == (2, 8, 16, 32, 32)
-    assert guidewindow.signal_frames.shape == (2, 8, 16, 32, 32)
-    assert guidewindow.amp33.shape == (2, 8, 16, 32, 32)
+    assert guidewindow.pedestal_frames.shape == (2, 2, 2, 2, 2)
+    assert guidewindow.signal_frames.shape == (2, 2, 2, 2, 2)
+    assert guidewindow.amp33.shape == (2, 2, 2, 2, 2)
 
     # Test validation
     guidewindow_model = datamodels.GuidewindowModel(guidewindow)
@@ -273,11 +273,11 @@ def test_reference_file_model_base(tmp_path):
 
 # Flat tests
 def test_make_flat():
-    flat = utils.mk_flat(shape=(20, 20))
+    flat = utils.mk_flat(shape=(8, 8))
     assert flat.meta.reftype == "FLAT"
     assert flat.data.dtype == np.float32
     assert flat.dq.dtype == np.uint32
-    assert flat.dq.shape == (20, 20)
+    assert flat.dq.shape == (8, 8)
     assert flat.err.dtype == np.float32
 
     # Test validation
@@ -323,11 +323,11 @@ def test_flat_model(tmp_path):
 
 # Dark Current tests
 def test_make_dark():
-    dark = utils.mk_dark(shape=(3, 20, 20))
+    dark = utils.mk_dark(shape=(2, 8, 8))
     assert dark.meta.reftype == "DARK"
     assert dark.data.dtype == np.float32
     assert dark.dq.dtype == np.uint32
-    assert dark.dq.shape == (20, 20)
+    assert dark.dq.shape == (8, 8)
     assert dark.err.dtype == np.float32
     assert dark.data.unit == u.DN
 
@@ -369,7 +369,7 @@ def test_opening_distortion_ref(tmp_path):
 
 # Gain tests
 def test_make_gain():
-    gain = utils.mk_gain(shape=(20, 20))
+    gain = utils.mk_gain(shape=(8, 8))
     assert gain.meta.reftype == "GAIN"
     assert gain.data.dtype == np.float32
     assert gain.data.unit == u.electron / u.DN
@@ -414,7 +414,7 @@ def test_opening_ipc_ref(tmp_path):
 
 # Linearity tests
 def test_make_linearity():
-    linearity = utils.mk_linearity(shape=(2, 20, 20))
+    linearity = utils.mk_linearity(shape=(2, 8, 8))
     assert linearity.meta.reftype == "LINEARITY"
     assert linearity.coeffs.dtype == np.float32
     assert linearity.dq.dtype == np.uint32
@@ -435,7 +435,7 @@ def test_opening_linearity_ref(tmp_path):
 
 # InverseLinearity tests
 def test_make_inverse_linearity():
-    inverselinearity = utils.mk_inverse_linearity(shape=(2, 20, 20))
+    inverselinearity = utils.mk_inverse_linearity(shape=(2, 8, 8))
     assert inverselinearity.meta.reftype == "INVERSELINEARITY"
     assert inverselinearity.coeffs.dtype == np.float32
     assert inverselinearity.dq.dtype == np.uint32
@@ -456,7 +456,7 @@ def test_opening_inverse_linearity_ref(tmp_path):
 
 # Mask tests
 def test_make_mask():
-    mask = utils.mk_mask(shape=(20, 20))
+    mask = utils.mk_mask(shape=(8, 8))
     assert mask.meta.reftype == "MASK"
     assert mask.dq.dtype == np.uint32
 
@@ -476,7 +476,7 @@ def test_opening_mask_ref(tmp_path):
 
 # Pixel Area tests
 def test_make_pixelarea():
-    pixearea = utils.mk_pixelarea(shape=(20, 20))
+    pixearea = utils.mk_pixelarea(shape=(8, 8))
     assert pixearea.meta.reftype == "AREA"
     assert type(pixearea.meta.photometry.pixelarea_steradians) == u.Quantity
     assert type(pixearea.meta.photometry.pixelarea_arcsecsq) == u.Quantity
@@ -498,7 +498,7 @@ def test_opening_pixelarea_ref(tmp_path):
 
 # Read Noise tests
 def test_make_readnoise():
-    readnoise = utils.mk_readnoise(shape=(20, 20))
+    readnoise = utils.mk_readnoise(shape=(8, 8))
     assert readnoise.meta.reftype == "READNOISE"
     assert readnoise.data.dtype == np.float32
     assert readnoise.data.unit == u.DN
@@ -538,7 +538,7 @@ def test_add_model_attribute(tmp_path):
 
 # Saturation tests
 def test_make_saturation():
-    saturation = utils.mk_saturation(shape=(20, 20))
+    saturation = utils.mk_saturation(shape=(8, 8))
     assert saturation.meta.reftype == "SATURATION"
     assert saturation.dq.dtype == np.uint32
     assert saturation.data.dtype == np.float32
@@ -560,12 +560,12 @@ def test_opening_saturation_ref(tmp_path):
 
 # Super Bias tests
 def test_make_superbias():
-    superbias = utils.mk_superbias(shape=(20, 20))
+    superbias = utils.mk_superbias(shape=(8, 8))
     assert superbias.meta.reftype == "BIAS"
     assert superbias.data.dtype == np.float32
     assert superbias.err.dtype == np.float32
     assert superbias.dq.dtype == np.uint32
-    assert superbias.dq.shape == (20, 20)
+    assert superbias.dq.shape == (8, 8)
 
     # Test validation
     superbias_model = datamodels.SuperbiasRefModel(superbias)
@@ -583,16 +583,16 @@ def test_opening_superbias_ref(tmp_path):
 
 # Refpix tests
 def test_make_refpix():
-    refpix = utils.mk_refpix(shape=(20, 20))
+    refpix = utils.mk_refpix(shape=(8, 8))
     assert refpix.meta.reftype == "REFPIX"
 
     assert refpix.gamma.dtype == np.complex128
     assert refpix.zeta.dtype == np.complex128
     assert refpix.alpha.dtype == np.complex128
 
-    assert refpix.gamma.shape == (20, 20)
-    assert refpix.zeta.shape == (20, 20)
-    assert refpix.alpha.shape == (20, 20)
+    assert refpix.gamma.shape == (8, 8)
+    assert refpix.zeta.shape == (8, 8)
+    assert refpix.alpha.shape == (8, 8)
 
     assert refpix.meta.input_units == u.DN
     assert refpix.meta.output_units == u.DN
@@ -645,7 +645,7 @@ def test_opening_wfi_img_photom_ref(tmp_path):
 
 # WFI Level 1 Science Raw tests
 def test_make_level1_science_raw():
-    wfi_science_raw = utils.mk_level1_science_raw()
+    wfi_science_raw = utils.mk_level1_science_raw(shape=(2, 8, 8))
 
     assert wfi_science_raw.data.dtype == np.uint16
     assert wfi_science_raw.data.unit == u.DN
@@ -667,7 +667,7 @@ def test_opening_level1_science_raw_ref(tmp_path):
 
 # WFI Level 2 Image tests
 def test_make_level2_image():
-    wfi_image = utils.mk_level2_image()
+    wfi_image = utils.mk_level2_image(shape=(8, 8))
 
     assert wfi_image.data.dtype == np.float32
     assert wfi_image.data.unit == u.electron / u.s
@@ -698,7 +698,7 @@ def test_opening_level2_image_ref(tmp_path):
 
 # WFI Level 3 Mosaic tests
 def test_make_level3_mosaic():
-    wfi_mosaic = utils.mk_level3_mosaic()
+    wfi_mosaic = utils.mk_level3_mosaic(shape=(8, 8))
 
     assert wfi_mosaic.data.dtype == np.float32
     assert wfi_mosaic.data.unit == u.electron / u.s
@@ -730,7 +730,7 @@ def test_opening_level3_mosaic_ref(tmp_path):
 
 
 def test_datamodel_info_search(capsys):
-    wfi_science_raw = utils.mk_level1_science_raw()
+    wfi_science_raw = utils.mk_level1_science_raw(shape=(2, 8, 8))
     af = asdf.AsdfFile()
     af.tree = {"roman": wfi_science_raw}
     dm = datamodels.open(af)
@@ -743,7 +743,7 @@ def test_datamodel_info_search(capsys):
 
 
 def test_datamodel_schema_info():
-    wfi_science_raw = utils.mk_level1_science_raw()
+    wfi_science_raw = utils.mk_level1_science_raw(shape=(2, 8, 8))
     af = asdf.AsdfFile()
     af.tree = {"roman": wfi_science_raw}
     dm = datamodels.open(af)
@@ -795,7 +795,7 @@ def test_crds_parameters(tmp_path):
 
 def test_model_validate_without_save():
     # regression test for rcal-538
-    img = utils.mk_level2_image()
+    img = utils.mk_level2_image(shape=(8, 8))
     m = datamodels.ImageModel(img)
 
     # invalidate pointing without using the
@@ -810,19 +810,21 @@ def test_model_validate_without_save():
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
 @pytest.mark.parametrize("node", datamodels.MODEL_REGISTRY.keys())
 @pytest.mark.parametrize("correct, model", datamodels.MODEL_REGISTRY.items())
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
 def test_model_only_init_with_correct_node(node, correct, model):
     """
     Datamodels should only be initializable with the correct node in the model_registry.
     This checks that it can be initiallized with the correct node, and that it cannot be
     with any other node.
     """
-    img = utils.mk_node(node)
+    img = utils.mk_node(node, shape=(2, 8, 8))
     with nullcontext() if node is correct else pytest.raises(ValidationError):
         model(img)
 
 
 def test_ramp_from_science_raw():
-    raw = datamodels.ScienceRawModel(utils.mk_level1_science_raw())
+    raw = datamodels.ScienceRawModel(utils.mk_level1_science_raw(shape=(2, 8, 8)))
 
     ramp = datamodels.RampModel.from_science_raw(raw)
     for key in ramp:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -299,8 +299,7 @@ def test_flat_model(tmp_path):
     # Set temporary asdf file
     file_path = tmp_path / "test.asdf"
 
-    meta = utils.mk_ref_common()
-    meta["reftype"] = "FLAT"
+    meta = utils.mk_ref_common("FLAT")
     flatref = stnode.FlatRef()
     flatref["meta"] = meta
     flatref.meta.instrument["optical_element"] = "F062"

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -23,9 +23,11 @@ def test_generated_node_classes(manifest):
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
 def test_copy(node_class):
     """Demonstrate nodes can copy themselves, but don't always deepcopy."""
-    node = maker_utils.mk_node(node_class)
+    node = maker_utils.mk_node(node_class, shape=(8, 8, 8))
     node_copy = node.copy()
 
     # Assert the copy is shallow:
@@ -40,8 +42,10 @@ def test_copy(node_class):
 
 @pytest.mark.parametrize("node_class", datamodels.MODEL_REGISTRY.keys())
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
 def test_deepcopy_model(node_class):
-    node = maker_utils.mk_node(node_class)
+    node = maker_utils.mk_node(node_class, shape=(8, 8, 8))
     model = datamodels.MODEL_REGISTRY[node_class](node)
     model_copy = model.copy()
 
@@ -74,10 +78,12 @@ def test_wfi_mode():
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
 def test_serialization(node_class, tmp_path):
     file_path = tmp_path / "test.asdf"
 
-    node = maker_utils.mk_node(node_class)
+    node = maker_utils.mk_node(node_class, shape=(8, 8, 8))
     with asdf.AsdfFile() as af:
         af["node"] = node
         af.write_to(file_path)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses @ddavis-stsci's https://github.com/spacetelescope/roman_datamodels/pull/197#issuecomment-1591716402, wherein it was suggested that #197 needed more work. The work suggested is totally independent of #197. This PR updates the `maker_utils` so that:

1. Any data parameter set by a maker_util can now be overridden via passing an appropriately nested dictionary.
2. The API for passing array shape parameters to `maker_utils` for datamodels is now flexible enough that they now all accept a common API, while making no outside changes to the API (basically the open `**kwargs` enable enough flexibility to support this).

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/231/ (requires spacetelescope/romancal#717 changes to romancal).
