### PR TITLE
Open `json` files as `ModelLibrary` if `romancal` is installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,8 @@ jobs:
     with:
       envs: |
         - linux: rad
+  test_with_romancal:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: with_romancal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,5 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: with_romancal
+        - linux: withromancal
+          coverage: codecov

--- a/changes/389.feature.rst
+++ b/changes/389.feature.rst
@@ -1,0 +1,1 @@
+Open ``.json`` files as ``ModelLibrary`` if ``romancal`` is installed.

--- a/src/roman_datamodels/datamodels/_utils.py
+++ b/src/roman_datamodels/datamodels/_utils.py
@@ -63,6 +63,14 @@ def rdm_open(init, memmap=False, **kwargs):
     -------
     `DataModel`
     """
+    if isinstance(init, str | Path):
+        if Path(init).suffix.lower() == ".json":
+            try:
+                from romancal.datamodels.library import ModelLibrary
+
+                return ModelLibrary(init)
+            except ImportError:
+                raise ImportError("Please install romancal to allow opening associations with roman_datamodels")
     with validate.nuke_validation():
         if isinstance(init, DataModel):
             # Copy the object so it knows not to close here
@@ -75,15 +83,6 @@ def rdm_open(init, memmap=False, **kwargs):
         asdf_file = init if isinstance(init, asdf.AsdfFile) else _open_path_like(init, memmap=memmap, **kwargs)
         if (model_type := type(asdf_file.tree["roman"])) in MODEL_REGISTRY:
             return MODEL_REGISTRY[model_type](asdf_file, **kwargs)
-
-        if isinstance(init, str):
-            exts = Path(init).suffixes
-            if not exts:
-                raise ValueError(f"Input file path does not have an extension: {init}")
-
-            # Assume json files are asn and return them
-            if exts[0] == "json":
-                return init
 
         asdf_file.close()
         raise TypeError(f"Unknown datamodel type: {model_type}")

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -244,7 +244,7 @@ def test_open_asn(tmp_path):
 
     fn = tmp_path / "test.json"
     asn = {
-        "product": [
+        "products": [
             {
                 "members": [],
                 "name": "foo",

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -242,7 +242,7 @@ def test_rdm_open_non_datamodel():
 def test_open_asn(tmp_path):
     romancal = pytest.importorskip("romancal")
 
-    fn = tmp_path / "test.asn"
+    fn = tmp_path / "test.json"
     asn = {
         "product": [
             {

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import asdf
@@ -236,3 +237,23 @@ def test_rdm_open_non_datamodel():
 
     with pytest.raises(TypeError, match=r"Unknown datamodel type: .*"):
         rdm_open(Path(__file__).parent / "data" / "not_a_datamodel.asdf")
+
+
+def test_open_asn(tmp_path):
+    romancal = pytest.importorskip("romancal")
+
+    fn = tmp_path / "test.asn"
+    asn = {
+        "product": [
+            {
+                "members": [],
+                "name": "foo",
+            }
+        ],
+    }
+    with open(fn, "w") as f:
+        json.dump(asn, f)
+
+    lib = datamodels.open(fn)
+
+    assert isinstance(lib, romancal.datamodels.ModelLibrary)

--- a/tox.ini
+++ b/tox.ini
@@ -69,3 +69,15 @@ deps =
     build
 commands =
     python -m build .
+
+[testenv:with_romancal]
+allowlist_externals =
+    git
+    bash
+commands_pre =
+    bash -c "pip freeze -q | grep 'roman_datamodels @' > {env_tmp_dir}/requirements.txt"
+    pip install git+https://github.com/spacetelescope/romancal.git
+    pip install -r {env_tmp_dir}/requirements.txt
+    pip freeze
+commands =
+    pytest tests/test_open.py::test_open_asn

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ env_list =
     test{,-devdeps}{,-pyargs,-cov}-xdist
     test-numpy{120,121,122}-xdist
     build-{docs,dist}
+    withromancal
 
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
@@ -70,14 +71,18 @@ deps =
 commands =
     python -m build .
 
-[testenv:with_romancal]
+[testenv:withromancal]
 allowlist_externals =
     git
     bash
+deps =
+    pytest-cov
 commands_pre =
     bash -c "pip freeze -q | grep 'roman_datamodels @' > {env_tmp_dir}/requirements.txt"
     pip install git+https://github.com/spacetelescope/romancal.git
     pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
-    pytest tests/test_open.py::test_open_asn
+    pytest tests/test_open.py::test_open_asn \
+    --cov=tests --cov-config pyproject.toml --cov-report term-missing --cov-report xml \
+    {posargs}


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #267

<!-- describe the changes comprising this PR here -->
As discussed in the issue, roman_datamodels by itself cannot open an association. So if a user provides an association to `roman_datamodels.open` we could:
- raise a helpful exception saying use romancal
- if a user has romancal installed, open the file as a `ModelLibrary

This PR takes the second approach. Adding support to open `.json` files provided to `datamodels.open` as `ModelLibrary` instances (if `romancal` is installed).

This required added a new CI job `with_romancal` which currently only runs the one unit test for this feature.

Regtests show same failures as main: https://github.com/spacetelescope/RegressionTests/actions/runs/11000547719

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [start a `romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/roman_datamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
