### PR TITLE
RCAL-682: Added optional dq array to science raw maker utility and test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@
 
 - Add slope and error to dark RefModel and tests. [#280]
 
+- Added optional dq array to science raw maker utility and test. [#282]
+
 0.17.1 (2023-08-03)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'numpy >=1.22',
     'astropy >=5.3.0',
     # 'rad >=0.17.1',
-    'rad @ git+https://github.com/spacetelescope/rad.git@main',
+    'rad @ git+https://github.com/spacetelescope/rad.git',
     'asdf-standard >=1.0.3',
 ]
 dynamic = ['version']

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -10,7 +10,7 @@ from ._common_meta import mk_common_meta, mk_guidewindow_meta, mk_msos_stack_met
 from ._tagged_nodes import mk_cal_logs
 
 
-def mk_level1_science_raw(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
+def mk_level1_science_raw(*, shape=(8, 4096, 4096), dq=False, filepath=None, **kwargs):
     """
     Create a dummy level 1 ScienceRaw instance (or file) with arrays and valid
     values for attributes required by the schema.
@@ -23,6 +23,10 @@ def mk_level1_science_raw(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
             (8, 4096, 4096)
         (8 integrations, 4088 x 4088 represent the science pixels, with the
         additional being the border reference pixels).
+
+    dq : bool
+        (optional, keyword-only) Toggle to add a data quality array for 
+        dropout pixels
 
     filepath : str
         (optional, keyword-only) File name and path to write model to.
@@ -41,6 +45,9 @@ def mk_level1_science_raw(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     n_groups = shape[0]
 
     wfi_science_raw["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16))
+
+    if dq:
+        wfi_science_raw["resultantdq"] = kwargs.get("resultantdq", np.zeros(shape, dtype=np.uint8))
 
     # add amp 33 ref pix
     wfi_science_raw["amp33"] = kwargs.get(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -245,8 +245,6 @@ def test_make_associations():
     member_shapes = (3, 8, 5, 2)
     association = utils.mk_associations(shape=member_shapes)
 
-    print("XXX association.products = " + str(association.products))
-
     assert association.asn_type == "image"
     assert len(association.products) == len(member_shapes)
 
@@ -591,7 +589,8 @@ def test_make_wfi_img_photom():
 
 # WFI Level 1 Science Raw tests
 def test_make_level1_science_raw():
-    wfi_science_raw = utils.mk_level1_science_raw(shape=(2, 8, 8))
+    shape=(2, 8, 8)
+    wfi_science_raw = utils.mk_level1_science_raw(shape=shape, dq=True)
 
     assert wfi_science_raw.data.dtype == np.uint16
     assert wfi_science_raw.data.unit == u.DN


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-682](https://jira.stsci.edu/browse/RCAL-682)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #912

<!-- describe the changes comprising this PR here -->
This PR adds optional dq array to science raw maker utility and test.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
