### PR TITLE
Update `maker_utils` for new `cal_step` keys.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@
 - Use ValidationError from asdf.exceptions instead of jsonschema. Increase minimum
   asdf version to 2.15.0. [#234]
 
+- Update ``maker_utils`` to support the new ``cal_step`` keys. [#228]
+
 0.16.1 (2023-06-27)
 ===================
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -305,16 +305,20 @@ def mk_cal_step(**kwargs):
     roman_datamodels.stnode.CalStep
     """
     calstep = stnode.CalStep()
-    calstep["flat_field"] = kwargs.get("flat_field", "INCOMPLETE")
-    calstep["dq_init"] = kwargs.get("dq_init", "INCOMPLETE")
     calstep["assign_wcs"] = kwargs.get("assign_wcs", "INCOMPLETE")
     calstep["dark"] = kwargs.get("dark", "INCOMPLETE")
+    calstep["dq_init"] = kwargs.get("dq_init", "INCOMPLETE")
+    calstep["flat_field"] = kwargs.get("flat_field", "INCOMPLETE")
     calstep["jump"] = kwargs.get("jump", "INCOMPLETE")
     calstep["linearity"] = kwargs.get("linearity", "INCOMPLETE")
     calstep["photom"] = kwargs.get("photom", "INCOMPLETE")
     calstep["source_detection"] = kwargs.get("source_detection", "INCOMPLETE")
+    calstep["outlier_detection"] = kwargs.get("outlier_detection", "INCOMPLETE")
     calstep["ramp_fit"] = kwargs.get("ramp_fit", "INCOMPLETE")
+    calstep["refpix"] = kwargs.get("refpix", "INCOMPLETE")
     calstep["saturation"] = kwargs.get("saturation", "INCOMPLETE")
+    calstep["skymatch"] = kwargs.get("skymatch", "INCOMPLETE")
+    calstep["tweakreg"] = kwargs.get("tweakreg", "INCOMPLETE")
 
     return calstep
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR adds the additional step keys added spacetelescope/rad#282 to the `maker_utils` maker function for `cal_step`.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/276/parameters/. Note Failing tests are due to intermittent issues which will be fixed by spacetelesecope/romancal#771.
