### PR TITLE
Clean up some parts of `datamodels._core`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
 - Update minimum version of numpy to 1.22 as this is the oldest version of numpy
   which is currently supported. [#258]
 
+- Fix the initialization of empty DataModels and clean up the datamodel core. [#251]
+
 0.17.1 (2023-08-03)
 ===================
 

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -90,18 +90,22 @@ class DataModel(abc.ABC):
                 return
 
         if init is None:
-            self._asdf = self.open_asdf(init=None, **kwargs)
+            self._instance = self._node_type()
+
         elif isinstance(init, (str, bytes, PurePath)):
             if isinstance(init, PurePath):
                 init = str(init)
             if isinstance(init, bytes):
                 init = init.decode(sys.getfilesystemencoding())
+
             self._asdf = self.open_asdf(init, **kwargs)
             if not self.check_type(self._asdf):
                 raise ValueError(f"ASDF file is not of the type expected. Expected {self.__class__.__name__}")
+
             self._instance = self._asdf.tree["roman"]
         elif isinstance(init, asdf.AsdfFile):
             self._asdf = init
+
             self._instance = self._asdf.tree["roman"]
         else:
             raise OSError("Argument does not appear to be an ASDF file or TaggedObjectNode.")
@@ -303,11 +307,18 @@ class DataModel(abc.ABC):
         """
         validate.value_change(self._instance, pass_invalid_values=False, strict_validation=True)
 
+    @property
+    def asdf(self):
+        if self._asdf is None:
+            self._asdf = asdf.AsdfFile({"roman": self._instance})
+
+        return self._asdf
+
     def info(self, *args, **kwargs):
-        return self._asdf.info(*args, **kwargs)
+        return self.asdf.info(*args, **kwargs)
 
     def search(self, *args, **kwargs):
-        return self._asdf.search(*args, **kwargs)
+        return self.asdf.search(*args, **kwargs)
 
     def schema_info(self, *args, **kwargs):
-        return self._asdf.schema_info(*args, **kwargs)
+        return self.asdf.schema_info(*args, **kwargs)

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -76,21 +76,21 @@ class DataModel(abc.ABC):
         self._shape = None
         self._instance = None
         self._asdf = None
+
         if init is None:
-            asdffile = self.open_asdf(init=None, **kwargs)
+            self._asdf = self.open_asdf(init=None, **kwargs)
         elif isinstance(init, (str, bytes, PurePath)):
             if isinstance(init, PurePath):
                 init = str(init)
             if isinstance(init, bytes):
                 init = init.decode(sys.getfilesystemencoding())
-            asdffile = self.open_asdf(init, **kwargs)
-            if not self.check_type(asdffile):
+            self._asdf = self.open_asdf(init, **kwargs)
+            if not self.check_type(self._asdf):
                 raise ValueError(f"ASDF file is not of the type expected. Expected {self.__class__.__name__}")
-            self._instance = asdffile.tree["roman"]
+            self._instance = self._asdf.tree["roman"]
         elif isinstance(init, asdf.AsdfFile):
-            asdffile = init
-            self._asdf = asdffile
-            self._instance = asdffile.tree["roman"]
+            self._asdf = init
+            self._instance = self._asdf.tree["roman"]
         elif isinstance(init, stnode.TaggedObjectNode):
             if not isinstance(self, MODEL_REGISTRY.get(init.__class__)):
                 expected = {mdl: node for node, mdl in MODEL_REGISTRY.items()}[self.__class__].__name__
@@ -99,11 +99,10 @@ class DataModel(abc.ABC):
                 )
             with validate.nuke_validation():
                 self._instance = init
-                asdffile = asdf.AsdfFile()
-                asdffile.tree = {"roman": init}
+                self._asdf = asdf.AsdfFile()
+                self._asdf.tree = {"roman": init}
         else:
             raise OSError("Argument does not appear to be an ASDF file or TaggedObjectNode.")
-        self._asdf = asdffile
 
     def check_type(self, asdf_file):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import asdf
 import pytest
 import yaml
@@ -8,3 +10,23 @@ MANIFEST = yaml.safe_load(asdf.get_config().resource_manager["asdf://stsci.edu/d
 @pytest.fixture(scope="session")
 def manifest():
     return MANIFEST
+
+
+@pytest.fixture(scope="function")
+def nuke_env_var(request):
+    from roman_datamodels import validate
+
+    assert os.getenv(validate.ROMAN_VALIDATE) == "true"
+    os.environ[validate.ROMAN_VALIDATE] = request.param
+    yield request.param, request.param.lower() in ["true", "yes", "1"]
+    os.environ[validate.ROMAN_VALIDATE] = "true"
+
+
+@pytest.fixture(scope="function")
+def nuke_env_strict_var(request):
+    from roman_datamodels import validate
+
+    assert os.getenv(validate.ROMAN_STRICT_VALIDATION) == "true"
+    os.environ[validate.ROMAN_STRICT_VALIDATION] = request.param
+    yield request.param
+    os.environ[validate.ROMAN_STRICT_VALIDATION] = "true"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,6 +63,29 @@ def test_model_schemas(node, model):
     asdf.schema.load_schema(instance.schema_uri)
 
 
+@pytest.mark.parametrize("node, model", datamodels.MODEL_REGISTRY.items())
+def test_empty_model(node, model):
+    mdl = model()
+    assert isinstance(mdl._instance, node)
+    assert mdl._asdf is None
+
+
+@pytest.mark.parametrize("node, model", datamodels.MODEL_REGISTRY.items())
+def test_empty_model_asdf(node, model):
+    mdl = model()
+
+    # Check there is a validation issue
+    with pytest.raises(asdf.ValidationError):
+        mdl.asdf
+
+    assert mdl._asdf is None
+
+    # Fill in instance properly and check that asdf can be created
+    mdl._instance = utils.mk_node(node)
+    assert mdl.asdf.tree["roman"] is mdl._instance
+    assert mdl._asdf is not None
+
+
 # Testing core schema
 def test_core_schema(tmp_path):
     # Set temporary asdf file


### PR DESCRIPTION
Resolves [RCAL-612](https://jira.stsci.edu/browse/RCAL-612)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #247

<!-- describe the changes comprising this PR here -->
This PR cleans up parts of the `datamodels._core` module and adds the ability to properly initialize an "empty" data model, in so far as that if an empty model is created, one can now successfully add information to it. However, the empty model will not validate until it is fully flushed out, so the recommendation is still to use the appropriate `maker_util`.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/294/. The failure appears to be the intermittent ASDF file open failure we sometimes get when a the network gets a bit slow.
