### PR TITLE
Use multiclass of uint32 and Enum rather than IntEnum

### DIFF
--- a/changes/402.misc.rst
+++ b/changes/402.misc.rst
@@ -1,0 +1,2 @@
+Use multiclass of `np.uint32` and `Enum` rather than a subclass of `IntEnum` for
+the dqflags as suggested by the numpy devs.

--- a/src/roman_datamodels/dqflags.py
+++ b/src/roman_datamodels/dqflags.py
@@ -19,12 +19,14 @@ which provides 32 bits. Bits of an integer are most easily referred to using
 the formula `2**bit_number` where `bit_number` is the 0-index bit of interest.
 """
 
-from enum import IntEnum, unique
+from enum import Enum, unique
+
+import numpy as np
 
 
 # fmt: off
 @unique
-class pixel(IntEnum):
+class pixel(np.uint32, Enum):
     """Pixel-specific data quality flags"""
 
     GOOD             = 0      # No bits set, all is good
@@ -62,7 +64,7 @@ class pixel(IntEnum):
 
 
 @unique
-class group(IntEnum):
+class group(np.uint32, Enum):
     """Group-specific data quality flags
         Once groups are combined, these flags are equivalent to the pixel-specific flags.
     """

--- a/tests/test_dqflags.py
+++ b/tests/test_dqflags.py
@@ -1,5 +1,6 @@
 from math import log10
 
+import numpy as np
 import pytest
 
 from roman_datamodels import datamodels as rdm
@@ -30,7 +31,7 @@ def test_pixel_flags(flag):
     assert isinstance(flag, dqflags.pixel)
 
     # Test that the pixel flags are ints
-    assert isinstance(flag, int)
+    assert isinstance(flag, np.uint32)
 
     # Test that the pixel flags are dict accessible
     assert dqflags.pixel[flag.name] is flag
@@ -78,7 +79,7 @@ def test_group_flags(flag):
     assert isinstance(flag, dqflags.group)
 
     # Test that the group flags are ints
-    assert isinstance(flag, int)
+    assert isinstance(flag, np.uint32)
 
     # Test that the group flags are dict accessible
     assert dqflags.group[flag.name] is flag


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
As part of the discussion in numpy/numpy#27540 about an issue related to the dq flags, it was suggested to instead do a multiclass of `np.uint32` and `Enum` rather than `IntEnum` (which under the hood is a multiclass of `int` and `Enum`). This is so that we prevent any mistakes related to choosing invalid integers under `uint32`. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
