### PR TITLE
Add conversion of dict to string during Qtable construction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Replaced the previous test for ``schema_info`` with something more robust. [#344]
 
+- Add conversion of dict to string during Qtable construction [#348]
+
 0.19.1 (2024-04-04)
 ===================
 

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -105,11 +105,13 @@ class MosaicModel(_RomanDataModel):
                 else:
                     # Append to existing table
                     self.meta.individual_image_meta[key].add_row(subtable_vals)
+            # Skip non-schema metas
+            elif isinstance(value, dict):
+                continue
+            # Skip ndarrays
+            elif isinstance(value.strip(), asdf.tags.core.ndarray.NDArrayType):
+                continue
             else:
-                # Skip ndarrays
-                if isinstance(value.strip(), asdf.tags.core.ndarray.NDArrayType):
-                    continue
-
                 # Store Basic keyword
                 basic_cols.append(key)
 

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -90,7 +90,7 @@ class MosaicModel(_RomanDataModel):
 
                     subtable_cols.append(subkey)
 
-                    if isinstance(subvalue, list):
+                    if isinstance(subvalue, (list, dict)):
                         subtable_vals.append([str(subvalue)])
                     else:
                         subtable_vals.append([subvalue])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
WIP [RCAL-798](https://jira.stsci.edu/browse/RCAL-798)

<!-- describe the changes comprising this PR here -->
This PR addresses a bug during Qtable construction for the MosiacImage `individual_image_meta` block.

While creating the Qtable for the `individual_image_meta` block, if an input meta has deeply nested nodes, these nodes, appropriately, are turned into dicts. However, the Qtable column for these situations becomes just a generic `object`, causing validation errors.

Taking the cue of the conversion of lists to strings, the same approach is taken for dicts.
**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
