### PR TITLE
remove unused sphinx-asdf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,6 @@ extensions = [
     "sphinx_automodapi.automodsumm",
     "sphinx_automodapi.autodoc_enhancements",
     "sphinx_automodapi.smart_resolver",
-    "sphinx_asdf",
     "sphinxcontrib.jquery",
 ]
 
@@ -199,11 +198,6 @@ pygments_style = "default"
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
-
-# Mapping for links to the ASDF Standard in ASDF schema documentation
-asdf_schema_reference_mappings = [
-    ("tag:stsci.edu:asdf", "http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/"),
-]
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ docs = [
     'sphinx-automodapi',
     'sphinx-rtd-theme',
     'sphinx-astropy',
-    'sphinx-asdf',
     'tomli; python_version <"3.11"',
 ]
 


### PR DESCRIPTION
sphinx-asdf is listed as a required dependency for docs. It is unused by the documentation (it handles rendering schemas so is useful for RAD but not roman_datamodels).

This PR removes sphinx-asdf as a dependency.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
