### PR TITLE
test with python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
         - linux: py310-oldestdeps-cov
           coverage: codecov
         - linux: py310
-        - linux: py311
-        - macos: py311
         - linux: py311-cov
           coverage: codecov
         - linux: py312
+        - linux: py313
+        - macos: py311
   test_upstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
     with:

--- a/changes/401.feature.rst
+++ b/changes/401.feature.rst
@@ -1,0 +1,1 @@
+Add python 3.13 support.


### PR DESCRIPTION
This PR adds python 3.13 to the CI.

I also removed the `py311` environment (testing with python 3.11) since we're already running `py311-cov` (python 3.11 while measuring coverage). This change will require updates to the branch protection rules as currently `py311` is marked as required. I'm happy to remove that change from this PR (if that's preferred) just let me know.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] [start a `romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/roman_datamodels@<branch>"`)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
