### PR TITLE
Remove duplicate validation, replace assumed validation on `AsdfFile.__init__` with `AsdfFile.validate`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 
 - Add ``meta.wcs`` to ``maker_utils``. [#302]
 
+- Remove duplicate validation during ``DataModel.to_asdf``, replace assumed validation
+  during ``AsdfFile.__init__`` with call to ``AsdfFile.validate``  [#301]
+
 0.18.0 (2023-11-06)
 ===================
 

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -220,7 +220,7 @@ class DataModel(abc.ABC):
     def to_asdf(self, init, *args, **kwargs):
         with validate.nuke_validation(), _temporary_update_filename(self, Path(init).name):
             asdf_file = self.open_asdf(**kwargs)
-            asdf_file.tree = {"roman": self._instance}
+            asdf_file["roman"] = self._instance
             asdf_file.write_to(init, *args, **kwargs)
 
     def get_primary_array_name(self):

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -39,7 +39,10 @@ def _set_default_asdf(func):
         if self._asdf is None:
             try:
                 with validate.nuke_validation():
-                    self._asdf = asdf.AsdfFile({"roman": self._instance})
+                    af = asdf.AsdfFile()
+                    af["roman"] = self._instance
+                    af.validate()
+                    self._asdf = af
             except ValidationError as err:
                 raise ValueError(f"DataModel needs to have all its data flushed out before calling {func.__name__}") from err
 
@@ -126,8 +129,10 @@ class DataModel(abc.ABC):
                 )
             with validate.nuke_validation():
                 self._instance = init
-                self._asdf = asdf.AsdfFile({"roman": init})
-
+                af = asdf.AsdfFile()
+                af["roman"] = self._instance
+                af.validate()
+                self._asdf = af
                 return
 
         if init is None:


### PR DESCRIPTION
This PR removes duplicate validation during `to_asdf`:
https://github.com/spacetelescope/roman_datamodels/blob/70f05e88d2c32a716358d0c2c3fbf8770f600165/src/roman_datamodels/datamodels/_core.py#L219-L223
The assignment to `tree` triggers the first validation and the `write_to` triggers a second.

This PR also updates several uses of `AsdfFile.__init__` to validate tree contents (replacing it with an explicit call to `AsdfFile.validate`).

These changes are to prepare roman_datamodels for an upcoming deprecation in asdf (see https://github.com/asdf-format/asdf/pull/1691).

Regression tests running with no errors: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/515/

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
