### PR TITLE
RCAL-927: Add ref_file entry for reference pixel subtraction reference file

### DIFF
--- a/changes/397.feature.rst
+++ b/changes/397.feature.rst
@@ -1,0 +1,1 @@
+Add ``ref_file`` entry for reference pixel subtraction reference file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,9 @@ dependencies = [
     "gwcs >=0.19.0",
     "numpy >=1.22",
     "astropy >=5.3.0",
-    "rad >= 0.21.0",
+    # "rad >= 0.21.0",
     # "rad @ git+https://github.com/spacetelescope/rad.git",
+    "rad @ git+https://github.com/PaulHuwe/rad.git@RAD-176_RefPixRefFile",
     "asdf-standard >=1.1.0",
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dependencies = [
     "numpy >=1.22",
     "astropy >=5.3.0",
     # "rad >= 0.21.0",
-    # "rad @ git+https://github.com/spacetelescope/rad.git",
-    "rad @ git+https://github.com/PaulHuwe/rad.git@RAD-176_RefPixRefFile",
+    "rad @ git+https://github.com/spacetelescope/rad.git",
     "asdf-standard >=1.1.0",
 ]
 dynamic = [

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -443,6 +443,7 @@ def mk_ref_file(**kwargs):
     ref_file["linearity"] = kwargs.get("linearity", "N/A")
     ref_file["mask"] = kwargs.get("mask", "N/A")
     ref_file["readnoise"] = kwargs.get("readnoise", "N/A")
+    ref_file["refpix"] = kwargs.get("refpix", "N/A")
     ref_file["saturation"] = kwargs.get("saturation", "N/A")
     ref_file["photom"] = kwargs.get("photom", "N/A")
     ref_file["crds"] = kwargs.get("crds", {"sw_version": "12.3.1", "context_used": "roman_0815.pmap"})


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-927](https://jira.stsci.edu/browse/RCAL-927)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR adds ref_file entry for reference pixel subtraction reference file.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [start a `romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/roman_datamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
