### PR TITLE
TST: Use Python 3.12 stable

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -23,4 +23,4 @@ jobs:
         - macos: py39
         - macos: py310
         - linux: py312-devdeps
-          python-version: "3.12-dev"
+          python-version: "3.12"

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -23,4 +23,3 @@ jobs:
         - macos: py39
         - macos: py310
         - linux: py312-devdeps
-          python-version: "3.12"


### PR DESCRIPTION
Python 3.12 is released.
