### PR TITLE
update metadata for release `0.19.0`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,9 @@
-0.18.1 (unreleased)
+0.19.1 (unreleased)
+===================
+
+-
+
+0.19.0 (2024-02-09)
 ===================
 
 - Allow assignment to or creation of node attributes using dot notation of object instances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     'psutil >=5.7.2',
     'numpy >=1.22',
     'astropy >=5.3.0',
-    # 'rad >=0.18.0',
-    'rad @ git+https://github.com/spacetelescope/rad.git',
+    'rad >=0.19.0',
+    # 'rad @ git+https://github.com/spacetelescope/rad.git',
     'asdf-standard >=1.0.3',
 ]
 dynamic = ['version']


### PR DESCRIPTION
blocked by https://github.com/spacetelescope/rad/pull/372 and its subsequent release