### PR TITLE
RCAL-684 Add Slope and Error to Dark RefModel and Tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@
 
 - Fix the initialization of empty DataModels and clean up the datamodel core. [#251]
 
+- Add slope and error to dark RefModel and tests. [#280]
+
 0.17.1 (2023-08-03)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     'psutil >=5.7.2',
     'numpy >=1.22',
     'astropy >=5.3.0',
-    'rad >=0.17.1',
-    #'rad @ git+https://github.com/spacetelescope/rad.git@main',
+    # 'rad >=0.17.1',
+    'rad @ git+https://github.com/spacetelescope/rad.git@main',
     'asdf-standard >=1.0.3',
 ]
 dynamic = ['version']

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -93,7 +93,6 @@ def mk_dark(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
 
     darkref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
     darkref["dq"] = kwargs.get("dq", np.zeros(shape[1:], dtype=np.uint32))
-    darkref["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
     darkref["dark_slope"] = kwargs.get(
         "dark_slope", u.Quantity(np.zeros(shape[1:], dtype=np.float32), u.DN / u.s, dtype=np.float32)
     )

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -94,6 +94,10 @@ def mk_dark(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     darkref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
     darkref["dq"] = kwargs.get("dq", np.zeros(shape[1:], dtype=np.uint32))
     darkref["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
+    darkref["dark_slope"] = kwargs.get("dark_slope",
+                                       u.Quantity(np.zeros(shape[1:], dtype=np.float32), u.DN / u.s, dtype=np.float32))
+    darkref["dark_slope_error"] = kwargs.get("dark_slope_error", \
+                                             u.Quantity(np.zeros(shape[1:], dtype=np.float32), u.DN / u.s, dtype=np.float32))
 
     return save_node(darkref, filepath=filepath)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -389,7 +389,6 @@ def test_make_dark():
     assert dark.data.dtype == np.float32
     assert dark.dq.dtype == np.uint32
     assert dark.dq.shape == (8, 8)
-    assert dark.err.dtype == np.float32
     assert dark.data.unit == u.DN
     assert dark.dark_slope.dtype == np.float32
     assert dark.dark_slope.unit == u.DN / u.s

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -391,6 +391,10 @@ def test_make_dark():
     assert dark.dq.shape == (8, 8)
     assert dark.err.dtype == np.float32
     assert dark.data.unit == u.DN
+    assert dark.dark_slope.dtype == np.float32
+    assert dark.dark_slope.unit == u.DN / u.s
+    assert dark.dark_slope_error.dtype == np.float32
+    assert dark.dark_slope_error.shape == (8, 8)
 
     # Test validation
     dark_model = datamodels.DarkRefModel(dark)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-684: <Fix a bug> -->
Resolves [RCAL-684](https://jira.stsci.edu/browse/RCAL-684)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #914

<!-- describe the changes comprising this PR here -->
This PR adds slope and slope error to the dark reference model and tests for use in the ramp fitting step.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/408/
