### PR TITLE
Added truncation to exposure.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@
 
 - Add slope and error to dark RefModel and tests. [#280]
 
+- Added truncation to exposure. [#283]
+
 0.17.1 (2023-08-03)
 ===================
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -47,6 +47,7 @@ def mk_exposure(**kwargs):
     exp["ma_table_number"] = kwargs.get("ma_table_number", NONUM)
     exp["level0_compressed"] = kwargs.get("level0_compressed", True)
     exp["read_pattern"] = kwargs.get("read_pattern", [[1], [2, 3], [4], [5, 6, 7, 8], [9, 10], [11]])
+    exp["truncated"] = kwargs.get("truncated", False)
 
     return exp
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-689: <Fix a bug> -->
Resolves [RCAL-689](https://jira.stsci.edu/browse/RCAL-689)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #927

<!-- describe the changes comprising this PR here -->
This PR adds the `truncated` keyword to the exposure group.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
