### PR TITLE
Fix dependency to be consistent with romancal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'numpy >=1.22',
     'astropy >=5.3.0',
     # 'rad >=0.17.1',
-    'rad @ git+https://github.com/spacetelescope/rad.git@main',
+    'rad @ git+https://github.com/spacetelescope/rad.git',
     'asdf-standard >=1.0.3',
 ]
 dynamic = ['version']


### PR DESCRIPTION
Currently the exact branch of `rad` is specified by this project. Unfortunately, this conflicts with the specification for dev dependencies in `romancal`, that is `romancal` does not have an `@main` decoration. This means that when attempting to install this version of `roman_datamodels` using the dev dependencies for `romancal` an "version conflict" occurs; meaning that none of the regression tests will even install properly. 

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
