### PR TITLE
RCAL-833 Recursively convert all meta attributes during model casting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.20.1 (unreleased)
 ===================
 
--
+- Recursively convert all meta attributes during model casting. [#352]
 
 0.20.0 (2024-05-15)
 ===================

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -143,7 +143,7 @@ class RampModel(_RomanDataModel):
 
         Parameters
         ----------
-        model : ScieceRawModel, TvacModel
+        model : ScienceRawModel, TvacModel
             The input data model (a RampModel will also work).
 
         Returns

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -149,26 +149,25 @@ class RampModel(_RomanDataModel):
 
         Returns
         -------
-        output_model : RampModel
+        ramp_model : RampModel
             The RampModel built from the input model. If the input is already
             a RampModel, it is simply returned.
         """
         if isinstance(model, cls):
             return model
-        if not isinstance(model, (ScienceRawModel, TvacModel)):
-            raise ValueError("Input must be one of (RampModel, ScienceRawModel, TvacModel)")
+        if not isinstance(model, (FpsModel, RampModel, ScienceRawModel, TvacModel)):
+            raise ValueError('Input must be one of (FpsModel, RampModel, ScienceRawModel, TvacModel)')
 
         # Create base ramp node with dummy values (for validation)
         from roman_datamodels.maker_utils import mk_ramp
-
-        input_ramp = mk_ramp(shape=model.shape)
+        ramp = mk_ramp(shape=model.shape)
 
         # check if the input model has a resultantdq from SDF
         if hasattr(model, "resultantdq"):
-            input_ramp.groupdq = model.resultantdq.copy()
+            ramp.groupdq = model.resultantdq.copy()
 
         # Define how to recursively copy all attributes.
-        def node_update(self, other, orig=False):
+        def node_update(self, other):
             """Implement update to directly access each value"""
             for key in other.keys():
                 if key == "resultantdq":
@@ -184,12 +183,11 @@ class RampModel(_RomanDataModel):
                         self[key] = other.__getattr__(key).astype(self[key].dtype)
                         continue
                 self[key] = other.__getattr__(key)
-
-        node_update(input_ramp, model)
+        node_update(ramp, model)
 
         # Create model from node
-        output_model = RampModel(input_ramp)
-        return output_model
+        ramp_model = RampModel(ramp)
+        return ramp_model
 
 
 class RampFitOutputModel(_RomanDataModel):

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -158,10 +158,11 @@ class RampModel(_RomanDataModel):
         if isinstance(model, cls):
             return model
         if not isinstance(model, ALLOWED_MODELS):
-            raise ValueError(f'Input must be one of {ALLOWED_MODELS}')
+            raise ValueError(f"Input must be one of {ALLOWED_MODELS}")
 
         # Create base ramp node with dummy values (for validation)
         from roman_datamodels.maker_utils import mk_ramp
+
         ramp = mk_ramp(shape=model.shape)
 
         # check if the input model has a resultantdq from SDF
@@ -185,6 +186,7 @@ class RampModel(_RomanDataModel):
                         self[key] = other.__getattr__(key).astype(self[key].dtype)
                         continue
                 self[key] = other.__getattr__(key)
+
         node_update(ramp, model)
 
         # Create model from node

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -171,15 +171,16 @@ class RampModel(_RomanDataModel):
             for key in other.keys():
                 if key == 'resultantdq':
                     continue
-                if key not in self:
-                    self[key] = other.__getattr__(key)
-                    continue
-                if isinstance(self[key], Mapping):
-                    node_update(self[key], other.__getattr__(key))
-                    continue
-                if isinstance(self[key], np.ndarray):
-                    self[key] = other.__getattr__(key).astype(self[key].dtype)
-                    continue
+                if key in self:
+                    if isinstance(self[key], Mapping):
+                        node_update(self[key], other.__getattr__(key))
+                        continue
+                    if isinstance(self[key], list):
+                        self[key] = other.__getattr__(key).data
+                        continue
+                    if isinstance(self[key], np.ndarray):
+                        self[key] = other.__getattr__(key).astype(self[key].dtype)
+                        continue
                 self[key] = other.__getattr__(key)
         node_update(input_ramp, model)
 

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -5,6 +5,7 @@ This module provides all the specific datamodels used by the Roman pipeline.
     the top-level STNode type that the datamodel wraps. This STNode type is derived
     from the schema manifest defined by RAD.
 """
+
 from collections.abc import Mapping
 
 import asdf
@@ -155,10 +156,11 @@ class RampModel(_RomanDataModel):
         if isinstance(model, cls):
             return model
         if not isinstance(model, (ScienceRawModel, TvacModel)):
-            raise ValueError('Input must be one of (RampModel, ScienceRawModel, TvacModel)')
+            raise ValueError("Input must be one of (RampModel, ScienceRawModel, TvacModel)")
 
         # Create base ramp node with dummy values (for validation)
         from roman_datamodels.maker_utils import mk_ramp
+
         input_ramp = mk_ramp(shape=model.shape)
 
         # check if the input model has a resultantdq from SDF
@@ -169,7 +171,7 @@ class RampModel(_RomanDataModel):
         def node_update(self, other, orig=False):
             """Implement update to directly access each value"""
             for key in other.keys():
-                if key == 'resultantdq':
+                if key == "resultantdq":
                     continue
                 if key in self:
                     if isinstance(self[key], Mapping):
@@ -182,6 +184,7 @@ class RampModel(_RomanDataModel):
                         self[key] = other.__getattr__(key).astype(self[key].dtype)
                         continue
                 self[key] = other.__getattr__(key)
+
         node_update(input_ramp, model)
 
         # Create model from node

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -164,7 +164,7 @@ class RampModel(_RomanDataModel):
         if hasattr(model, "resultantdq"):
             input_ramp.groupdq = model.resultantdq.copy()
 
-        # Copy input_model contents into RampModel
+        # Copy input model contents into RampModel
         for key in model.keys():
             # check for resultantdq if present copy this to the emp
             # it to the ramp model, we don't want to carry this around

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -139,8 +139,8 @@ class RampModel(_RomanDataModel):
         """
         Attempt to construct a RampModel from a DataModel
 
-        If the model has a `resultantdq` attribute, this is copied into
-        the `RampModel.groupdq` attribute.
+        If the model has a resultantdq attribute, this is copied into
+        the RampModel.groupdq attribute.
 
         Parameters
         ----------

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -153,10 +153,12 @@ class RampModel(_RomanDataModel):
             The RampModel built from the input model. If the input is already
             a RampModel, it is simply returned.
         """
+        ALLOWED_MODELS = (FpsModel, RampModel, ScienceRawModel, TvacModel)
+
         if isinstance(model, cls):
             return model
-        if not isinstance(model, (FpsModel, RampModel, ScienceRawModel, TvacModel)):
-            raise ValueError('Input must be one of (FpsModel, RampModel, ScienceRawModel, TvacModel)')
+        if not isinstance(model, ALLOWED_MODELS):
+            raise ValueError(f'Input must be one of {ALLOWED_MODELS}')
 
         # Create base ramp node with dummy values (for validation)
         from roman_datamodels.maker_utils import mk_ramp

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -958,3 +958,10 @@ def test_datamodel_save_filename(tmp_path):
 
     with datamodels.open(filename) as new_ramp:
         assert new_ramp.meta.filename == filename.name
+
+
+@pytest.mark.parametrize('model_class', [datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel])
+def test_rampmodel_from_science_raw(model_class):
+    """Test creation of RampModel from raw science/tvac"""
+    model = utils.mk_datamodel(model_class)
+    ramp = datamodels.RampModel.from_science_raw(model)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -960,7 +960,7 @@ def test_datamodel_save_filename(tmp_path):
         assert new_ramp.meta.filename == filename.name
 
 
-@pytest.mark.parametrize('model_class', [datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel])
+@pytest.mark.parametrize("model_class", [datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel])
 def test_rampmodel_from_science_raw(model_class):
     """Test creation of RampModel from raw science/tvac"""
     model = utils.mk_datamodel(model_class)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -960,16 +960,21 @@ def test_datamodel_save_filename(tmp_path):
         assert new_ramp.meta.filename == filename.name
 
 
-@pytest.mark.parametrize('model_class, expect_success',
-                         [(datamodels.FpsModel, True),
-                          (datamodels.RampModel, True),
-                          (datamodels.ScienceRawModel, True),
-                          (datamodels.TvacModel, True),
-                          (datamodels.MosaicModel, False)])
+@pytest.mark.parametrize(
+    "model_class, expect_success",
+    [
+        (datamodels.FpsModel, True),
+        (datamodels.RampModel, True),
+        (datamodels.ScienceRawModel, True),
+        (datamodels.TvacModel, True),
+        (datamodels.MosaicModel, False),
+    ],
+)
 def test_rampmodel_from_science_raw(model_class, expect_success):
     """Test creation of RampModel from raw science/tvac"""
-    model = utils.mk_datamodel(model_class, meta={'calibration_software_version': '1.2.3',
-                                                  'exposure': {'read_pattern': [[1], [2], [3]]}})
+    model = utils.mk_datamodel(
+        model_class, meta={"calibration_software_version": "1.2.3", "exposure": {"read_pattern": [[1], [2], [3]]}}
+    )
     if expect_success:
         ramp = datamodels.RampModel.from_science_raw(model)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -960,8 +960,22 @@ def test_datamodel_save_filename(tmp_path):
         assert new_ramp.meta.filename == filename.name
 
 
-@pytest.mark.parametrize("model_class", [datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel])
-def test_rampmodel_from_science_raw(model_class):
+@pytest.mark.parametrize('model_class, expect_success',
+                         [(datamodels.FpsModel, True),
+                          (datamodels.RampModel, True),
+                          (datamodels.ScienceRawModel, True),
+                          (datamodels.TvacModel, True),
+                          (datamodels.MosaicModel, False)])
+def test_rampmodel_from_science_raw(model_class, expect_success):
     """Test creation of RampModel from raw science/tvac"""
-    model = utils.mk_datamodel(model_class)
-    ramp = datamodels.RampModel.from_science_raw(model)
+    model = utils.mk_datamodel(model_class, meta={'calibration_software_version': '1.2.3',
+                                                  'exposure': {'read_pattern': [[1], [2], [3]]}})
+    if expect_success:
+        ramp = datamodels.RampModel.from_science_raw(model)
+
+        assert ramp.meta.calibration_software_version == model.meta.calibration_software_version
+        assert ramp.meta.exposure.read_pattern == model.meta.exposure.read_pattern
+
+    else:
+        with pytest.raises(ValueError):
+            datamodels.RampModel.from_science_raw(model)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-833](https://jira.stsci.edu/browse/RCAL-833)

<!-- describe the changes comprising this PR here -->
This PR addresses issues found while trying to convert TVAC raw/level 1 data into a RampModel.

The issue is that the meta update was using `dict.update`, which doesn't transcribe/copy all the attributes. This left attributes with TVAC tags, producing validation warnings when the RampModel is produced.

Solution is to recursively traverse the meta tree, equating/converting each item.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [x] updated relevant documentation
- [x] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
