### PR TITLE
Make use of the new `datamodel_name` keyword in RAD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,9 @@
 ===================
 - Remove the ``random_utils`` module and make ``maker_utils`` entirely deterministic. [#217]
 
+- Add tests to ensure consistency between file-level schemas in RAD and the corresponding
+  datamodels in ``roman_datamodels``. [#214]
+
 0.16.1 (2023-06-27)
 ===================
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,14 +17,6 @@ from roman_datamodels.testing import assert_node_equal
 EXPECTED_COMMON_REFERENCE = {"$ref": "ref_common-1.0.0"}
 
 
-# Helper class to iterate over model subclasses
-def iter_subclasses(model_class, include_base_model=True):
-    if include_base_model:
-        yield model_class
-    for sub_class in model_class.__subclasses__():
-        yield from iter_subclasses(sub_class)
-
-
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
 @pytest.mark.parametrize("node, model", datamodels.MODEL_REGISTRY.items())
 def test_model_schemas(node, model):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,7 +14,46 @@ from roman_datamodels import maker_utils as utils
 from roman_datamodels import stnode
 from roman_datamodels.testing import assert_node_equal
 
+from .conftest import MANIFEST
+
 EXPECTED_COMMON_REFERENCE = {"$ref": "ref_common-1.0.0"}
+
+
+def datamodel_names():
+    names = []
+
+    extension_manager = asdf.AsdfFile().extension_manager
+    for tag in MANIFEST["tags"]:
+        schema_uri = extension_manager.get_tag_definition(tag["tag_uri"]).schema_uris[0]
+        schema = asdf.schema.load_schema(schema_uri, resolve_references=True)
+
+        if "datamodel_name" in schema:
+            names.append(schema["datamodel_name"])
+
+    return names
+
+
+@pytest.mark.parametrize("name", datamodel_names())
+def test_datamodel_exists(name):
+    """
+    Confirm that a datamodel exists for every schema indicating that it is a datamodel
+    """
+    assert hasattr(datamodels, name)
+
+
+@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
+def test_node_type_matches_model(model):
+    """
+    Test that the _node_type listed for each model is what is listed in the schema
+    """
+    node_type = model._node_type
+    node = utils.mk_node(node_type, shape=(8, 8, 8))
+    schema = node.get_schema()
+    name = schema["datamodel_name"]
+
+    assert model.__name__ == name
 
 
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
@@ -22,19 +61,6 @@ EXPECTED_COMMON_REFERENCE = {"$ref": "ref_common-1.0.0"}
 def test_model_schemas(node, model):
     instance = model(utils.mk_node(node))
     asdf.schema.load_schema(instance.schema_uri)
-
-
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_node_type_matches_model(model):
-    """
-    Test that the _node_type listed for each model is what is listed in the schema
-    """
-    node_type = model._node_type
-    node = utils.mk_node(node_type)
-    schema = node.get_schema()
-    name = schema["datamodel_name"]
-
-    assert model.__name__ == name
 
 
 # Testing core schema

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,6 +32,19 @@ def test_model_schemas(node, model):
     asdf.schema.load_schema(instance.schema_uri)
 
 
+@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
+def test_node_type_matches_model(model):
+    """
+    Test that the _node_type listed for each model is what is listed in the schema
+    """
+    node_type = model._node_type
+    node = utils.mk_node(node_type)
+    schema = node.get_schema()
+    name = schema["datamodel_name"]
+
+    assert model.__name__ == name
+
+
 # Testing core schema
 def test_core_schema(tmp_path):
     # Set temporary asdf file


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This is a follow on PR to spacetelescope/rad#278, which describes the reasoning behind the `datamodel_name` and implements it.

This PR simply adds the consistency testing described by spacetelescope/rad#278 to `roman_datamodels`.

Note that this PR is built on top of #201 as it directly associates a datamodel type with an stnode type which is created directly from the RAD schemas. It is possible to do this without #201, but those changes make it much simpler to implement.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] ~Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/~ This only effects roman_datamodels testing.
