### PR TITLE
RCAL-933 Update filename on open

### DIFF
--- a/changes/409.feature.rst
+++ b/changes/409.feature.rst
@@ -1,0 +1,3 @@
+Have datamodels update their ``meta.filename`` attribute match the filename of the
+file they were loaded from. This means users can rename files on disk, but when they
+open them in datamodels, the filename will be updated to match the new filename.

--- a/src/roman_datamodels/datamodels/__init__.py
+++ b/src/roman_datamodels/datamodels/__init__.py
@@ -2,4 +2,5 @@ from ._core import *  # noqa: F403
 from ._datamodels import *  # noqa: F403
 
 # rename rdm_open to open to match the current roman_datamodels API
+from ._utils import FilenameMismatchWarning  # noqa: F403, F401
 from ._utils import rdm_open as open  # noqa: F403, F401

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -221,8 +221,13 @@ class DataModel(abc.ABC):
         return output_path
 
     def open_asdf(self, init=None, **kwargs):
+        from ._utils import _open_path_like
+
         with validate.nuke_validation():
-            return asdf.open(init, **kwargs) if isinstance(init, str) else asdf.AsdfFile(init, **kwargs)
+            if isinstance(init, str):
+                return _open_path_like(init, **kwargs)
+
+            return asdf.AsdfFile(init, **kwargs)
 
     def to_asdf(self, init, *args, **kwargs):
         with validate.nuke_validation(), _temporary_update_filename(self, Path(init).name):

--- a/src/roman_datamodels/datamodels/_utils.py
+++ b/src/roman_datamodels/datamodels/_utils.py
@@ -4,6 +4,7 @@ This module contains the utility functions for the datamodels sub-package. Mainl
 """
 
 import warnings
+from collections.abc import Mapping
 from pathlib import Path
 
 import asdf
@@ -51,6 +52,7 @@ def _open_path_like(init, lazy_tree=True, **kwargs):
 
     if (
         "roman" in asdf_file
+        and isinstance(asdf_file["roman"], Mapping)  # Fix issue for Python 3.10
         and "meta" in asdf_file["roman"]
         and "filename" in asdf_file["roman"]["meta"]
         and asdf_file["roman"]["meta"]["filename"] != init.name

--- a/src/roman_datamodels/datamodels/_utils.py
+++ b/src/roman_datamodels/datamodels/_utils.py
@@ -3,6 +3,7 @@ This module contains the utility functions for the datamodels sub-package. Mainl
     the open/factory function for creating datamodels
 """
 
+import warnings
 from pathlib import Path
 
 import asdf
@@ -11,7 +12,14 @@ from roman_datamodels import validate
 
 from ._core import MODEL_REGISTRY, DataModel
 
-__all__ = ["rdm_open"]
+__all__ = ["rdm_open", "FilenameMismatchWarning"]
+
+
+class FilenameMismatchWarning(UserWarning):
+    """
+    Warning when the filename in the meta attribute does not match the filename
+    of the file being opened.
+    """
 
 
 def _open_path_like(init, lazy_tree=True, **kwargs):
@@ -34,11 +42,24 @@ def _open_path_like(init, lazy_tree=True, **kwargs):
     # asdf defaults to lazy_tree=False, this overwrites it to
     # lazy_tree=True for roman_datamodels
     kwargs["lazy_tree"] = lazy_tree
+    init = Path(init)
 
     try:
         asdf_file = asdf.open(init, **kwargs)
     except ValueError as err:
         raise TypeError("Open requires a filepath, file-like object, or Roman datamodel") from err
+
+    if (
+        "roman" in asdf_file
+        and "meta" in asdf_file["roman"]
+        and "filename" in asdf_file["roman"]["meta"]
+        and asdf_file["roman"]["meta"]["filename"] != init.name
+    ):
+        warnings.warn(
+            f"meta.filename: {asdf_file['roman']['meta']['filename']} does not match filename: {init.name}, updating the filename in memory!",
+            FilenameMismatchWarning,
+        )
+        asdf_file["roman"]["meta"]["filename"] = init.name
 
     return asdf_file
 

--- a/src/roman_datamodels/maker_utils/_base.py
+++ b/src/roman_datamodels/maker_utils/_base.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import asdf
 
 NONUM = -999999
@@ -20,6 +22,11 @@ def save_node(node, filepath=None):
     """
 
     if filepath:
+        # Force sync filename with file path if we are saving to a file
+        if "meta" in node and "filename" in node["meta"]:
+            # Need the __class__ to avoid issues for tvac and fps
+            node["meta"]["filename"] = node["meta"]["filename"].__class__(Path(filepath).name)
+
         af = asdf.AsdfFile()
         af.tree = {"roman": node}
         af.write_to(filepath)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -181,7 +181,8 @@ def test_core_schema(tmp_path):
         with datamodels.open(file_path) as model:
             pass
     asdf.get_config().validate_on_read = False
-    with datamodels.open(file_path) as model:
+    # Filename mismatch warning, because did not save through datamodel to_asdf method
+    with pytest.warns(datamodels.FilenameMismatchWarning), datamodels.open(file_path) as model:
         assert model.meta.telescope == "XOMAN"
     asdf.get_config().validate_on_read = True
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-933][(https://jira.stsci.edu/browse/RCAL-933)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #spacetelescope/romancal#1443

<!-- describe the changes comprising this PR here -->
This PR makes datamodels open with the `meta.filename` matching their filename on disk. This only works when opening via the `rdm.open` not `asdf.open`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
