### PR TITLE
Update coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         - linux: py310
         - linux: py311
         - macos: py311
-        - linux: cov
+        - linux: py311-cov
           coverage: codecov
   test_upstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
PR https://github.com/tox-dev/tox/pull/3089 released as part of tox 4.9.0 prevents tox from implicitly creating environments. We were using this to create the tox environment for `cov`. This PR fixes this by explicitly creating the environment in our CI.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] ~Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/~ GitHub CI update
