### PR TITLE
ignore addressed attrs deprecation warning in oldestdeps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ testpaths = [
 filterwarnings = [
     "error",
     "ignore:numpy.ndarray size changed:RuntimeWarning",
+    "ignore:The `hash` argument is deprecated in favor of `unsafe_hash` and will be removed in or after August 2025:DeprecationWarning",
 ]
 env = [
     "ROMAN_VALIDATE=true",


### PR DESCRIPTION
The newest version of `attrs` includes a deprecation warning for a feature used in asdf:
https://github.com/python-attrs/attrs/releases/tag/24.1.0
This has been addressed:
https://github.com/asdf-format/asdf/pull/1815
and released in asdf 3.4.0
https://github.com/asdf-format/asdf/releases/tag/3.4.0

However the oldestdeps job here will not pick up the change until the minimum asdf version is 3.4.0. This is because the oldest deps job only installs the oldest versions of direct dependencies (like asdf) and will install the newest version of indirect deps (like attrs).

This PR adds a warning filter to ignore the warning from attrs.

**Checklist**
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
