### PR TITLE
RCAL-712: Add Members Keyword to Resample Schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@
 
 - Add attributes under the ``basic`` schema to ``WfiMosaic.meta``. [#328]
 
+- Add Members Keyword to Resample datamodel maker utility. [#333]
+
 0.19.0 (2024-02-09)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "gwcs >=0.18.1",
     "numpy >=1.22",
     "astropy >=5.3.0",
-    "rad @ git+https://github.com/spacetelescope/rad.git",
+    # "rad @ git+https://github.com/spacetelescope/rad.git",
+    "rad @ git+https://github.com/PaulHuwe/rad.git@RAD-139_ResampleMembers", 
     "asdf-standard >=1.0.3",
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "numpy >=1.22",
     "astropy >=5.3.0",
     # "rad @ git+https://github.com/spacetelescope/rad.git",
-    "rad @ git+https://github.com/PaulHuwe/rad.git@RAD-139_ResampleMembers", 
+    "rad @ git+https://github.com/PaulHuwe/rad.git@RAD-139_ResampleMembers",
     "asdf-standard >=1.0.3",
 ]
 dynamic = [

--- a/src/roman_datamodels/maker_utils/_tagged_nodes.py
+++ b/src/roman_datamodels/maker_utils/_tagged_nodes.py
@@ -35,6 +35,7 @@ def mk_resample(**kwargs):
     roman_datamodels.stnode.Resample
     """
     res = stnode.Resample()
+    res["members"] = kwargs.get("members", [])
     res["pixel_scale_ratio"] = kwargs.get("pixel_scale_ratio", NONUM)
     res["pixfrac"] = kwargs.get("pixfrac", NONUM)
     res["pointings"] = kwargs.get("pointings", -1 * NONUM)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-712](https://jira.stsci.edu/browse/RCAL-712)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds the members keyword to the resample datamodel maker utility.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/692/
