### PR TITLE
 RCAL-833 Recursively convert all meta attributes during model casting (pure model version)

### DIFF
--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -142,7 +142,7 @@ class RampModel(_RomanDataModel):
 
         Parameters
         ----------
-        model : ScieceRawModel, TvacModel
+        model : ScienceRawModel, TvacModel
             The input data model (a RampModel will also work).
 
         Returns

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -154,12 +154,13 @@ class RampModel(_RomanDataModel):
         if isinstance(model, cls):
             return model
         if not isinstance(model, (ScienceRawModel, TvacModel)):
-            raise ValueError('Input must be one of (RampModel, ScienceRawModel, TvacModel)')
+            raise ValueError("Input must be one of (RampModel, ScienceRawModel, TvacModel)")
 
         # Create base ramp node with dummy values (for validation)
         # from roman_datamodels.maker_utils import mk_ramp
         # input_ramp = mk_ramp(shape=model.shape)
         from roman_datamodels.maker_utils import mk_datamodel
+
         output_model = mk_datamodel(RampModel, shape=model.shape)
 
         # check if the input model has a resultantdq from SDF
@@ -174,14 +175,12 @@ class RampModel(_RomanDataModel):
                 if key not in output_model:
                     output_model[key] = model.__getattr__(key)
                 elif isinstance(output_model[key], dict):
-                    # If a dictionary (like meta), overwrite entires (but keep
+                    # If a dictionary (like meta), overwrite entries (but keep
                     # required dummy entries that may not be in input_model)
                     output_model[key].update(model.__getattr__(key))
                 elif isinstance(output_model[key], np.ndarray):
                     # Cast input ndarray as RampModel dtype
-                    output_model[key] = model.__getattr__(key).astype(
-                        output_model[key].dtype
-                    )
+                    output_model[key] = model.__getattr__(key).astype(output_model[key].dtype)
                 else:
                     output_model[key] = model.__getattr__(key)
 

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -164,7 +164,7 @@ class RampModel(_RomanDataModel):
         if hasattr(model, "resultantdq"):
             input_ramp.groupdq = model.resultantdq.copy()
 
-        # Copy input_model contents into RampModel
+        # Copy input model contents into RampModel
         for key in model.keys():
             # check for resultantdq if present copy this to the emp
             # it to the ramp model, we don't want to carry this around

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -157,34 +157,36 @@ class RampModel(_RomanDataModel):
             raise ValueError('Input must be one of (RampModel, ScienceRawModel, TvacModel)')
 
         # Create base ramp node with dummy values (for validation)
-        from roman_datamodels.maker_utils import mk_ramp
-        input_ramp = mk_ramp(shape=model.shape)
+        # from roman_datamodels.maker_utils import mk_ramp
+        # input_ramp = mk_ramp(shape=model.shape)
+        from roman_datamodels.maker_utils import mk_datamodel
+        output_model = mk_datamodel(RampModel, shape=model.shape)
 
         # check if the input model has a resultantdq from SDF
         if hasattr(model, "resultantdq"):
-            input_ramp.groupdq = model.resultantdq.copy()
+            output_model.groupdq = model.resultantdq.copy()
 
         # Copy input model contents into RampModel
         for key in model.keys():
             # check for resultantdq if present copy this to the emp
             # it to the ramp model, we don't want to carry this around
             if key != "resultantdq":
-                if key not in input_ramp:
-                    input_ramp[key] = model.__getattr__(key)
-                elif isinstance(input_ramp[key], dict):
+                if key not in output_model:
+                    output_model[key] = model.__getattr__(key)
+                elif isinstance(output_model[key], dict):
                     # If a dictionary (like meta), overwrite entires (but keep
                     # required dummy entries that may not be in input_model)
-                    input_ramp[key].update(model.__getattr__(key))
-                elif isinstance(input_ramp[key], np.ndarray):
+                    output_model[key].update(model.__getattr__(key))
+                elif isinstance(output_model[key], np.ndarray):
                     # Cast input ndarray as RampModel dtype
-                    input_ramp[key] = model.__getattr__(key).astype(
-                        input_ramp[key].dtype
+                    output_model[key] = model.__getattr__(key).astype(
+                        output_model[key].dtype
                     )
                 else:
-                    input_ramp[key] = model.__getattr__(key)
+                    output_model[key] = model.__getattr__(key)
 
         # Create model from node
-        output_model = RampModel(input_ramp)
+        # output_model = RampModel(input_ramp)
         return output_model
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -958,3 +958,10 @@ def test_datamodel_save_filename(tmp_path):
 
     with datamodels.open(filename) as new_ramp:
         assert new_ramp.meta.filename == filename.name
+
+
+@pytest.mark.parametrize('model_class', [datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel])
+def test_rampmodel_from_science_raw(model_class):
+    """Test creation of RampModel from raw science/tvac"""
+    model = utils.mk_datamodel(model_class)
+    ramp = datamodels.RampModel.from_science_raw(model)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -960,7 +960,7 @@ def test_datamodel_save_filename(tmp_path):
         assert new_ramp.meta.filename == filename.name
 
 
-@pytest.mark.parametrize('model_class', [datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel])
+@pytest.mark.parametrize("model_class", [datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel])
 def test_rampmodel_from_science_raw(model_class):
     """Test creation of RampModel from raw science/tvac"""
     model = utils.mk_datamodel(model_class)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-833](https://jira.stsci.edu/browse/RCAL-833)

<!-- describe the changes comprising this PR here -->
This PR addresses issues found while trying to convert TVAC raw/level 1 data into a RampModel.

The issue is that the meta update was using dict.update, which doesn't transcribe/copy all the attributes. This left attributes with TVAC tags, producing validation warnings when the RampModel is produced.

The solution is to remove the `stnode` direct updating and do the updating through the RampModel directly

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
