### PR TITLE
Fix maker utils to use correct units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.17.1 (unreleased)
 ===================
 
--
+- Fix newly required units from rand [#256]
 
 0.17.0 (2023-07-28)
 ===================

--- a/src/roman_datamodels/maker_utils/_tagged_nodes.py
+++ b/src/roman_datamodels/maker_utils/_tagged_nodes.py
@@ -15,11 +15,11 @@ def mk_photometry(**kwargs):
     roman_datamodels.stnode.Photometry
     """
     phot = stnode.Photometry()
-    phot["conversion_microjanskys"] = kwargs.get("conversion_microjanskys", NONUM * u.uJy / u.sr)
+    phot["conversion_microjanskys"] = kwargs.get("conversion_microjanskys", NONUM * u.uJy / u.arcsec**2)
     phot["conversion_megajanskys"] = kwargs.get("conversion_megajanskys", NONUM * u.MJy / u.sr)
     phot["pixelarea_steradians"] = kwargs.get("pixelarea_steradians", NONUM * u.sr)
     phot["pixelarea_arcsecsq"] = kwargs.get("pixelarea_arcsecsq", NONUM * u.arcsec**2)
-    phot["conversion_microjanskys_uncertainty"] = kwargs.get("conversion_microjanskys_muncertainty", NONUM * u.uJy / u.sr)
+    phot["conversion_microjanskys_uncertainty"] = kwargs.get("conversion_microjanskys_uncertainty", NONUM * u.uJy / u.arcsec**2)
     phot["conversion_megajanskys_uncertainty"] = kwargs.get("conversion_megajanskys_uncertainty", NONUM * u.MJy / u.sr)
 
     return phot


### PR DESCRIPTION

<!-- describe the changes comprising this PR here -->
This PR properly resolves the units  required by spacetelescope/rad#300 which resolves some inconsistencies between the two libraries.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
