### PR TITLE
RCAL-728: Fix `meta.model_type` to reflect the data model's type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 
 - Bugfix for ``model.meta.filename`` not matching the filename of the file on disk. [#295]
 
+- Bugfix for ``meta.model_type`` not being set to match the model writing the file. [#296]
+
 0.18.0 (2023-11-06)
 ===================
 

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -25,29 +25,42 @@ class _DataModel(DataModel):
     def __init_subclass__(cls, **kwargs):
         """Register each subclass in the __all__ for this module"""
         super().__init_subclass__(**kwargs)
+
+        # Don't register private classes
+        if cls.__name__.startswith("_"):
+            return
+
         if cls.__name__ in __all__:
             raise ValueError(f"Duplicate model type {cls.__name__}")
 
         __all__.append(cls.__name__)
 
 
-class MosaicModel(_DataModel):
+class _RomanDataModel(_DataModel):
+    def __init__(self, init=None, **kwargs):
+        super().__init__(init, **kwargs)
+
+        if init is not None:
+            self.meta.model_type = self.__class__.__name__
+
+
+class MosaicModel(_RomanDataModel):
     _node_type = stnode.WfiMosaic
 
 
-class ImageModel(_DataModel):
+class ImageModel(_RomanDataModel):
     _node_type = stnode.WfiImage
 
 
-class ScienceRawModel(_DataModel):
+class ScienceRawModel(_RomanDataModel):
     _node_type = stnode.WfiScienceRaw
 
 
-class MsosStackModel(_DataModel):
+class MsosStackModel(_RomanDataModel):
     _node_type = stnode.MsosStack
 
 
-class RampModel(_DataModel):
+class RampModel(_RomanDataModel):
     _node_type = stnode.Ramp
 
     @classmethod
@@ -86,7 +99,7 @@ class RampModel(_DataModel):
         raise ValueError("Input model must be a ScienceRawModel or RampModel")
 
 
-class RampFitOutputModel(_DataModel):
+class RampFitOutputModel(_RomanDataModel):
     _node_type = stnode.RampFitOutput
 
 
@@ -107,7 +120,7 @@ class AssociationsModel(_DataModel):
         return isinstance(asn_data, dict) and "asn_id" in asn_data and "asn_pool" in asn_data
 
 
-class GuidewindowModel(_DataModel):
+class GuidewindowModel(_RomanDataModel):
     _node_type = stnode.Guidewindow
 
 

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -7,6 +7,7 @@ from astropy import units as u
 from astropy.time import Time
 
 from roman_datamodels import datamodels, maker_utils, stnode
+from roman_datamodels.datamodels._datamodels import _RomanDataModel
 from roman_datamodels.maker_utils import _ref_files as ref_files
 from roman_datamodels.testing import assert_node_equal
 
@@ -109,7 +110,8 @@ def test_datamodel_maker(model_class):
     assert isinstance(model, model_class)
     model.validate()
 
-    assert model.meta.model_type == model_class.__name__
+    if issubclass(model_class, _RomanDataModel):
+        assert model.meta.model_type == model_class.__name__
 
 
 @pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -109,6 +109,8 @@ def test_datamodel_maker(model_class):
     assert isinstance(model, model_class)
     model.validate()
 
+    assert model.meta.model_type == model_class.__name__
+
 
 @pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -772,6 +772,14 @@ def test_ramp_from_science_raw():
         if isinstance(ramp_value, np.ndarray):
             assert_array_equal(ramp_value, raw_value.astype(ramp_value.dtype))
 
+        elif key == "meta":
+            for meta_key in ramp_value:
+                if meta_key == "model_type":
+                    ramp_value[meta_key] = ramp.__class__.__name__
+                    raw_value[meta_key] = raw.__class__.__name__
+                    continue
+                assert_node_equal(ramp_value[meta_key], raw_value[meta_key])
+
         elif isinstance(ramp_value, stnode.DNode):
             assert_node_equal(ramp_value, raw_value)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-728: <Fix a bug> -->
Resolves [RCAL-728](https://jira.stsci.edu/browse/RCAL-728)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes spacetelescope/romancal#1036

<!-- describe the changes comprising this PR here -->
This PR ensures that during model initialization, the `meta.model_type` is set to reflect the "model_type" of the datamodel. This does not enforce this past initialization.

Note, I chose "model_type" to mean the "name" (`__class__.__name__`) of the RDM datamodel. This is an arbitrary minimal choice. A reasonable alternative is the CamelCase-ification of the root name of the top level schema, eg `.../wfi_science_raw` -> `WfiScienceRawModel` or `WfiScienceRaw`, but the `__class__.__name__` corresponding to this is acutally `ScienceRawModel`. In any case, we need to clarify our model-naming conventions and decide how they map to the `meta.model_type`.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
