### PR TITLE
add jquery sphinx extension to fix docs search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,7 @@ extensions = [
     "sphinx_automodapi.autodoc_enhancements",
     "sphinx_automodapi.smart_resolver",
     "sphinx_asdf",
+    "sphinxcontrib.jquery",
 ]
 
 if on_rtd:


### PR DESCRIPTION
Search is currently not working in docs because of missing `jQuery`:
https://roman-datamodels.readthedocs.io/en/latest/search.html?q=foo&check_keywords=yes&area=default

This PR applies the same fix as this jwst PR https://github.com/spacetelescope/jwst/pull/7524 which fixed a similar issue.

Fixes: https://github.com/spacetelescope/roman_datamodels/issues/223

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
