### PR TITLE
switch back to rad main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ dependencies = [
     "gwcs >=0.18.1",
     "numpy >=1.22",
     "astropy >=5.3.0",
-    # "rad @ git+https://github.com/spacetelescope/rad.git",
-    "rad @ git+https://github.com/PaulHuwe/rad.git@RAD-139_ResampleMembers",
+    "rad @ git+https://github.com/spacetelescope/rad.git",
     "asdf-standard >=1.0.3",
 ]
 dynamic = [


### PR DESCRIPTION
Regtests are failing due to a dependency resolution failure:
```
Collecting rad@ git+https://github.com/PaulHuwe/rad.git@RAD-139_ResampleMembers (from roman-datamodels@ git+[https://github.com/spacetelescope/roman_datamodels.git->romancal==0.14.1.dev115+g603709a](https://github.com/spacetelescope/roman_datamodels.git-%3Eromancal==0.14.1.dev115+g603709a))
  Cloning https://github.com/PaulHuwe/rad.git (to revision RAD-139_ResampleMembers) to /private/var/folders/fy/_s99d0l14k598wxq803bjjr800000g/T/pip-install-u0k_zsyz/rad_d392c76c66db4106b940e253d5b78392
  Running command git clone --filter=blob:none --quiet https://github.com/PaulHuwe/rad.git /private/var/folders/fy/_s99d0l14k598wxq803bjjr800000g/T/pip-install-u0k_zsyz/rad_d392c76c66db4106b940e253d5b78392
  Running command git checkout -b RAD-139_ResampleMembers --track origin/RAD-139_ResampleMembers
  Switched to a new branch 'RAD-139_ResampleMembers'
  branch 'RAD-139_ResampleMembers' set up to track 'origin/RAD-139_ResampleMembers'.
  Resolved https://github.com/PaulHuwe/rad.git to commit 3f397d86db7995e5465b6be9c6c620a945700063
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
INFO: pip is looking at multiple versions of roman-datamodels to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install romancal and romancal==0.14.1.dev115+g603709a because these package versions have conflicting dependencies.
```

https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FRoman-Developers-Pull-Requests/detail/Roman-Developers-Pull-Requests/695/pipeline

This appears to be due to the rad requirement here not matching romancal. This PR switches rad back to main.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
