### PR TITLE
Fixes for reference file unit removal

### DIFF
--- a/changes/408.feature.rst
+++ b/changes/408.feature.rst
@@ -1,0 +1,1 @@
+Remove units from reference files.

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -693,9 +693,6 @@ def mk_ref_distoriton_meta(**kwargs):
     """
     meta = mk_ref_common("DISTORTION", **kwargs)
 
-    meta["input_units"] = kwargs.get("input_units", u.pixel)
-    meta["output_units"] = kwargs.get("output_units", u.arcsec)
-
     return meta
 
 
@@ -704,8 +701,8 @@ def _mk_ref_photometry_meta(**kwargs):
     Create the photometry meta data for pixelarea reference files
     """
     meta = {}
-    meta["pixelarea_steradians"] = kwargs.get("pixelarea_steradians", float(NONUM) * u.sr)
-    meta["pixelarea_arcsecsq"] = kwargs.get("pixelarea_arcsecsq", float(NONUM) * u.arcsec**2)
+    meta["pixelarea_steradians"] = kwargs.get("pixelarea_steradians", float(NONUM))
+    meta["pixelarea_arcsecsq"] = kwargs.get("pixelarea_arcsecsq", float(NONUM))
 
     return meta
 
@@ -733,9 +730,6 @@ def mk_ref_units_dn_meta(reftype_, **kwargs):
     dict (follows reference_file/ref_common-1.0.0 schema + DN input/output metadata)
     """
     meta = mk_ref_common(reftype_, **kwargs)
-
-    meta["input_units"] = kwargs.get("input_units", u.DN)
-    meta["output_units"] = kwargs.get("output_units", u.DN)
 
     return meta
 

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -1,7 +1,6 @@
 import warnings
 
 import numpy as np
-from astropy import units as u
 from astropy.modeling import models
 
 from roman_datamodels import stnode
@@ -197,14 +196,10 @@ def mk_dark(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     darkref = stnode.DarkRef()
     darkref["meta"] = mk_ref_dark_meta(**kwargs.get("meta", {}))
 
-    darkref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
+    darkref["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
     darkref["dq"] = kwargs.get("dq", np.zeros(shape[1:], dtype=np.uint32))
-    darkref["dark_slope"] = kwargs.get(
-        "dark_slope", u.Quantity(np.zeros(shape[1:], dtype=np.float32), u.DN / u.s, dtype=np.float32)
-    )
-    darkref["dark_slope_error"] = kwargs.get(
-        "dark_slope_error", u.Quantity(np.zeros(shape[1:], dtype=np.float32), u.DN / u.s, dtype=np.float32)
-    )
+    darkref["dark_slope"] = kwargs.get("dark_slope", np.zeros(shape[1:], dtype=np.float32))
+    darkref["dark_slope_error"] = kwargs.get("dark_slope_error", np.zeros(shape[1:], dtype=np.float32))
 
     return save_node(darkref, filepath=filepath)
 
@@ -291,7 +286,7 @@ def mk_gain(*, shape=(4096, 4096), filepath=None, **kwargs):
     gainref = stnode.GainRef()
     gainref["meta"] = mk_ref_common("GAIN", **kwargs.get("meta", {}))
 
-    gainref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.electron / u.DN, dtype=np.float32))
+    gainref["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
 
     return save_node(gainref, filepath=filepath)
 
@@ -464,11 +459,11 @@ def _mk_phot_table_entry(key, **kwargs):
         }
     else:
         entry = {
-            "photmjsr": kwargs.get("photmjsr", 1.0e-15 * u.megajansky / u.steradian),
-            "uncertainty": kwargs.get("uncertainty", 1.0e-16 * u.megajansky / u.steradian),
+            "photmjsr": kwargs.get("photmjsr", 1.0e-15),
+            "uncertainty": kwargs.get("uncertainty", 1.0e-16),
         }
 
-    entry["pixelareasr"] = kwargs.get("pixelareasr", 1.0e-13 * u.steradian)
+    entry["pixelareasr"] = kwargs.get("pixelareasr", 1.0e-13)
 
     return entry
 
@@ -528,7 +523,7 @@ def mk_readnoise(*, shape=(4096, 4096), filepath=None, **kwargs):
     readnoiseref = stnode.ReadnoiseRef()
     readnoiseref["meta"] = mk_ref_readnoise_meta(**kwargs.get("meta", {}))
 
-    readnoiseref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
+    readnoiseref["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
 
     return save_node(readnoiseref, filepath=filepath)
 
@@ -560,7 +555,7 @@ def mk_saturation(*, shape=(4096, 4096), filepath=None, **kwargs):
     saturationref["meta"] = mk_ref_common("SATURATION", **kwargs.get("meta", {}))
 
     saturationref["dq"] = kwargs.get("dq", np.zeros(shape, dtype=np.uint32))
-    saturationref["data"] = kwargs.get("data", u.Quantity(np.zeros(shape, dtype=np.float32), u.DN, dtype=np.float32))
+    saturationref["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
 
     return save_node(saturationref, filepath=filepath)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -406,9 +406,7 @@ def test_make_dark():
     assert dark.data.dtype == np.float32
     assert dark.dq.dtype == np.uint32
     assert dark.dq.shape == (8, 8)
-    assert dark.data.unit == u.DN
     assert dark.dark_slope.dtype == np.float32
-    assert dark.dark_slope.unit == u.DN / u.s
     assert dark.dark_slope_error.dtype == np.float32
     assert dark.dark_slope_error.shape == (8, 8)
 
@@ -421,8 +419,6 @@ def test_make_dark():
 def test_make_distortion():
     distortion = utils.mk_distortion()
     assert distortion.meta.reftype == "DISTORTION"
-    assert distortion["meta"]["input_units"] == u.pixel
-    assert distortion["meta"]["output_units"] == u.arcsec
     assert isinstance(distortion["coordinate_distortion_transform"], Model)
 
     # Test validation
@@ -449,7 +445,6 @@ def test_make_gain():
     gain = utils.mk_gain(shape=(8, 8))
     assert gain.meta.reftype == "GAIN"
     assert gain.data.dtype == np.float32
-    assert gain.data.unit == u.electron / u.DN
 
     # Test validation
     gain_model = datamodels.GainRefModel(gain)
@@ -508,8 +503,6 @@ def test_make_mask():
 def test_make_pixelarea():
     pixearea = utils.mk_pixelarea(shape=(8, 8))
     assert pixearea.meta.reftype == "AREA"
-    assert isinstance(pixearea.meta.photometry.pixelarea_steradians, u.Quantity)
-    assert isinstance(pixearea.meta.photometry.pixelarea_arcsecsq, u.Quantity)
     assert pixearea.data.dtype == np.float32
 
     # Test validation
@@ -522,7 +515,6 @@ def test_make_readnoise():
     readnoise = utils.mk_readnoise(shape=(8, 8))
     assert readnoise.meta.reftype == "READNOISE"
     assert readnoise.data.dtype == np.float32
-    assert readnoise.data.unit == u.DN
 
     # Test validation
     readnoise_model = datamodels.ReadnoiseRefModel(readnoise)
@@ -569,7 +561,6 @@ def test_make_saturation():
     assert saturation.meta.reftype == "SATURATION"
     assert saturation.dq.dtype == np.uint32
     assert saturation.data.dtype == np.float32
-    assert saturation.data.unit == u.DN
 
     # Test validation
     saturation_model = datamodels.SaturationRefModel(saturation)
@@ -603,30 +594,15 @@ def test_make_refpix():
     assert refpix.zeta.shape == (8, 8)
     assert refpix.alpha.shape == (8, 8)
 
-    assert refpix.meta.input_units == u.DN
-    assert refpix.meta.output_units == u.DN
-
 
 # WFI Photom tests
 def test_make_wfi_img_photom():
     wfi_img_photom = utils.mk_wfi_img_photom()
 
     assert wfi_img_photom.meta.reftype == "PHOTOM"
-    assert isinstance(wfi_img_photom.phot_table.F146.photmjsr, u.Quantity)
-    assert wfi_img_photom.phot_table.F146.photmjsr.unit == u.megajansky / u.steradian
-    assert isinstance(wfi_img_photom.phot_table.F184.photmjsr, u.Quantity)
-
-    assert isinstance(wfi_img_photom.phot_table.F146.uncertainty, u.Quantity)
-    assert isinstance(wfi_img_photom.phot_table.F184.uncertainty, u.Quantity)
-    assert wfi_img_photom.phot_table.F184.uncertainty.unit == u.megajansky / u.steradian
-
-    assert isinstance(wfi_img_photom.phot_table.F184.pixelareasr, u.Quantity)
-    assert isinstance(wfi_img_photom.phot_table.F146.pixelareasr, u.Quantity)
-    assert wfi_img_photom.phot_table.GRISM.pixelareasr.unit == u.steradian
 
     assert wfi_img_photom.phot_table.PRISM.photmjsr is None
     assert wfi_img_photom.phot_table.PRISM.uncertainty is None
-    assert isinstance(wfi_img_photom.phot_table.PRISM.pixelareasr, u.Quantity)
 
     # Test validation
     wfi_img_photom_model = datamodels.WfiImgPhotomRefModel(wfi_img_photom)
@@ -753,7 +729,6 @@ def test_make_fps():
     fps = utils.mk_fps(shape=shape)
 
     assert fps.data.dtype == np.uint16
-    assert fps.data.unit == u.DN
 
     # Test validation
     fps_model = datamodels.FpsModel(fps)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -321,19 +321,6 @@ def test_make_guidewindow():
     assert guidewindow_model.validate() is None
 
 
-# Testing all reference file schemas
-@pytest.mark.parametrize("tag", [t for t in stnode.NODE_EXTENSIONS[0].tags if "/reference_files/" in t.tag_uri])
-def test_reference_file_model_base(tag):
-    schema = asdf.schema.load_schema(tag.schema_uris[0])
-    # Check that schema references common reference schema
-    allofs = schema["properties"]["meta"]["allOf"]
-    for item in allofs:
-        if item == EXPECTED_COMMON_REFERENCE:
-            break
-    else:
-        raise ValueError("Reference schema does not include ref_common")  # pragma: no cover
-
-
 # AB Vega Offset Correction tests
 def test_make_abvegaoffset():
     abvegaoffset = utils.mk_abvegaoffset()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR makes `roman_datamodels` compatible with the reference file unit removals in spacetelescope/rad#490.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
