### PR TITLE
AL-751: Allow DNode and LNode instances to be assigned to tree attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,13 +7,14 @@
 - Update minimum version of numpy to 1.22 as this is the oldest version of numpy
   which is currently supported. [#258]
 
+
+- Allow DNode and LNode subclass instances to be assigned to tree attributes (without
+  immediate validation). [#527]
+
 0.17.1 (2023-08-03)
 ===================
 
 - Fix newly required units from rand [#256]
-
-- Allow DNode and LNode subclass instances to be assigned to tree attributes (without
-  immediate validation). [#527]
 
 - Add checks for for association processing [#241]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@
   which is currently supported. [#258]
 
 - Allow DNode and LNode subclass instances to be assigned to tree attributes (without
-  immediate validation). [#527]
+  immediate validation). [#523]
 
 0.17.1 (2023-08-03)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,8 @@ A minor release to set the minimum version of RAD to 0.16.0.
 
 0.16.0 (2023-06-23)
 ===================
+- Permit assignment of Node subclasses to tree attributes. [xxx]
+
 - Remove ``ModelContainer`` from ``roman_datamodels.datamodels``. [#204]
 
 - Update the ``reftype`` for ``InverseLinearityRev``. [#195]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@
 
 - Fix newly required units from rand [#256]
 
-0.17.0 (2023-07-28)
-===================
+- Allow DNode and LNode subclass instances to be assigned to tree attributes (without
+  immediate validation). [#527]
 
 - Add checks for for association processing [#241]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,6 @@
 - Update minimum version of numpy to 1.22 as this is the oldest version of numpy
   which is currently supported. [#258]
 
-
 - Allow DNode and LNode subclass instances to be assigned to tree attributes (without
   immediate validation). [#527]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,6 @@ A minor release to set the minimum version of RAD to 0.16.0.
 
 0.16.0 (2023-06-23)
 ===================
-- Permit assignment of Node subclasses to tree attributes. [xxx]
 
 - Remove ``ModelContainer`` from ``roman_datamodels.datamodels``. [#204]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@
   which is currently supported. [#258]
 
 - Allow DNode and LNode subclass instances to be assigned to tree attributes (without
-  immediate validation). [#523]
+  immediate validation). [#253]
 
 0.17.1 (2023-08-03)
 ===================

--- a/docs/roman_datamodels/datamodels/using_datamodels.rst
+++ b/docs/roman_datamodels/datamodels/using_datamodels.rst
@@ -100,7 +100,7 @@ page::
 
     There are a couple subtlties with regard to changing values in a datamodel.
     If you assign dicts or lists to attributes, it will map these into the
-    corresponding DNode or LNode subclasses. In such uses, the assigned values 
+    corresponding DNode or LNode subclasses. In such uses, the assigned values
     will be immediately be checked by validating against the defining schemas.
     When the value being assigned fails to pass that validation, an exception
     will occur. This is generally a good thing, particularly if you are changing
@@ -108,7 +108,7 @@ page::
 
     On the other hand, if one assigns to the attribute a subclass of DNode
     or LNode, no immediate validation is done (for current implenentation
-    reasons). If the wrong kind of DNode or LNode is assigned to the 
+    reasons). If the wrong kind of DNode or LNode is assigned to the
     attribute that doesn't match the expected tag for that attribute, the error
     will only be raised when trying to write the file to disk.
 

--- a/docs/roman_datamodels/datamodels/using_datamodels.rst
+++ b/docs/roman_datamodels/datamodels/using_datamodels.rst
@@ -98,9 +98,19 @@ page::
 
 .. note::
 
-	All datamodels have built in validation against the defining schemas.
-	This means that if you try to assign a value that is not allowed according
-	to one of these schemas, you will get an error. This is a good thing!
+    There are a couple subtlties with regard to changing values in a datamodel.
+    If you assign dicts or lists to attributes, it will map these into the
+    corresponding DNode or LNode subclasses. In such uses, the assigned values 
+    will be immediately be checked by validating against the defining schemas.
+    When the value being assigned fails to pass that validation, an exception
+    will occur. This is generally a good thing, particularly if you are changing
+    values interactively
+
+    On the other hand, if one assigns to the attribute a subclass of DNode
+    or LNode, no immediate validation is done (for current implenentation
+    reasons). If the wrong kind of DNode or LNode is assigned to the 
+    attribute that doesn't match the expected tag for that attribute, the error
+    will only be raised when trying to write the file to disk.
 
 	If you are getting validation errors consult the corresponding schema in
 	``rad`` to se what is allowed. If you think the schema is wrong, or you

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -151,9 +151,7 @@ class DNode(MutableMapping):
                 if not (isinstance(value, DNode) or isinstance(value, LNode)):
                     if will_validate():
                         schema = _get_schema_for_property(self._schema(), key)
-                        if schema == {} or _validate(key, value, schema, self.ctx):
-                            # self._data[key] = value
-                            pass
+                        schema == {} or _validate(key, value, schema, self.ctx)
                 self._data[key] = value
             else:
                 raise AttributeError(f"No such attribute ({key}) found in node")

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -142,16 +142,19 @@ class DNode(MutableMapping):
     def __setattr__(self, key, value):
         """
         Permit assigning dict keys as attributes.
+        If the attribute is assigned a Node subclass (whether correct or not),
+        it will not be validated on assignment.
         """
         if key[0] != "_":
             value = self._convert_to_scalar(key, value)
             if key in self._data:
-                if will_validate():
-                    schema = _get_schema_for_property(self._schema(), key)
-
-                    if schema == {} or _validate(key, value, schema, self.ctx):
-                        self._data[key] = value
-                self.__dict__["_data"][key] = value
+                if not (isinstance(value, DNode) or isinstance(value, LNode)):
+                    if will_validate():
+                        schema = _get_schema_for_property(self._schema(), key)
+                        if schema == {} or _validate(key, value, schema, self.ctx):
+                            # self._data[key] = value
+                            pass
+                self._data[key] = value
             else:
                 raise AttributeError(f"No such attribute ({key}) found in node")
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -538,7 +538,7 @@ def test_make_level1_science_raw():
 
 
 # WFI Level 2 Image tests
-def test_make_level2_image(tmp_path):
+def test_make_level2_image():
     wfi_image = utils.mk_level2_image(shape=(8, 8))
 
     assert wfi_image.data.dtype == np.float32
@@ -559,8 +559,8 @@ def test_make_level2_image(tmp_path):
 
 
 # Test that attributes can be assigned subclass instances of DNode or LNode 
-def test_node_assignment(tmp_path):
-    # Test round trip attribute access and assignment
+def test_node_assignment():
+    """Test round trip attribute access and assignment"""
     wfi_image = utils.mk_level2_image(shape=(8, 8))
     wfi_image_model = datamodels.ImageModel(wfi_image)
     aperture = wfi_image.meta.aperture
@@ -568,11 +568,9 @@ def test_node_assignment(tmp_path):
     wfi_image.meta.aperture = aperture
     assert isinstance(wfi_image.meta.aperture, stnode.DNode)
     # Since no validation is done when assigning Nodes to attributes,
-    # test that such an instance is caught on writing to a file.
     wfi_image.meta.aperture = utils.mk_program()
-    file_path = tmp_path / "test.asdf"
     with pytest.raises(ValidationError):
-        wfi_image_model.to_asdf(file_path)
+        wfi_image_model.validate()
 
 
 # WFI Level 3 Mosaic tests

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -557,7 +557,12 @@ def test_make_level2_image(tmp_path):
     wfi_image_model = datamodels.ImageModel(wfi_image)
     assert wfi_image_model.validate() is None
 
+
+# Test that attributes can be assigned subclass instances of DNode or LNode 
+def test_node_assignment(tmp_path):
     # Test round trip attribute access and assignment
+    wfi_image = utils.mk_level2_image(shape=(8, 8))
+    wfi_image_model = datamodels.ImageModel(wfi_image)
     aperture = wfi_image.meta.aperture
     assert isinstance(aperture, stnode.DNode)
     wfi_image.meta.aperture = aperture
@@ -568,7 +573,6 @@ def test_make_level2_image(tmp_path):
     file_path = tmp_path / "test.asdf"
     with pytest.raises(ValidationError):
         wfi_image_model.to_asdf(file_path)
-
 
 
 # WFI Level 3 Mosaic tests

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -558,7 +558,7 @@ def test_make_level2_image():
     assert wfi_image_model.validate() is None
 
 
-# Test that attributes can be assigned subclass instances of DNode or LNode 
+# Test that attributes can be assigned subclass instances of DNode or LNode
 def test_node_assignment():
     """Test round trip attribute access and assignment"""
     wfi_image = utils.mk_level2_image(shape=(8, 8))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -85,7 +85,6 @@ def test_core_schema(tmp_path):
         with pytest.raises(ValidationError):
             af.write_to(file_path)
         af.tree["roman"].meta.telescope = "ROMAN"
-
         # Test origin name
         with pytest.raises(ValidationError):
             # See note above for explanation of why both
@@ -539,7 +538,7 @@ def test_make_level1_science_raw():
 
 
 # WFI Level 2 Image tests
-def test_make_level2_image():
+def test_make_level2_image(tmp_path):
     wfi_image = utils.mk_level2_image(shape=(8, 8))
 
     assert wfi_image.data.dtype == np.float32
@@ -557,6 +556,19 @@ def test_make_level2_image():
     # Test validation
     wfi_image_model = datamodels.ImageModel(wfi_image)
     assert wfi_image_model.validate() is None
+
+    # Test round trip attribute access and assignment
+    aperture = wfi_image.meta.aperture
+    assert isinstance(aperture, stnode.DNode)
+    wfi_image.meta.aperture = aperture
+    assert isinstance(wfi_image.meta.aperture, stnode.DNode)
+    # Since no validation is done when assigning Nodes to attributes,
+    # test that such an instance is caught on writing to a file.
+    wfi_image.meta.aperture = utils.mk_program()
+    file_path = tmp_path / "test.asdf"
+    with pytest.raises(ValidationError):
+        wfi_image_model.to_asdf(file_path)
+
 
 
 # WFI Level 3 Mosaic tests

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -324,3 +324,4 @@ def test_node_representation(model):
                 "optical_element": "F158",
             }
         )
+

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -324,4 +324,3 @@ def test_node_representation(model):
                 "optical_element": "F158",
             }
         )
-


### PR DESCRIPTION
Previously, if one obtained a DNode or LNode subclassed object from referencing a tree attribute, and then subsequently assigned it to the same attribute, a ValidationError was triggered. This was very non-intuitive. This PR permits this to be done, at the cost of not doing immediate validation in such cases (postponing such validation until the model was written, or validation was explicitly requested). Doing so makes the changes much simpler. Support for immediate validation will require much more work. As a result, this implementation allows the assignment of inconsistent objects to the attribute. 

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
