### PR TITLE
RCAL-782: Changed image units.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@
 - Make datamodels follow the same subscription pattern as the ``stnode`` based
   objects. [#322]
 
-- Changed image units. [#327]
+- Changed image units from e/s to DN/s (and added support for MJy/sr). [#327]
 
 0.19.0 (2024-02-09)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@
 - Make datamodels follow the same subscription pattern as the ``stnode`` based
   objects. [#322]
 
+- Changed image units. [#327]
+
 0.19.0 (2024-02-09)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     'numpy >=1.22',
     'astropy >=5.3.0',
     # 'rad >=0.18.0',
-    'rad @ git+https://github.com/spacetelescope/rad.git',
+    # 'rad @ git+https://github.com/spacetelescope/rad.git',
+    'rad @ git+https://github.com/PaulHuwe/rad.git@RAD-158_ImageUnits',
     'asdf-standard >=1.0.3',
 ]
 dynamic = ['version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ dependencies = [
     'numpy >=1.22',
     'astropy >=5.3.0',
     # 'rad >=0.18.0',
-    # 'rad @ git+https://github.com/spacetelescope/rad.git',
-    'rad @ git+https://github.com/PaulHuwe/rad.git@RAD-158_ImageUnits',
+    'rad @ git+https://github.com/spacetelescope/rad.git',
     'asdf-standard >=1.0.3',
 ]
 dynamic = ['version']

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -121,18 +121,18 @@ def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
     # add amp 33 ref pixel array
     amp33_size = (n_groups, 4096, 128)
     wfi_image["amp33"] = kwargs.get("amp33", u.Quantity(np.zeros(amp33_size, dtype=np.uint16), u.DN, dtype=np.uint16))
-    wfi_image["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32))
+    wfi_image["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN / u.s, dtype=np.float32))
     wfi_image["dq"] = kwargs.get("dq", np.zeros(shape, dtype=np.uint32))
-    wfi_image["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32))
+    wfi_image["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN / u.s, dtype=np.float32))
 
     wfi_image["var_poisson"] = kwargs.get(
-        "var_poisson", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
+        "var_poisson", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32)
     )
     wfi_image["var_rnoise"] = kwargs.get(
-        "var_rnoise", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
+        "var_rnoise", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32)
     )
     wfi_image["var_flat"] = kwargs.get(
-        "var_flat", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
+        "var_flat", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32)
     )
     wfi_image["cal_logs"] = mk_cal_logs(**kwargs)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -618,19 +618,30 @@ def test_make_level2_image():
     wfi_image = utils.mk_level2_image(shape=(8, 8))
 
     assert wfi_image.data.dtype == np.float32
-    assert wfi_image.data.unit == u.electron / u.s
+    assert wfi_image.data.unit == u.DN / u.s
     assert wfi_image.dq.dtype == np.uint32
     assert wfi_image.err.dtype == np.float32
-    assert wfi_image.err.unit == u.electron / u.s
+    assert wfi_image.err.unit == u.DN / u.s
     assert wfi_image.var_poisson.dtype == np.float32
-    assert wfi_image.var_poisson.unit == u.electron**2 / u.s**2
+    assert wfi_image.var_poisson.unit == u.DN**2 / u.s**2
     assert wfi_image.var_rnoise.dtype == np.float32
-    assert wfi_image.var_rnoise.unit == u.electron**2 / u.s**2
+    assert wfi_image.var_rnoise.unit == u.DN**2 / u.s**2
     assert wfi_image.var_flat.dtype == np.float32
+    assert wfi_image.var_flat.unit == u.DN**2 / u.s**2
     assert isinstance(wfi_image.cal_logs[0], str)
 
     # Test validation
     wfi_image_model = datamodels.ImageModel(wfi_image)
+    assert wfi_image_model.validate() is None
+
+    # Test Physical units
+    wfi_image_model.data = wfi_image_model.data.value * (u.MJy / u.sr)
+    wfi_image_model.err = wfi_image_model.err.value * (u.MJy / u.sr)
+    wfi_image_model.var_poisson = wfi_image_model.var_poisson.value * (u.MJy**2 / u.sr**2)
+    wfi_image_model.var_rnoise = wfi_image_model.var_rnoise.value * (u.MJy**2 / u.sr**2)
+    wfi_image_model.var_flat = wfi_image_model.var_flat.value * (u.MJy**2 / u.sr**2)
+
+    # Test validation
     assert wfi_image_model.validate() is None
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -85,7 +85,7 @@ def test_path_input(tmp_path):
 def test_model_input(tmp_path):
     file_path = tmp_path / "test.asdf"
 
-    data = u.Quantity(np.random.default_rng(42).uniform(size=(4, 4)).astype(np.float32), u.electron / u.s, dtype=np.float32)
+    data = u.Quantity(np.random.default_rng(42).uniform(size=(4, 4)).astype(np.float32), u.DN / u.s, dtype=np.float32)
 
     with asdf.AsdfFile() as af:
         af.tree = {"roman": utils.mk_level2_image(shape=(8, 8))}
@@ -120,10 +120,10 @@ def test_memmap(tmp_path):
             ),
             dtype=np.float32,
         ),
-        u.electron / u.s,
+        u.DN / u.s,
         dtype=np.float32,
     )
-    new_value = u.Quantity(1.0, u.electron / u.s, dtype=np.float32)
+    new_value = u.Quantity(1.0, u.DN / u.s, dtype=np.float32)
     new_data = data.copy()
     new_data[6, 19] = new_value
 
@@ -173,10 +173,10 @@ def test_no_memmap(tmp_path, kwargs):
             ),
             dtype=np.float32,
         ),
-        u.electron / u.s,
+        u.DN / u.s,
         dtype=np.float32,
     )
-    new_value = u.Quantity(1.0, u.electron / u.s, dtype=np.float32)
+    new_value = u.Quantity(1.0, u.DN / u.s, dtype=np.float32)
     new_data = data.copy()
     new_data[6, 19] = new_value
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-782](https://jira.stsci.edu/browse/RCAL-782)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR changes the units of the variables within the Image Model maker utilities and tests 

NOTE: no regression test link, because these changes require update to regression test files.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
