### PR TITLE
Update cal-step maker to include `resample`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@
 - Use ValidationError from asdf.exceptions instead of jsonschema. Increase minimum
   asdf version to 2.15.0. [#234]
 
-- Update ``maker_utils`` to support the new ``cal_step`` keys. [#228]
+- Update ``maker_utils`` to support the new ``cal_step`` keys. [#228, #243]
 
 - Clean up the ``rdm_open`` function. [#233]
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -319,6 +319,7 @@ def mk_cal_step(**kwargs):
     calstep["saturation"] = kwargs.get("saturation", "INCOMPLETE")
     calstep["skymatch"] = kwargs.get("skymatch", "INCOMPLETE")
     calstep["tweakreg"] = kwargs.get("tweakreg", "INCOMPLETE")
+    calstep["resample"] = kwargs.get("resample", "INCOMPLETE")
 
     return calstep
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR adds support for spacetelescope/rad#295.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] ~Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/~ This adds a non-required entry which is not used by Romancal currently. Meaning this should have no effect on the regression tests.
