### PR TITLE
Fix bug that was crashing method when attribute was an array.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Separated TVAC and FPS into their own makers to freeze from from main development. [#347]
 
+- Fix bug that prevented proper handling of ``np.NDArray``\s. [#350]
+
 
 0.19.2 (2024-05-08)
 ===================


### PR DESCRIPTION
Resolves [RCAL-838](https://jira.stsci.edu/browse/RCAL-838)

This PR addresses a bug that was preventing the proper check and handling of `np.NDArray` arrays.

**Regression Tests**
https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/755/

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [X] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
