### PR TITLE
AL-751 validate on DNode or LNode assignment to a Node attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,11 @@
 - Allow DNode and LNode subclass instances to be assigned to tree attributes and support
   validation of all such instances. [#275]
 
-- Fix newly required units from rand [#256]
-
 - Update minimum version of astropy to 5.3.0 in order to fix a bug due to a breaking
   change in astropy. [#258]
 
 - Update minimum version of numpy to 1.22 as this is the oldest version of numpy
   which is currently supported. [#258]
-
 
 0.17.1 (2023-08-03)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,17 @@
 0.17.2 (unreleased)
 ===================
 
+- Allow DNode and LNode subclass instances to be assigned to tree attributes and support
+  validation of all such instances. [#275]
+
+- Fix newly required units from rand [#256]
+
 - Update minimum version of astropy to 5.3.0 in order to fix a bug due to a breaking
   change in astropy. [#258]
 
 - Update minimum version of numpy to 1.22 as this is the oldest version of numpy
   which is currently supported. [#258]
+
 
 0.17.1 (2023-08-03)
 ===================
@@ -53,6 +59,7 @@ A minor release to set the minimum version of RAD to 0.16.0.
 
 0.16.0 (2023-06-23)
 ===================
+
 - Remove ``ModelContainer`` from ``roman_datamodels.datamodels``. [#204]
 
 - Update the ``reftype`` for ``InverseLinearityRev``. [#195]

--- a/docs/roman_datamodels/datamodels/using_datamodels.rst
+++ b/docs/roman_datamodels/datamodels/using_datamodels.rst
@@ -104,7 +104,7 @@ page::
     will be immediately checked by validating against the defining schemas.
     When the value being assigned fails to pass that validation, an exception
     will occur. This is generally a good thing, particularly if you are changing
-    values interactively
+    values interactively.
 
 	If you are getting validation errors consult the corresponding schema in
 	``rad`` to se what is allowed. If you think the schema is wrong, or you

--- a/docs/roman_datamodels/datamodels/using_datamodels.rst
+++ b/docs/roman_datamodels/datamodels/using_datamodels.rst
@@ -100,7 +100,7 @@ page::
 
     There are a couple subtlties with regard to changing values in a datamodel.
     If you assign dicts or lists to attributes, it will map these into the
-    corresponding DNode or LNode subclasses. In such uses, the assigned values 
+    corresponding DNode or LNode subclasses. In such uses, the assigned values
     will be immediately checked by validating against the defining schemas.
     When the value being assigned fails to pass that validation, an exception
     will occur. This is generally a good thing, particularly if you are changing

--- a/docs/roman_datamodels/datamodels/using_datamodels.rst
+++ b/docs/roman_datamodels/datamodels/using_datamodels.rst
@@ -98,9 +98,13 @@ page::
 
 .. note::
 
-	All datamodels have built in validation against the defining schemas.
-	This means that if you try to assign a value that is not allowed according
-	to one of these schemas, you will get an error. This is a good thing!
+    There are a couple subtlties with regard to changing values in a datamodel.
+    If you assign dicts or lists to attributes, it will map these into the
+    corresponding DNode or LNode subclasses. In such uses, the assigned values 
+    will be immediately checked by validating against the defining schemas.
+    When the value being assigned fails to pass that validation, an exception
+    will occur. This is generally a good thing, particularly if you are changing
+    values interactively
 
 	If you are getting validation errors consult the corresponding schema in
 	``rad`` to se what is allowed. If you think the schema is wrong, or you

--- a/src/roman_datamodels/stnode/_converters.py
+++ b/src/roman_datamodels/stnode/_converters.py
@@ -3,8 +3,8 @@ The ASDF Converters to handle the serialization/deseialization of the STNode cla
 """
 from asdf.extension import Converter, ManifestExtension
 from astropy.time import Time
-
-from ._registry import LIST_NODE_CLASSES_BY_TAG, NODE_CONVERTERS, OBJECT_NODE_CLASSES_BY_TAG, SCALAR_NODE_CLASSES_BY_TAG
+from ._registry import (LIST_NODE_CLASSES_BY_TAG, NODE_CONVERTERS,
+    OBJECT_NODE_CLASSES_BY_TAG, SCALAR_NODE_CLASSES_BY_TAG)
 
 __all__ = [
     "TaggedObjectNodeConverter",
@@ -117,5 +117,6 @@ class TaggedScalarNodeConverter(_RomanConverter):
 
 # Create the ASDF extension for the STNode classes.
 NODE_EXTENSIONS = [
-    ManifestExtension.from_uri("asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0", converters=NODE_CONVERTERS.values())
+    ManifestExtension.from_uri("asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0",
+        converters=NODE_CONVERTERS.values()),
 ]

--- a/src/roman_datamodels/stnode/_converters.py
+++ b/src/roman_datamodels/stnode/_converters.py
@@ -3,8 +3,8 @@ The ASDF Converters to handle the serialization/deseialization of the STNode cla
 """
 from asdf.extension import Converter, ManifestExtension
 from astropy.time import Time
-from ._registry import (LIST_NODE_CLASSES_BY_TAG, NODE_CONVERTERS,
-    OBJECT_NODE_CLASSES_BY_TAG, SCALAR_NODE_CLASSES_BY_TAG)
+
+from ._registry import LIST_NODE_CLASSES_BY_TAG, NODE_CONVERTERS, OBJECT_NODE_CLASSES_BY_TAG, SCALAR_NODE_CLASSES_BY_TAG
 
 __all__ = [
     "TaggedObjectNodeConverter",
@@ -117,6 +117,5 @@ class TaggedScalarNodeConverter(_RomanConverter):
 
 # Create the ASDF extension for the STNode classes.
 NODE_EXTENSIONS = [
-    ManifestExtension.from_uri("asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0",
-        converters=NODE_CONVERTERS.values()),
+    ManifestExtension.from_uri("asdf://stsci.edu/datamodels/roman/manifests/datamodels-1.0", converters=NODE_CONVERTERS.values()),
 ]

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -18,6 +18,7 @@ from asdf.util import HashableDict
 from astropy.time import Time
 
 from roman_datamodels.validate import ValidationWarning, _check_type, _error_message, will_strict_validate, will_validate
+
 from ._registry import SCALAR_NODE_CLASSES_BY_KEY
 
 __all__ = ["DNode", "LNode"]
@@ -63,9 +64,9 @@ def _validate(attr, instance, schema, ctx):
     # Note that the following checks cannot use isinstance since the TaggedObjectNode
     # and TaggedListNode subclasses will break as a result. And currently there is no
     # non-tagged subclasses of these classes that exist, nor are any envisioned yet.
-    if type(instance) == DNode: # noqa: E721
+    if type(instance) == DNode:  # noqa: E721
         instance = instance._data
-    elif type(instance) == LNode: # noqa: E721
+    elif type(instance) == LNode:  # noqa: E721
         instance = instance.data
     tagged_tree = yamlutil.custom_tree_to_tagged_tree(instance, ctx)
     return _value_change(attr, tagged_tree, schema, False, will_strict_validate(), ctx)

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -18,7 +18,6 @@ from asdf.util import HashableDict
 from astropy.time import Time
 
 from roman_datamodels.validate import ValidationWarning, _check_type, _error_message, will_strict_validate, will_validate
-
 from ._registry import SCALAR_NODE_CLASSES_BY_KEY
 
 __all__ = ["DNode", "LNode"]
@@ -56,12 +55,18 @@ def _check_value(value, schema, validator_context):
     temp_schema = {"$schema": "http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema"}
     temp_schema.update(schema)
     validator = asdfschema.get_validator(temp_schema, validator_context, validator_callbacks)
-
     validator.validate(value, _schema=temp_schema)
     validator_context.close()
 
 
 def _validate(attr, instance, schema, ctx):
+    # Note that the following checks cannot use isinstance since the TaggedObjectNode
+    # and TaggedListNode subclasses will break as a result. And currently there is no
+    # non-tagged subclasses of these classes that exist, nor are any envisioned yet.
+    if type(instance) == DNode: # noqa: E721
+        instance = instance._data
+    elif type(instance) == LNode: # noqa: E721
+        instance = instance.data
     tagged_tree = yamlutil.custom_tree_to_tagged_tree(instance, ctx)
     return _value_change(attr, tagged_tree, schema, False, will_strict_validate(), ctx)
 
@@ -142,16 +147,17 @@ class DNode(MutableMapping):
     def __setattr__(self, key, value):
         """
         Permit assigning dict keys as attributes.
+
         """
+
         if key[0] != "_":
             value = self._convert_to_scalar(key, value)
             if key in self._data:
                 if will_validate():
                     schema = _get_schema_for_property(self._schema(), key)
-
-                    if schema == {} or _validate(key, value, schema, self.ctx):
-                        self._data[key] = value
-                self.__dict__["_data"][key] = value
+                    if schema:
+                        _validate(key, value, schema, self.ctx)
+                self._data[key] = value
             else:
                 raise AttributeError(f"No such attribute ({key}) found in node")
         else:
@@ -193,7 +199,6 @@ class DNode(MutableMapping):
             # Extract the subschema corresponding to this node.
             subschema = _get_schema_for_property(parent_schema, self._name)
             self._x_schema = subschema
-
         return self._x_schema
 
     def __asdf_traverse__(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -578,7 +578,7 @@ def test_node_assignment():
     darkexp = darkmodel.meta.exposure
     assert isinstance(darkexp, stnode.DNode)
     darkexp.ngroups = darkexp.ngroups + 1
-    assert(darkexp.ngroups == 7)
+    assert darkexp.ngroups == 7
     darkmodel.meta.exposure = darkexp
 
 


### PR DESCRIPTION
Resolves [AL-751](https://jira.stsci.edu/browse/AL-751)

Closes #274

This PR addresses the shortcoming in the previous PR ( #253) to deal with this issue, namely that no validation was done on assignment. Now is validated on assignment.
