### PR TITLE
RCAL-911 & 932: remove units from MOS and ELP pipelines.

### DIFF
--- a/changes/405.removal.rst
+++ b/changes/405.removal.rst
@@ -1,0 +1,1 @@
+Remove units from roman_datamodels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,7 @@ dependencies = [
     "numpy >=1.22",
     "astropy >=5.3.0",
     # "rad >= 0.21.0",
-    # "rad @ git+https://github.com/spacetelescope/rad.git",
-    "rad @ git+https://github.com/mairanteodoro/rad.git@RCAL-932-remove-units-in-exposure-level-pipeline",
+    "rad @ git+https://github.com/spacetelescope/rad.git",
     "asdf-standard >=1.1.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,7 @@ name = "roman_datamodels"
 description = "data models supporting calibration of the Nancy Grace Roman Space Telescope"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [
-    { name = "STScI", email = "help@stsci.edu" },
-]
+authors = [{ name = "STScI", email = "help@stsci.edu" }]
 classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Astronomy",
@@ -18,13 +16,12 @@ dependencies = [
     "gwcs >=0.19.0",
     "numpy >=1.22",
     "astropy >=5.3.0",
-    "rad >= 0.21.0",
+    # "rad >= 0.21.0",
     # "rad @ git+https://github.com/spacetelescope/rad.git",
+    "rad @ git+https://github.com/mairanteodoro/rad.git@RCAL-932-remove-units-in-exposure-level-pipeline",
     "asdf-standard >=1.1.0",
 ]
-dynamic = [
-    "version",
-]
+dynamic = ["version"]
 
 [project.license]
 file = "LICENSE"
@@ -36,9 +33,7 @@ test = [
     "pytest-doctestplus >=0.10.0",
     "pytest-env >= 0.8",
 ]
-aws = [
-    "stsci-aws-utils >= 0.1.2",
-]
+aws = ["stsci-aws-utils >= 0.1.2"]
 docs = [
     "sphinx",
     "sphinx-automodapi",
@@ -55,20 +50,14 @@ repository = "https://github.com/spacetelescope/roman_datamodels"
 roman_datamodels = "roman_datamodels.stnode._integration:get_extensions"
 
 [build-system]
-requires = [
-    "setuptools >=61",
-    "setuptools_scm[toml] >=3.4",
-    "wheel",
-]
+requires = ["setuptools >=61", "setuptools_scm[toml] >=3.4", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/roman_datamodels/_version.py"
 
 [tool.setuptools.packages.find]
-where = [
-    "src",
-]
+where = ["src"]
 
 [tool.pytest.ini_options]
 minversion = 4.6
@@ -76,18 +65,13 @@ doctest_plus = true
 doctest_rst = true
 text_file_format = "rst"
 addopts = "--color=yes --doctest-rst"
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:numpy.ndarray size changed:RuntimeWarning",
     "ignore:The `hash` argument is deprecated in favor of `unsafe_hash` and will be removed in or after August 2025:DeprecationWarning",
 ]
-env = [
-    "ROMAN_VALIDATE=true",
-    "ROMAN_STRICT_VALIDATION=true",
-]
+env = ["ROMAN_VALIDATE=true", "ROMAN_STRICT_VALIDATION=true"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -151,7 +151,7 @@ def mk_sky_background(**kwargs):
     roman_datamodels.stnode.SkyBackground
     """
     sb = stnode.SkyBackground()
-    sb["level"] = kwargs.get("level", NONUM * (u.MJy / u.sr))
+    sb["level"] = kwargs.get("level", NONUM)
     sb["method"] = kwargs.get("method", "None")
     sb["subtracted"] = kwargs.get("subtracted", False)
 

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -54,14 +54,14 @@ def mk_level1_science_raw(*, shape=(8, 4096, 4096), dq=False, filepath=None, **k
 
     n_groups = shape[0]
 
-    wfi_science_raw["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16))
+    wfi_science_raw["data"] = kwargs.get("data", np.zeros(shape, dtype=np.uint16))
 
     if dq:
         wfi_science_raw["resultantdq"] = kwargs.get("resultantdq", np.zeros(shape, dtype=np.uint8))
 
     # add amp 33 ref pix
     wfi_science_raw["amp33"] = kwargs.get(
-        "amp33", u.Quantity(np.zeros((n_groups, 4096, 128), dtype=np.uint16), u.DN, dtype=np.uint16)
+        "amp33", np.zeros((n_groups, 4096, 128), dtype=np.uint16)
     )
 
     return save_node(wfi_science_raw, filepath=filepath)
@@ -262,16 +262,16 @@ def mk_ramp(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
 
     # add border reference pixel arrays
     ramp["border_ref_pix_left"] = kwargs.get(
-        "border_ref_pix_left", u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32), u.DN, dtype=np.float32)
+        "border_ref_pix_left", np.zeros((shape[0], shape[1], 4), dtype=np.float32)
     )
     ramp["border_ref_pix_right"] = kwargs.get(
-        "border_ref_pix_right", u.Quantity(np.zeros((shape[0], shape[1], 4), dtype=np.float32), u.DN, dtype=np.float32)
+        "border_ref_pix_right", np.zeros((shape[0], shape[1], 4), dtype=np.float32)
     )
     ramp["border_ref_pix_top"] = kwargs.get(
-        "border_ref_pix_top", u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32), u.DN, dtype=np.float32)
+        "border_ref_pix_top", np.zeros((shape[0], 4, shape[2]), dtype=np.float32)
     )
     ramp["border_ref_pix_bottom"] = kwargs.get(
-        "border_ref_pix_bottom", u.Quantity(np.zeros((shape[0], 4, shape[2]), dtype=np.float32), u.DN, dtype=np.float32)
+        "border_ref_pix_bottom", np.zeros((shape[0], 4, shape[2]), dtype=np.float32)
     )
 
     # and their dq arrays
@@ -281,12 +281,12 @@ def mk_ramp(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     ramp["dq_border_ref_pix_bottom"] = kwargs.get("dq_border_ref_pix_bottom", np.zeros((4, shape[2]), dtype=np.uint32))
 
     # add amp 33 ref pixel array
-    ramp["amp33"] = kwargs.get("amp33", u.Quantity(np.zeros((shape[0], shape[1], 128), dtype=np.uint16), u.DN, dtype=np.uint16))
+    ramp["amp33"] = kwargs.get("amp33", np.zeros((shape[0], shape[1], 128), dtype=np.uint16))
 
-    ramp["data"] = kwargs.get("data", u.Quantity(np.full(shape, 1.0, dtype=np.float32), u.DN, dtype=np.float32))
+    ramp["data"] = kwargs.get("data", np.full(shape, 1.0, dtype=np.float32))
     ramp["pixeldq"] = kwargs.get("pixeldq", np.zeros(shape[1:], dtype=np.uint32))
     ramp["groupdq"] = kwargs.get("groupdq", np.zeros(shape, dtype=np.uint8))
-    ramp["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
+    ramp["err"] = kwargs.get("err", np.zeros(shape, dtype=np.float32))
 
     return save_node(ramp, filepath=filepath)
 
@@ -316,23 +316,23 @@ def mk_ramp_fit_output(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     rampfitoutput["meta"] = mk_common_meta(**kwargs.get("meta", {}))
 
     rampfitoutput["slope"] = kwargs.get(
-        "slope", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32)
+        "slope", np.zeros(shape, dtype=np.float32)
     )
     rampfitoutput["sigslope"] = kwargs.get(
-        "sigslope", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.s, dtype=np.float32)
+        "sigslope", np.zeros(shape, dtype=np.float32)
     )
-    rampfitoutput["yint"] = kwargs.get("yint", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron, dtype=np.float32))
-    rampfitoutput["sigyint"] = kwargs.get("sigyint", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron, dtype=np.float32))
+    rampfitoutput["yint"] = kwargs.get("yint", np.zeros(shape, dtype=np.float32)
+    rampfitoutput["sigyint"] = kwargs.get("sigyint", np.zeros(shape, dtype=np.float32))
     rampfitoutput["pedestal"] = kwargs.get(
-        "pedestal", u.Quantity(np.zeros(shape[1:], dtype=np.float32), u.electron, dtype=np.float32)
+        "pedestal", np.zeros(shape[1:], dtype=np.float32)
     )
     rampfitoutput["weights"] = kwargs.get("weights", np.zeros(shape, dtype=np.float32))
-    rampfitoutput["crmag"] = kwargs.get("crmag", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron, dtype=np.float32))
+    rampfitoutput["crmag"] = kwargs.get("crmag", np.zeros(shape, dtype=np.float32))
     rampfitoutput["var_poisson"] = kwargs.get(
-        "var_poisson", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
+        "var_poisson", np.zeros(shape, dtype=np.float32))
     )
     rampfitoutput["var_rnoise"] = kwargs.get(
-        "var_rnoise", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron**2 / u.s**2, dtype=np.float32)
+        "var_rnoise", np.zeros(shape, dtype=np.float32)
     )
 
     return save_node(rampfitoutput, filepath=filepath)

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -321,7 +321,7 @@ def mk_ramp_fit_output(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     rampfitoutput["sigslope"] = kwargs.get(
         "sigslope", np.zeros(shape, dtype=np.float32)
     )
-    rampfitoutput["yint"] = kwargs.get("yint", np.zeros(shape, dtype=np.float32)
+    rampfitoutput["yint"] = kwargs.get("yint", np.zeros(shape, dtype=np.float32))
     rampfitoutput["sigyint"] = kwargs.get("sigyint", np.zeros(shape, dtype=np.float32))
     rampfitoutput["pedestal"] = kwargs.get(
         "pedestal", np.zeros(shape[1:], dtype=np.float32)
@@ -329,7 +329,7 @@ def mk_ramp_fit_output(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     rampfitoutput["weights"] = kwargs.get("weights", np.zeros(shape, dtype=np.float32))
     rampfitoutput["crmag"] = kwargs.get("crmag", np.zeros(shape, dtype=np.float32))
     rampfitoutput["var_poisson"] = kwargs.get(
-        "var_poisson", np.zeros(shape, dtype=np.float32))
+        "var_poisson", np.zeros(shape, dtype=np.float32)
     )
     rampfitoutput["var_rnoise"] = kwargs.get(
         "var_rnoise", np.zeros(shape, dtype=np.float32)

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -111,16 +111,16 @@ def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
 
     # add border reference pixel arrays
     wfi_image["border_ref_pix_left"] = kwargs.get(
-        "border_ref_pix_left", u.Quantity(np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32), u.DN, dtype=np.float32)
+        "border_ref_pix_left", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32)
     )
     wfi_image["border_ref_pix_right"] = kwargs.get(
-        "border_ref_pix_right", u.Quantity(np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32), u.DN, dtype=np.float32)
+        "border_ref_pix_right", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32)
     )
     wfi_image["border_ref_pix_top"] = kwargs.get(
-        "border_ref_pix_top", u.Quantity(np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32), u.DN, dtype=np.float32)
+        "border_ref_pix_top", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32)
     )
     wfi_image["border_ref_pix_bottom"] = kwargs.get(
-        "border_ref_pix_bottom", u.Quantity(np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32), u.DN, dtype=np.float32)
+        "border_ref_pix_bottom", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32)
     )
 
     # and their dq arrays
@@ -131,19 +131,19 @@ def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
 
     # add amp 33 ref pixel array
     amp33_size = (n_groups, 4096, 128)
-    wfi_image["amp33"] = kwargs.get("amp33", u.Quantity(np.zeros(amp33_size, dtype=np.uint16), u.DN, dtype=np.uint16))
-    wfi_image["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN / u.s, dtype=np.float32))
+    wfi_image["amp33"] = kwargs.get("amp33", np.zeros(amp33_size, dtype=np.uint16))
+    wfi_image["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
     wfi_image["dq"] = kwargs.get("dq", np.zeros(shape, dtype=np.uint32))
-    wfi_image["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN / u.s, dtype=np.float32))
+    wfi_image["err"] = kwargs.get("err", np.zeros(shape, dtype=np.float32))
 
     wfi_image["var_poisson"] = kwargs.get(
-        "var_poisson", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32)
+        "var_poisson", np.zeros(shape, dtype=np.float32)
     )
     wfi_image["var_rnoise"] = kwargs.get(
-        "var_rnoise", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32)
+        "var_rnoise", np.zeros(shape, dtype=np.float32)
     )
     wfi_image["var_flat"] = kwargs.get(
-        "var_flat", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32)
+        "var_flat", np.zeros(shape, dtype=np.float32)
     )
     wfi_image["cal_logs"] = mk_cal_logs(**kwargs)
 

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -185,20 +185,14 @@ def mk_level3_mosaic(*, shape=(4088, 4088), n_images=2, filepath=None, **kwargs)
 
     wfi_mosaic = stnode.WfiMosaic()
     wfi_mosaic["meta"] = mk_mosaic_meta(**kwargs.get("meta", {}))
-    wfi_mosaic["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.MJy / u.sr, dtype=np.float32))
-    wfi_mosaic["err"] = kwargs.get("err", u.Quantity(np.zeros(shape, dtype=np.float32), u.MJy / u.sr, dtype=np.float32))
+    wfi_mosaic["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
+    wfi_mosaic["err"] = kwargs.get("err", np.zeros(shape, dtype=np.float32))
     wfi_mosaic["context"] = kwargs.get("context", np.zeros((n_images,) + shape, dtype=np.uint32))
     wfi_mosaic["weight"] = kwargs.get("weight", np.zeros(shape, dtype=np.float32))
 
-    wfi_mosaic["var_poisson"] = kwargs.get(
-        "var_poisson", u.Quantity(np.zeros(shape, dtype=np.float32), u.MJy**2 / u.sr**2, dtype=np.float32)
-    )
-    wfi_mosaic["var_rnoise"] = kwargs.get(
-        "var_rnoise", u.Quantity(np.zeros(shape, dtype=np.float32), u.MJy**2 / u.sr**2, dtype=np.float32)
-    )
-    wfi_mosaic["var_flat"] = kwargs.get(
-        "var_flat", u.Quantity(np.zeros(shape, dtype=np.float32), u.MJy**2 / u.sr**2, dtype=np.float32)
-    )
+    wfi_mosaic["var_poisson"] = kwargs.get("var_poisson", np.zeros(shape, dtype=np.float32))
+    wfi_mosaic["var_rnoise"] = kwargs.get("var_rnoise", np.zeros(shape, dtype=np.float32))
+    wfi_mosaic["var_flat"] = kwargs.get("var_flat", np.zeros(shape, dtype=np.float32))
     wfi_mosaic["cal_logs"] = mk_cal_logs(**kwargs)
 
     wfi_mosaic["meta"]["wcs"] = mk_wcs()

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -60,9 +60,7 @@ def mk_level1_science_raw(*, shape=(8, 4096, 4096), dq=False, filepath=None, **k
         wfi_science_raw["resultantdq"] = kwargs.get("resultantdq", np.zeros(shape, dtype=np.uint8))
 
     # add amp 33 ref pix
-    wfi_science_raw["amp33"] = kwargs.get(
-        "amp33", np.zeros((n_groups, 4096, 128), dtype=np.uint16)
-    )
+    wfi_science_raw["amp33"] = kwargs.get("amp33", np.zeros((n_groups, 4096, 128), dtype=np.uint16))
 
     return save_node(wfi_science_raw, filepath=filepath)
 
@@ -110,15 +108,11 @@ def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
     wfi_image["meta"] = mk_photometry_meta(**kwargs.get("meta", {}))
 
     # add border reference pixel arrays
-    wfi_image["border_ref_pix_left"] = kwargs.get(
-        "border_ref_pix_left", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32)
-    )
+    wfi_image["border_ref_pix_left"] = kwargs.get("border_ref_pix_left", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32))
     wfi_image["border_ref_pix_right"] = kwargs.get(
         "border_ref_pix_right", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32)
     )
-    wfi_image["border_ref_pix_top"] = kwargs.get(
-        "border_ref_pix_top", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32)
-    )
+    wfi_image["border_ref_pix_top"] = kwargs.get("border_ref_pix_top", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32))
     wfi_image["border_ref_pix_bottom"] = kwargs.get(
         "border_ref_pix_bottom", np.zeros((n_groups, shape[0] + 8, 4), dtype=np.float32)
     )
@@ -136,15 +130,9 @@ def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
     wfi_image["dq"] = kwargs.get("dq", np.zeros(shape, dtype=np.uint32))
     wfi_image["err"] = kwargs.get("err", np.zeros(shape, dtype=np.float32))
 
-    wfi_image["var_poisson"] = kwargs.get(
-        "var_poisson", np.zeros(shape, dtype=np.float32)
-    )
-    wfi_image["var_rnoise"] = kwargs.get(
-        "var_rnoise", np.zeros(shape, dtype=np.float32)
-    )
-    wfi_image["var_flat"] = kwargs.get(
-        "var_flat", np.zeros(shape, dtype=np.float32)
-    )
+    wfi_image["var_poisson"] = kwargs.get("var_poisson", np.zeros(shape, dtype=np.float32))
+    wfi_image["var_rnoise"] = kwargs.get("var_rnoise", np.zeros(shape, dtype=np.float32))
+    wfi_image["var_flat"] = kwargs.get("var_flat", np.zeros(shape, dtype=np.float32))
     wfi_image["cal_logs"] = mk_cal_logs(**kwargs)
 
     wfi_image["meta"]["wcs"] = mk_wcs()
@@ -261,18 +249,10 @@ def mk_ramp(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     ramp["meta"] = mk_common_meta(**kwargs.get("meta", {}))
 
     # add border reference pixel arrays
-    ramp["border_ref_pix_left"] = kwargs.get(
-        "border_ref_pix_left", np.zeros((shape[0], shape[1], 4), dtype=np.float32)
-    )
-    ramp["border_ref_pix_right"] = kwargs.get(
-        "border_ref_pix_right", np.zeros((shape[0], shape[1], 4), dtype=np.float32)
-    )
-    ramp["border_ref_pix_top"] = kwargs.get(
-        "border_ref_pix_top", np.zeros((shape[0], 4, shape[2]), dtype=np.float32)
-    )
-    ramp["border_ref_pix_bottom"] = kwargs.get(
-        "border_ref_pix_bottom", np.zeros((shape[0], 4, shape[2]), dtype=np.float32)
-    )
+    ramp["border_ref_pix_left"] = kwargs.get("border_ref_pix_left", np.zeros((shape[0], shape[1], 4), dtype=np.float32))
+    ramp["border_ref_pix_right"] = kwargs.get("border_ref_pix_right", np.zeros((shape[0], shape[1], 4), dtype=np.float32))
+    ramp["border_ref_pix_top"] = kwargs.get("border_ref_pix_top", np.zeros((shape[0], 4, shape[2]), dtype=np.float32))
+    ramp["border_ref_pix_bottom"] = kwargs.get("border_ref_pix_bottom", np.zeros((shape[0], 4, shape[2]), dtype=np.float32))
 
     # and their dq arrays
     ramp["dq_border_ref_pix_left"] = kwargs.get("dq_border_ref_pix_left", np.zeros((shape[1], 4), dtype=np.uint32))
@@ -315,25 +295,15 @@ def mk_ramp_fit_output(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     rampfitoutput = stnode.RampFitOutput()
     rampfitoutput["meta"] = mk_common_meta(**kwargs.get("meta", {}))
 
-    rampfitoutput["slope"] = kwargs.get(
-        "slope", np.zeros(shape, dtype=np.float32)
-    )
-    rampfitoutput["sigslope"] = kwargs.get(
-        "sigslope", np.zeros(shape, dtype=np.float32)
-    )
+    rampfitoutput["slope"] = kwargs.get("slope", np.zeros(shape, dtype=np.float32))
+    rampfitoutput["sigslope"] = kwargs.get("sigslope", np.zeros(shape, dtype=np.float32))
     rampfitoutput["yint"] = kwargs.get("yint", np.zeros(shape, dtype=np.float32))
     rampfitoutput["sigyint"] = kwargs.get("sigyint", np.zeros(shape, dtype=np.float32))
-    rampfitoutput["pedestal"] = kwargs.get(
-        "pedestal", np.zeros(shape[1:], dtype=np.float32)
-    )
+    rampfitoutput["pedestal"] = kwargs.get("pedestal", np.zeros(shape[1:], dtype=np.float32))
     rampfitoutput["weights"] = kwargs.get("weights", np.zeros(shape, dtype=np.float32))
     rampfitoutput["crmag"] = kwargs.get("crmag", np.zeros(shape, dtype=np.float32))
-    rampfitoutput["var_poisson"] = kwargs.get(
-        "var_poisson", np.zeros(shape, dtype=np.float32)
-    )
-    rampfitoutput["var_rnoise"] = kwargs.get(
-        "var_rnoise", np.zeros(shape, dtype=np.float32)
-    )
+    rampfitoutput["var_poisson"] = kwargs.get("var_poisson", np.zeros(shape, dtype=np.float32))
+    rampfitoutput["var_rnoise"] = kwargs.get("var_rnoise", np.zeros(shape, dtype=np.float32))
 
     return save_node(rampfitoutput, filepath=filepath)
 

--- a/src/roman_datamodels/maker_utils/_tagged_nodes.py
+++ b/src/roman_datamodels/maker_utils/_tagged_nodes.py
@@ -1,5 +1,3 @@
-from astropy import units as u
-
 from roman_datamodels import stnode
 
 from ._base import NONUM
@@ -15,12 +13,12 @@ def mk_photometry(**kwargs):
     roman_datamodels.stnode.Photometry
     """
     phot = stnode.Photometry()
-    phot["conversion_microjanskys"] = kwargs.get("conversion_microjanskys", NONUM * u.uJy / u.arcsec**2)
-    phot["conversion_megajanskys"] = kwargs.get("conversion_megajanskys", NONUM * u.MJy / u.sr)
-    phot["pixelarea_steradians"] = kwargs.get("pixelarea_steradians", NONUM * u.sr)
-    phot["pixelarea_arcsecsq"] = kwargs.get("pixelarea_arcsecsq", NONUM * u.arcsec**2)
-    phot["conversion_microjanskys_uncertainty"] = kwargs.get("conversion_microjanskys_uncertainty", NONUM * u.uJy / u.arcsec**2)
-    phot["conversion_megajanskys_uncertainty"] = kwargs.get("conversion_megajanskys_uncertainty", NONUM * u.MJy / u.sr)
+    phot["conversion_microjanskys"] = kwargs.get("conversion_microjanskys", float(NONUM))
+    phot["conversion_megajanskys"] = kwargs.get("conversion_megajanskys", float(NONUM))
+    phot["pixelarea_steradians"] = kwargs.get("pixelarea_steradians", float(NONUM))
+    phot["pixelarea_arcsecsq"] = kwargs.get("pixelarea_arcsecsq", float(NONUM))
+    phot["conversion_microjanskys_uncertainty"] = kwargs.get("conversion_microjanskys_uncertainty", float(NONUM))
+    phot["conversion_megajanskys_uncertainty"] = kwargs.get("conversion_megajanskys_uncertainty", float(NONUM))
 
     return phot
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -683,16 +683,12 @@ def test_make_level3_mosaic():
     wfi_mosaic = utils.mk_level3_mosaic(shape=(8, 8))
 
     assert wfi_mosaic.data.dtype == np.float32
-    assert wfi_mosaic.data.unit == u.MJy / u.sr
 
     assert wfi_mosaic.err.dtype == np.float32
-    assert wfi_mosaic.err.unit == u.MJy / u.sr
     assert wfi_mosaic.context.dtype == np.uint32
     assert wfi_mosaic.weight.dtype == np.float32
     assert wfi_mosaic.var_poisson.dtype == np.float32
-    assert wfi_mosaic.var_poisson.unit == u.MJy**2 / u.sr**2
     assert wfi_mosaic.var_rnoise.dtype == np.float32
-    assert wfi_mosaic.var_rnoise.unit == u.MJy**2 / u.sr**2
     assert wfi_mosaic.var_flat.dtype == np.float32
     assert isinstance(wfi_mosaic.cal_logs[0], str)
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -56,7 +56,7 @@ def test_path_input(tmp_path):
 def test_model_input(tmp_path):
     file_path = tmp_path / "test.asdf"
 
-    data = u.Quantity(np.random.default_rng(42).uniform(size=(4, 4)).astype(np.float32), u.DN / u.s, dtype=np.float32)
+    data = np.random.default_rng(42).uniform(size=(4, 4)).astype(np.float32)
 
     with asdf.AsdfFile() as af:
         af.tree = {"roman": utils.mk_level2_image(shape=(8, 8))}
@@ -83,18 +83,14 @@ def test_invalid_input():
 
 
 def test_memmap(tmp_path):
-    data = u.Quantity(
-        np.zeros(
+    data = np.zeros(
             (
                 400,
                 400,
             ),
             dtype=np.float32,
-        ),
-        u.DN / u.s,
-        dtype=np.float32,
-    )
-    new_value = u.Quantity(1.0, u.DN / u.s, dtype=np.float32)
+        )
+    new_value = 1.0
     new_data = data.copy()
     new_data[6, 19] = new_value
 
@@ -136,18 +132,14 @@ def test_memmap(tmp_path):
     ],
 )
 def test_no_memmap(tmp_path, kwargs):
-    data = u.Quantity(
-        np.zeros(
+    data = np.zeros(
             (
                 400,
                 400,
             ),
             dtype=np.float32,
-        ),
-        u.DN / u.s,
-        dtype=np.float32,
-    )
-    new_value = u.Quantity(1.0, u.DN / u.s, dtype=np.float32)
+        )
+    new_value = 1.0
     new_data = data.copy()
     new_data[6, 19] = new_value
 


### PR DESCRIPTION
Resolves [RCAL-911](https://jira.stsci.edu/browse/RCAL-911)
Resolves [RCAL-932](https://jira.stsci.edu/browse/RCAL-932)

This PR modifies several files so that units are not used anymore. Additionally, the filename used in the regression tests was changed to remove the `ggsaa` component.

The information about units is still retained in the RAD schema.

## Tasks
- [X] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/405.general.rst``: Remove units from roman_datamodels.

</details>
