### PR TITLE
Add badge for weekly cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CI](https://github.com/spacetelescope/roman_datamodels/actions/workflows/ci.yml/badge.svg)](https://github.com/spacetelescope/roman_datamodels/actions/workflows/ci.yml)
+[![Weekly Cron](https://github.com/spacetelescope/roman_datamodels/actions/workflows/ci_cron.yml/badge.svg)](https://github.com/spacetelescope/roman_datamodels/actions/workflows/ci_cron.yml)
 [![codecov](https://codecov.io/gh/spacetelescope/roman_datamodels/branch/main/graph/badge.svg)](https://codecov.io/gh/spacetelescope/roman_datamodels)
 [![Documentation Status](https://readthedocs.org/projects/roman-datamodels/badge/?version=latest)](https://roman-datamodels.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR adds a badge to the readme showing the status of the weekly cron. I find this useful when checking if all is well.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
