### PR TITLE
Remove `__del__` from `DataModel`.

### DIFF
--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -155,10 +155,6 @@ class DataModel(abc.ABC):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def __del__(self):
-        """Ensure closure of resources when deleted."""
-        self.close()
-
     def copy(self, deepcopy=True, memo=None):
         result = self.__class__(init=None)
         self.clone(result, self, deepcopy=deepcopy, memo=memo)

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -278,17 +278,19 @@ def test_nuke_validation(nuke_env_var, tmp_path):
 
     # Read broken files with datamodel object
     with context:
-        datamodels.WfiImgPhotomRefModel(broken_save)
+        dm = datamodels.WfiImgPhotomRefModel(broken_save)
+        dm.close()
     with context:
-        datamodels.WfiImgPhotomRefModel(broken_to_asdf)
+        dm = datamodels.WfiImgPhotomRefModel(broken_to_asdf)
+        dm.close()
 
     # True to read broken files with rdm.open
     with context:
-        with datamodels.open(broken_save):
-            pass
+        with datamodels.open(broken_save) as dm:
+            dm.close()
     with context:
-        with datamodels.open(broken_to_asdf):
-            pass
+        with datamodels.open(broken_to_asdf) as dm:
+            dm.close()
 
 
 @pytest.mark.parametrize("nuke_env_strict_var", VALIDATION_CASES, indirect=True)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
We have now encountered several issues concerning `roman_datamodels` closing there associated ASDF file unexpectedly and/or unreliably. These issues tend to be extremely difficult to debug as the bugs cannot be consistently replicated. In the majority of cases these issues are caused by the fact that there is a `DataModel.__del__` method which triggers the closure of the associated ASDF file if there is one. This method is "called" whenever a given object's reference count drops to zero, and in this case it is improperly being used as a "destructor".

The issue with comes with the fact that the ASDF file opened and held by the `DataModel` itself references the `DataModel` which creates a reference cycle. Thus in this case `DataModel.__del__` is only called on a given instance by the garbage collector not when its apparent reference count drops to zero. Consequently, we cannot guarantee when/if `DataModel.__del__` is successfully called on a given `DataModel` instance. This ambiguity can lead to issues where sometimes operations which reference data in the ASDF file work and sometimes they do not, the root of which is when the Python garbage collector actually gets run during a particular program execution instance.

Note that the reason why `DataModel.__del__` exists the way that it does is so that usage of `DataModels` should not leave behind open files. While this is important, the inherent inconsistencies with the approach of using `DataModel.__del__` create's more issues than it solves. Instead, either

1. `DataModel.__del__` should be removed.
2. `Datamodel.__del__` should raise an error if the ASDF file is still open.

Currently, this PR removes `DataModel.__del__`.

Note that to avoid issues with `DataModels` and file handles we really should make the `roman_datamodels.open` method a proper context manager instead of just a function, so that it explicitly cleans up the `DataModel` whenever it exits AND resolve any open file warnings/errors we encounter during testing.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
