### PR TITLE
use ValidationError from asdf.exceptions instead of jsonschema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,8 @@
   keyword was meant to address; namely, passing a datamodel instance to the constructor for
   that datamodel instance should return the instance back with no modifications. [#235]
 
-- Use ValidationError from asdf.exceptions instead of jsonschema. [#234]
+- Use ValidationError from asdf.exceptions instead of jsonschema. Increase minimum
+  asdf version to 2.15.0. [#234]
 
 0.16.1 (2023-06-27)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@
   keyword was meant to address; namely, passing a datamodel instance to the constructor for
   that datamodel instance should return the instance back with no modifications. [#235]
 
+- Use ValidationError from asdf.exceptions instead of jsonschema. [#234]
+
 0.16.1 (2023-06-27)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
 ]
 dependencies = [
-    'asdf >=2.14.2',
+    'asdf >=2.15.0',
     'asdf-astropy >=0.4.0',
     'gwcs >=0.18.1',
     'psutil >=5.7.2',

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -17,8 +17,8 @@ from pathlib import PurePath
 
 import asdf
 import numpy as np
+from asdf.exceptions import ValidationError
 from astropy.time import Time
-from jsonschema import ValidationError
 
 from roman_datamodels import stnode, validate
 

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -11,8 +11,8 @@ from collections.abc import MutableMapping
 import asdf
 import asdf.schema as asdfschema
 import asdf.yamlutil as yamlutil
-import jsonschema
 import numpy as np
+from asdf.exceptions import ValidationError
 from asdf.tags.core import ndarray
 from asdf.util import HashableDict
 from astropy.time import Time
@@ -36,13 +36,13 @@ def _value_change(path, value, schema, pass_invalid_values, strict_validation, c
         _check_value(value, schema, ctx)
         update = True
 
-    except jsonschema.ValidationError as error:
+    except ValidationError as error:
         update = False
         errmsg = _error_message(path, error)
         if pass_invalid_values:
             update = True
         if strict_validation:
-            raise jsonschema.ValidationError(errmsg)
+            raise ValidationError(errmsg)
         else:
             warnings.warn(errmsg, ValidationWarning)
     return update

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -7,10 +7,10 @@ import warnings
 from contextlib import contextmanager
 from textwrap import dedent
 
-import jsonschema
 from asdf import AsdfFile
 from asdf import schema as asdf_schema
 from asdf import yamlutil
+from asdf.exceptions import ValidationError
 from asdf.util import HashableDict
 
 __all__ = [
@@ -94,7 +94,7 @@ def value_change(value, pass_invalid_values, strict_validation):
     try:
         _check_value(value)
         update = True
-    except jsonschema.ValidationError as errmsg:
+    except ValidationError as errmsg:
         update = False
         if pass_invalid_values:
             update = True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,9 +4,9 @@ from contextlib import nullcontext
 import asdf
 import numpy as np
 import pytest
+from asdf.exceptions import ValidationError
 from astropy import units as u
 from astropy.modeling import Model
-from jsonschema import ValidationError
 from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels


### PR DESCRIPTION
By using asdf.exceptions.ValidationError asdf will be free to make this error hopefully more useful and to untie it from jsonschema.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/278/

passed all except for known failure `test_one_group_small_buffer_fit_ols[none]` see https://github.com/spacetelescope/romancal/issues/769
