### PR TITLE
RCAL-800 Add initialization for the flux step meta

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@
 
 - Add attributes under the ``basic`` schema to ``WfiMosaic.meta``. [#328]
 
+- Add initialization for the flux step meta. [#332]
+
 0.19.0 (2024-02-09)
 ===================
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -357,6 +357,7 @@ def mk_cal_step(**kwargs):
     calstep["dark"] = kwargs.get("dark", "INCOMPLETE")
     calstep["dq_init"] = kwargs.get("dq_init", "INCOMPLETE")
     calstep["flat_field"] = kwargs.get("flat_field", "INCOMPLETE")
+    calstep["flux"] = kwargs.get("flux", "INCOMPLETE")
     calstep["jump"] = kwargs.get("jump", "INCOMPLETE")
     calstep["linearity"] = kwargs.get("linearity", "INCOMPLETE")
     calstep["photom"] = kwargs.get("photom", "INCOMPLETE")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-800](https://jira.stsci.edu/browse/RCAL-800)

Related PRs:
- [rad#395](https://github.com/spacetelescope/rad/pull/395)
- [romancal#1160](https://github.com/spacetelescope/romancal/pull/1160)

<!-- describe the changes comprising this PR here -->
This PR adds the initialization for the `cal_step.flux` meta in the maker utilities.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
