### PR TITLE
RCAL-723 Fix `model.meta.filename` when saving model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Allow assignment to or creation of node attributes using dot notation of object instances
   with validation. [#284]
 
+- Bugfix for ``model.meta.filename`` not matching the filename of the file on disk. [#295]
+
 0.18.0 (2023-11-06)
 ===================
 

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -61,6 +61,10 @@ def _temporary_update_filename(datamodel, filename):
 
         yield
         datamodel._instance.meta.filename = old_filename
+        return
+
+    yield
+    return
 
 
 class DataModel(abc.ABC):

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -11,10 +11,8 @@ import abc
 import copy
 import datetime
 import functools
-import os
-import os.path
 import sys
-from pathlib import PurePath
+from pathlib import Path, PurePath
 
 import asdf
 import numpy as np
@@ -181,17 +179,9 @@ class DataModel(abc.ABC):
         target._ctx = target
 
     def save(self, path, dir_path=None, *args, **kwargs):
-        if callable(path):
-            path_head, path_tail = os.path.split(path(self.meta.filename))
-        else:
-            path_head, path_tail = os.path.split(path)
-        base, ext = os.path.splitext(path_tail)
-        if isinstance(ext, bytes):
-            ext = ext.decode(sys.getfilesystemencoding())
-
-        if dir_path:
-            path_head = dir_path
-        output_path = os.path.join(path_head, path_tail)
+        path = Path(path(self.meta.filename) if callable(path) else path)
+        output_path = Path(dir_path) / path.name if dir_path else path
+        ext = path.suffix.decode(sys.getfilesystemencoding()) if isinstance(path.suffix, bytes) else path.suffix
 
         # TODO: Support gzip-compressed fits
         if ext == ".asdf":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -804,3 +804,15 @@ def test_datamodel_construct_like_from_like(model):
     new_mdl = model(mdl)
     assert new_mdl is mdl
     assert new_mdl._iscopy == "foo"  # Verify that the constructor didn't override stuff
+
+
+def test_datamodel_save_filename(tmp_path):
+    filename = tmp_path / "fancy_filename.asdf"
+    ramp = utils.mk_datamodel(datamodels.RampModel, shape=(2, 8, 8))
+    assert ramp.meta.filename != filename.name
+
+    ramp.save(filename)
+    assert ramp.meta.filename != filename.name
+
+    with datamodels.open(filename) as new_ramp:
+        assert new_ramp.meta.filename == filename.name


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-723](https://jira.stsci.edu/browse/RCAL-723)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes spacetelescope/romancal#1026

<!-- describe the changes comprising this PR here -->
When saving a `DataModel` to an arbitrary ASDF file, it was noted that the `model.meta.filename` does not reflect the name of the file it was saved to. This PR makes sure that when saving a `DataModel` to `foo.asdf` that `Datamodel.meta.filename==foo.asdf` in the saved file. 

Note that this solves RCAL-723 when running individual steps or outputting all the step results.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
