### PR TITLE
only use roman.meta for get_crds_parameters

### DIFF
--- a/changes/372.bugfix.rst
+++ b/changes/372.bugfix.rst
@@ -1,0 +1,1 @@
+Only use ``roman.meta`` attributes for crds parameter selection.

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -317,7 +317,7 @@ class DataModel(abc.ABC):
         schemas directly.
         """
 
-        yield from self._instance.items(recursive=True)
+        yield from self._instance._recursive_items()
 
     def get_crds_parameters(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -858,18 +858,15 @@ def test_datamodel_schema_info_existence(name):
                     assert keyword in info["roman"]["meta"]
 
 
-def test_crds_parameters(tmp_path):
+@pytest.mark.parametrize("mk_model", (utils.mk_level2_image, utils.mk_ramp))
+def test_crds_parameters(mk_model, tmp_path):
     # CRDS uses meta.exposure.start_time to compare to USEAFTER
-    file_path = tmp_path / "testwfi_image.asdf"
-    utils.mk_level2_image(filepath=file_path)
+    file_path = tmp_path / "test.asdf"
+    mk_model(filepath=file_path)
     with datamodels.open(file_path) as wfi_image:
         crds_pars = wfi_image.get_crds_parameters()
         assert "roman.meta.exposure.start_time" in crds_pars
-
-    utils.mk_ramp(filepath=file_path)
-    with datamodels.open(file_path) as ramp:
-        crds_pars = ramp.get_crds_parameters()
-        assert "roman.meta.exposure.start_time" in crds_pars
+        assert "roman.cal_logs" not in crds_pars
 
 
 def test_model_validate_without_save():


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #367
Closes #366 

<!-- describe the changes comprising this PR here -->
This PR modifies `DataModel.get_crds_parameters` to only include (and only access) items under `roman.meta`. `get_crds_parameters` is called twice during the setup of commands like the following `strun MyStep mydata.asdf`. Once to get the pars file for the `MyStep` and again to prefetch reference files for `mydata.asdf`. Each of these calls will:
- open the `Datamodel` contains in `mydata.asdf` (each call separately opens the file, the opened datamodel is not shared between calls)
- call `Datamodel.get_crds_parameters`
With the current implementation of `get_crds_parameters`, every attribute of the datamodel is accessed and then the attributes are filtered to include select non-array values (see the code for the specific filtering). For a "lazy" file this will result in loading and converting all contents of the file twice before the file is again re-opened within `MyStep.process`.

With this PR only the nodes under `roman.meta` are accessed and included for `get_crds_parameters`. This PR does not query crds for the required parameter selectors (parkeys) as:
- there doesn't appear to be an API for reliably getting these parkeys
- even with an API some coordination with stpipe would likely be called for as it has a crds dependency (unlike roman_datamodels)

Querying crds would allow fewer metadata entries to be loaded (which is a very minor improvement that might be offset by the crds API) and would protect against the unlikely case that a non-`roman.meta` attribute is used as a selector.

This PR also fixes the "include_arrays" filtering for `DataModel.to_flat_dict`.

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/10268370867
show unrelated failures due to background changes.

**Checklist**
- [x] Added entry in `CHANGES.rst` under the corresponding subsection
- [x] updated relevant tests
- [ ] updated relevant documentation
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
