### PR TITLE
fix mk_outlier_detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     "gwcs >=0.18.1",
     "numpy >=1.22",
     "astropy >=5.3.0",
-    # "rad @ git+https://github.com/spacetelescope/rad.git",
-    "rad >= 0.19.2",
+    "rad @ git+https://github.com/spacetelescope/rad.git",
+    #"rad >= 0.19.2",
     "asdf-standard >=1.0.3",
 ]
 dynamic = [


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-823: <Fix a bug> -->
Resolves [RCAL-823](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an issue with where mk_outlier_detection is placed. Since it's a tagged node it needs to be under tagged_nodes, not common_meta. The first commit repoints roman_datamodels to rad/main and shows the failure. The second fixes it.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
