### PR TITLE
measure coverage on package not tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands =
     pytest \
     warnings: -W error \
     xdist: -n auto \
-    cov: --cov . --cov-config pyproject.toml --cov-report term-missing --cov-report xml \
+    cov: --cov=roman_datamodels --cov-config pyproject.toml --cov-report term-missing --cov-report xml \
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
It appears the coverage measurement in the CI is measuring coverage of the tests, not the package as seen by the coverage results:
https://app.codecov.io/gh/spacetelescope/roman_datamodels
and an example of a recent coverage run:
https://github.com/spacetelescope/roman_datamodels/actions/runs/5283947700/jobs/9560855551#step:10:97

Is this expected or should the coverage be run against the package?

This PR switches the coverage measurement to run against the package and not the tests. It might be preferable to include both the package and tests (this can be helpful to catch test definitions with the same name and other bugs in the tests) but I'm not sure how to do this. @zacharyburnett is there an incantation that will enable coverage for both?

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
