### PR TITLE
Clean up random numbers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,12 @@
 
 - Make ``maker_utils`` return the node when writing the node to a file. [#218]
 
+- Clean up overlooked randomness in ``maker_utils`` and tests. [#236]
+
 0.16.1 (2023-06-27)
 ===================
 
-A minor release to set the minimum version of RADD to 0.16.0.
+A minor release to set the minimum version of RAD to 0.16.0.
 
 0.16.0 (2023-06-23)
 ===================

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -322,8 +322,8 @@ def _mk_phot_table_entry(key, **kwargs):
         }
     else:
         entry = {
-            "photmjsr": kwargs.get("photmjsr", 1.0e-15 * np.random.random() * u.megajansky / u.steradian),
-            "uncertainty": kwargs.get("uncertainty", 1.0e-16 * np.random.random() * u.megajansky / u.steradian),
+            "photmjsr": kwargs.get("photmjsr", 1.0e-15 * u.megajansky / u.steradian),
+            "uncertainty": kwargs.get("uncertainty", 1.0e-16 * u.megajansky / u.steradian),
         }
 
     entry["pixelareasr"] = kwargs.get("pixelareasr", 1.0e-13 * u.steradian)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -85,7 +85,7 @@ def test_path_input(tmp_path):
 def test_model_input(tmp_path):
     file_path = tmp_path / "test.asdf"
 
-    data = u.Quantity(np.random.uniform(size=(4, 4)).astype(np.float32), u.electron / u.s, dtype=np.float32)
+    data = u.Quantity(np.random.default_rng(42).uniform(size=(4, 4)).astype(np.float32), u.electron / u.s, dtype=np.float32)
 
     with asdf.AsdfFile() as af:
         af.tree = {"roman": utils.mk_level2_image(shape=(8, 8))}


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
In a similar fashion (though with no bugs intermittent failures) to spacetelescope/romcal#771, this PR makes all of the "random" numbers generated in the tests deterministic and removes a random number generation overlooked in the `maker_utils`.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] ~Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/~
