### PR TITLE
RCAL-695 generalize attribute assignment and creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@
 0.18.0 (2023-11-06)
 ===================
 - Allow assignment to or creation of node attributes using dot notation of object instances 
-  with validation. []
+  with validation. [#284]
 
 - Allow DNode and LNode subclass instances to be assigned to tree attributes and support
   validation of all such instances. [#275]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 
 0.18.0 (2023-11-06)
 ===================
-- Allow assignment to or creation of node attributes using dot notation of object instances 
+- Allow assignment to or creation of node attributes using dot notation of object instances
   with validation. [#284]
 
 - Allow DNode and LNode subclass instances to be assigned to tree attributes and support

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,11 @@
 0.18.1 (unreleased)
 ===================
 
--
+- Allow assignment to or creation of node attributes using dot notation of object instances
+  with validation. [#284]
 
 0.18.0 (2023-11-06)
 ===================
-- Allow assignment to or creation of node attributes using dot notation of object instances
-  with validation. [#284]
 
 - Allow DNode and LNode subclass instances to be assigned to tree attributes and support
   validation of all such instances. [#275]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 0.18.0 (2023-11-06)
 ===================
+- Allow assignment to or creation of node attributes using dot notation of object instances 
+  with validation. []
 
 - Allow DNode and LNode subclass instances to be assigned to tree attributes and support
   validation of all such instances. [#275]

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -18,6 +18,7 @@ from asdf.util import HashableDict
 from astropy.time import Time
 
 from roman_datamodels.validate import ValidationWarning, _check_type, _error_message, will_strict_validate, will_validate
+
 from ._registry import SCALAR_NODE_CLASSES_BY_KEY
 
 __all__ = ["DNode", "LNode"]
@@ -63,9 +64,9 @@ def _validate(attr, instance, schema, ctx):
     # Note that the following checks cannot use isinstance since the TaggedObjectNode
     # and TaggedListNode subclasses will break as a result. And currently there is no
     # non-tagged subclasses of these classes that exist, nor are any envisioned yet.
-    if type(instance) == DNode: # noqa: E721
+    if type(instance) == DNode:  # noqa: E721
         instance = instance._data
-    elif type(instance) == LNode: # noqa: E721
+    elif type(instance) == LNode:  # noqa: E721
         instance = instance.data
     tagged_tree = yamlutil.custom_tree_to_tagged_tree(instance, ctx)
     return _value_change(attr, tagged_tree, schema, False, will_strict_validate(), ctx)

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -63,9 +63,9 @@ def _validate(attr, instance, schema, ctx):
     # Note that the following checks cannot use isinstance since the TaggedObjectNode
     # and TaggedListNode subclasses will break as a result. And currently there is no
     # non-tagged subclasses of these classes that exist, nor are any envisioned yet.
-    if type(instance) == DNode: # noqa E721
+    if type(instance) == DNode: # noqa: E721
         instance = instance._data
-    elif type(instance) == LNode: # noqa E721
+    elif type(instance) == LNode: # noqa: E721
         instance = instance.data
     tagged_tree = yamlutil.custom_tree_to_tagged_tree(instance, ctx)
     return _value_change(attr, tagged_tree, schema, False, will_strict_validate(), ctx)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -641,8 +641,27 @@ def test_node_assignment():
     darkexp = darkmodel.meta.exposure
     assert isinstance(darkexp, stnode.DNode)
     darkexp.ngroups = darkexp.ngroups + 1
-    assert darkexp.ngroups == 7
+    assert(darkexp.ngroups == 7)
     darkmodel.meta.exposure = darkexp
+
+# Test that a currently undefined attribute can be assigned using dot notation
+# so long as the attribute is defined in the coresponding schema.
+def test_node_new_attribute_assignment():
+    exp = stnode.Exposure()
+    with pytest.raises(AttributeError):
+        exp.bozo = 0
+    exp.ngroups = 5
+    assert exp.ngroups == 5
+    # Test patternProperties attribute case
+    photmod = utils.mk_wfi_img_photom()
+    phottab = photmod.phot_table
+    newphottab = {'F062': phottab['F062']}
+    photmod.phot_table = newphottab
+    photmod.phot_table.F213 = phottab['F213']
+    with pytest.raises(AttributeError):
+        photmod.phot_table.F214 = phottab['F213']
+    with pytest.raises(ValidationError):
+        photmod.phot_table.F106 = 0
 
 
 # WFI Level 3 Mosaic tests

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -641,7 +641,7 @@ def test_node_assignment():
     darkexp = darkmodel.meta.exposure
     assert isinstance(darkexp, stnode.DNode)
     darkexp.ngroups = darkexp.ngroups + 1
-    assert(darkexp.ngroups == 7)
+    assert darkexp.ngroups == 7
     darkmodel.meta.exposure = darkexp
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -644,25 +644,6 @@ def test_node_assignment():
     assert(darkexp.ngroups == 7)
     darkmodel.meta.exposure = darkexp
 
-# Test that a currently undefined attribute can be assigned using dot notation
-# so long as the attribute is defined in the coresponding schema.
-def test_node_new_attribute_assignment():
-    exp = stnode.Exposure()
-    with pytest.raises(AttributeError):
-        exp.bozo = 0
-    exp.ngroups = 5
-    assert exp.ngroups == 5
-    # Test patternProperties attribute case
-    photmod = utils.mk_wfi_img_photom()
-    phottab = photmod.phot_table
-    newphottab = {'F062': phottab['F062']}
-    photmod.phot_table = newphottab
-    photmod.phot_table.F213 = phottab['F213']
-    with pytest.raises(AttributeError):
-        photmod.phot_table.F214 = phottab['F213']
-    with pytest.raises(ValidationError):
-        photmod.phot_table.F106 = 0
-
 
 # WFI Level 3 Mosaic tests
 def test_make_level3_mosaic():

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -2,12 +2,14 @@ import os
 from contextlib import nullcontext
 
 import asdf
-from asdf.exceptions import ValidationError
 import astropy.units as u
 import pytest
+from asdf.exceptions import ValidationError
 
+from roman_datamodels import datamodels
+from roman_datamodels import maker_utils
 from roman_datamodels import maker_utils as utils
-from roman_datamodels import datamodels, maker_utils, stnode, validate
+from roman_datamodels import stnode, validate
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy, wraps_hashable
 
 from .conftest import MANIFEST
@@ -184,7 +186,7 @@ def test_set_pattern_properties():
 
 
 # Test that a currently undefined attribute can be assigned using dot notation
-# so long as the attribute is defined in the coresponding schema.
+# so long as the attribute is defined in the corresponding schema.
 def test_node_new_attribute_assignment():
     exp = stnode.Exposure()
     with pytest.raises(AttributeError):
@@ -194,11 +196,11 @@ def test_node_new_attribute_assignment():
     # Test patternProperties attribute case
     photmod = utils.mk_wfi_img_photom()
     phottab = photmod.phot_table
-    newphottab = {'F062': phottab['F062']}
+    newphottab = {"F062": phottab["F062"]}
     photmod.phot_table = newphottab
-    photmod.phot_table.F213 = phottab['F213']
+    photmod.phot_table.F213 = phottab["F213"]
     with pytest.raises(AttributeError):
-        photmod.phot_table.F214 = phottab['F213']
+        photmod.phot_table.F214 = phottab["F213"]
     with pytest.raises(ValidationError):
         photmod.phot_table.F106 = 0
 

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -2,9 +2,11 @@ import os
 from contextlib import nullcontext
 
 import asdf
+from asdf.exceptions import ValidationError
 import astropy.units as u
 import pytest
 
+from roman_datamodels import maker_utils as utils
 from roman_datamodels import datamodels, maker_utils, stnode, validate
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy, wraps_hashable
 
@@ -179,6 +181,26 @@ def test_set_pattern_properties():
     mdl.phot_table.F062.photmjsr = None
     mdl.phot_table.F062.uncertainty = None
     mdl.phot_table.F062.pixelareasr = None
+
+
+# Test that a currently undefined attribute can be assigned using dot notation
+# so long as the attribute is defined in the coresponding schema.
+def test_node_new_attribute_assignment():
+    exp = stnode.Exposure()
+    with pytest.raises(AttributeError):
+        exp.bozo = 0
+    exp.ngroups = 5
+    assert exp.ngroups == 5
+    # Test patternProperties attribute case
+    photmod = utils.mk_wfi_img_photom()
+    phottab = photmod.phot_table
+    newphottab = {'F062': phottab['F062']}
+    photmod.phot_table = newphottab
+    photmod.phot_table.F213 = phottab['F213']
+    with pytest.raises(AttributeError):
+        photmod.phot_table.F214 = phottab['F213']
+    with pytest.raises(ValidationError):
+        photmod.phot_table.F106 = 0
 
 
 VALIDATION_CASES = ("true", "yes", "1", "True", "Yes", "TrUe", "YeS", "foo", "Bar", "BaZ")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-695](https://jira.stsci.edu/browse/RCAL-695)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #54

<!-- describe the changes comprising this PR here -->
This PR addresses allows new node attributes to be created using dot notation so long as the attribute is consistent with the schema (e.g., an explicit property or matches a patternProperty).

It also enables validation of the created attribute's value, as well as validating object instances assigned to existing attributes.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
