### PR TITLE
Skip QTables in individual image metadata.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Add conversion of dict to string during Qtable construction [#348]
 
+- Do not include QTables in individual image metadata [#349]
+
 0.19.1 (2024-04-04)
 ===================
 

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -87,6 +87,9 @@ class MosaicModel(_RomanDataModel):
                     # Skip ndarrays
                     if isinstance(subvalue, asdf.tags.core.ndarray.NDArrayType):
                         continue
+                    # Skip QTables
+                    if isinstance(subvalue, QTable):
+                        continue
 
                     subtable_cols.append(subkey)
 
@@ -110,6 +113,9 @@ class MosaicModel(_RomanDataModel):
                 continue
             # Skip ndarrays
             elif isinstance(value.strip(), asdf.tags.core.ndarray.NDArrayType):
+                continue
+            # Skip QTables
+            elif isinstance(value, QTable):
                 continue
             else:
                 # Store Basic keyword


### PR DESCRIPTION
This PR adds QTable to the list of things to skip for the individual image metadata.

QTables get made as part of the PSF catalog that is now the tweakreg_catalog, instead of the old ndarray.