### PR TITLE
Add test for DataModel.schema_uri and update to non-deprecated usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@
 - Update ``roman_datamodels`` to support the new reference file for the
   reference pixel correction. [#190]
 
+- Update ``DataModel.schema_uri`` to use non-deprecated
+  ``TagDefinition.schema_uris`` from asdf [#209]
+
 0.15.0 (2023-05-15)
 ===================
 

--- a/src/roman_datamodels/datamodels.py
+++ b/src/roman_datamodels/datamodels.py
@@ -111,7 +111,7 @@ class DataModel:
     @property
     def schema_uri(self):
         # Determine the schema corresponding to this model's tag
-        schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags if t.tag_uri == self._instance._tag).schema_uri
+        schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags if t.tag_uri == self._instance._tag).schema_uris[0]
         return schema_uri
 
     def close(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,11 +27,11 @@ def iter_subclasses(model_class, include_base_model=True):
         yield from iter_subclasses(sub_class)
 
 
-def test_model_schemas():
-    dmodels = datamodels.MODEL_REGISTRY.keys()
-    for model in dmodels:
-        schema_uri = next(t for t in DATAMODEL_EXTENSIONS[0].tags if t._tag_uri == model._tag).schema_uris[0]
-        asdf.schema.load_schema(schema_uri)
+@pytest.mark.filterwarnings("ignore:ERFA function.*")
+@pytest.mark.parametrize("node, model", datamodels.MODEL_REGISTRY.items())
+def test_model_schemas(node, model):
+    instance = model(create_node(node))
+    asdf.schema.load_schema(instance.schema_uri)
 
 
 # Testing core schema


### PR DESCRIPTION
`TagDefinition.schema_uri` is deprecated since asdf (since 2.9)
https://asdf.readthedocs.io/en/stable/api/asdf.extension.TagDefinition.html#asdf.extension.TagDefinition.schema_uri
and is currently used by `DataModel.schema_uri`.

This PR updates `DataModel.schema_uri` to use the non-deprecated `TagDefinition.scham_uris` (note the `s`). This PR also adds a test to cover `DataModel.schema_uri` which was not previously being tests (see https://github.com/spacetelescope/roman_datamodels/pull/208).

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/234/