### PR TITLE
test RTD docdiff addon

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,8 @@
 User Manual
 ===========
 
+added test text for docdiff
+
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
it works:
[<img width="1152" alt="image" src="https://github.com/user-attachments/assets/0592f30e-4e89-4dcc-a5d1-44e4db805d48">](https://roman-datamodels--391.org.readthedocs.build/en/391/)
(press hotkey `d`):
[<img width="1152" alt="Screenshot 2024-09-25 at 1 03 47 PM" src="https://github.com/user-attachments/assets/4fdc2293-4a87-43a5-9539-ba143adb7ae4">](https://roman-datamodels--391.org.readthedocs.build/en/391/)
