### PR TITLE
use shorter string for NOSTR value

### DIFF
--- a/changes/388.bugfix.rst
+++ b/changes/388.bugfix.rst
@@ -1,0 +1,1 @@
+Use a shorter string "?" for maker_utils default values for strings.

--- a/src/roman_datamodels/maker_utils/_base.py
+++ b/src/roman_datamodels/maker_utils/_base.py
@@ -2,6 +2,7 @@ import asdf
 
 NONUM = -999999
 NOSTR = "?"
+NOFN = "none"
 
 MESSAGE = "This function assumes shape is 2D, but it was given at least 3 dimensions"
 

--- a/src/roman_datamodels/maker_utils/_base.py
+++ b/src/roman_datamodels/maker_utils/_base.py
@@ -1,7 +1,7 @@
 import asdf
 
 NONUM = -999999
-NOSTR = "dummy value"
+NOSTR = "?"
 
 MESSAGE = "This function assumes shape is 2D, but it was given at least 3 dimensions"
 

--- a/src/roman_datamodels/maker_utils/_basic_meta.py
+++ b/src/roman_datamodels/maker_utils/_basic_meta.py
@@ -2,7 +2,7 @@ from astropy import time
 
 from roman_datamodels import stnode
 
-from ._base import NOSTR
+from ._base import NOFN, NOSTR
 
 
 def mk_calibration_software_version(**kwargs):
@@ -36,7 +36,7 @@ def mk_filename(**kwargs):
     -------
     roman_datamodels.stnode.Filename
     """
-    return stnode.Filename(kwargs.get("filename", NOSTR))
+    return stnode.Filename(kwargs.get("filename", NOFN))
 
 
 def mk_file_date(**kwargs):

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -10,7 +10,7 @@ from roman_datamodels import datamodels
 from roman_datamodels import maker_utils
 from roman_datamodels import maker_utils as utils
 from roman_datamodels import stnode, validate
-from roman_datamodels.maker_utils._base import NONUM, NOSTR
+from roman_datamodels.maker_utils._base import NOFN, NONUM, NOSTR
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy, wraps_hashable
 
 from .conftest import MANIFEST
@@ -375,7 +375,7 @@ def test_node_representation(model):
             }
             assert mdl.meta.model_type == model_types[type(mdl)]
             assert mdl.meta.telescope == "ROMAN"
-            assert mdl.meta.filename == NOSTR
+            assert mdl.meta.filename == NOFN
         elif isinstance(mdl, (datamodels.SegmentationMapModel, datamodels.SourceCatalogModel)):
             assert mdl.meta.optical_element == "F158"
         else:

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -10,6 +10,7 @@ from roman_datamodels import datamodels
 from roman_datamodels import maker_utils
 from roman_datamodels import maker_utils as utils
 from roman_datamodels import stnode, validate
+from roman_datamodels.maker_utils._base import NONUM, NOSTR
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy, wraps_hashable
 
 from .conftest import MANIFEST
@@ -351,20 +352,20 @@ def test_node_representation(model):
         if isinstance(mdl, (datamodels.MosaicModel, datamodels.MosaicSegmentationMapModel, datamodels.MosaicSourceCatalogModel)):
             assert repr(mdl.meta.basic) == repr(
                 {
-                    "time_first_mjd": -999999,
-                    "time_last_mjd": -999999,
-                    "time_mean_mjd": -999999,
-                    "max_exposure_time": -999999,
-                    "mean_exposure_time": -999999,
-                    "visit": -999999,
-                    "segment": -999999,
-                    "pass": -999999,
-                    "program": "dummy value",
-                    "survey": "dummy value",
+                    "time_first_mjd": NONUM,
+                    "time_last_mjd": NONUM,
+                    "time_mean_mjd": NONUM,
+                    "max_exposure_time": NONUM,
+                    "mean_exposure_time": NONUM,
+                    "visit": NONUM,
+                    "segment": NONUM,
+                    "pass": NONUM,
+                    "program": NOSTR,
+                    "survey": NOSTR,
                     "optical_element": "F158",
                     "instrument": "WFI",
-                    "location_name": "dummy value",
-                    "product_type": "dummy value",
+                    "location_name": NOSTR,
+                    "product_type": NOSTR,
                 }
             )
             model_types = {
@@ -374,7 +375,7 @@ def test_node_representation(model):
             }
             assert mdl.meta.model_type == model_types[type(mdl)]
             assert mdl.meta.telescope == "ROMAN"
-            assert mdl.meta.filename == "dummy value"
+            assert mdl.meta.filename == NOSTR
         elif isinstance(mdl, (datamodels.SegmentationMapModel, datamodels.SourceCatalogModel)):
             assert mdl.meta.optical_element == "F158"
         else:


### PR DESCRIPTION
The current `NOSTR` value used in the maker utils is incompatible with some archive_catalog nvarchar entries. Although this value likely shouldn't ever end up in the archive it prevents adding corresponding `minLength` keywords to the schemas (to check these nvarchars during schema validation).

This PR set's a new `NOSTR` value of `?`. This was chosen as the smallest `nvarchar` value is 2 for [visit_file_activity](https://github.com/spacetelescope/rad/blob/525ce48b8ec9023d1034b4d82f9dc5ff628ad8b4/src/rad/resources/schemas/observation-1.0.0.yaml#L158).

`meta.filename` requires a different value `none` as `source_catalog` will use this value for some unit tests:
https://github.com/spacetelescope/romancal/blob/96af8bbc6a6dafd48d1beb251b5209d9da875ca1/romancal/source_catalog/source_catalog_step.py#L151
Which then leads to a failure since it attempts to write to "?".

romancal also includes some of these default values in the doctests. https://github.com/spacetelescope/romancal/pull/1419 is needed before this PR can be merged. EDIT: romancal PR is merged, rerunning regtests but will open this for review in case there are requested changes

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/10966346784
show same failures as main: https://github.com/spacetelescope/RegressionTests/actions/runs/10998102193

This PR is a requirement for https://github.com/spacetelescope/rad/pull/448

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [start a `romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/roman_datamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
