### PR TITLE
RCAL-769: Change Mosaic Association Model Name

### DIFF
--- a/changes/412.bugfix.rst
+++ b/changes/412.bugfix.rst
@@ -1,0 +1,1 @@
+Renamed mosaic association model variable name.

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -498,11 +498,11 @@ def mk_mosaic_associations(**kwargs):
     roman_datamodels.stnode.MosaicAssociations
     """
 
-    mosass = stnode.MosaicAssociations()
-    mosass["pool_name"] = kwargs.get("pool_name", NOSTR)
-    mosass["table_name"] = kwargs.get("table_name", NOSTR)
+    mosasn = stnode.MosaicAssociations()
+    mosasn["pool_name"] = kwargs.get("pool_name", NOSTR)
+    mosasn["table_name"] = kwargs.get("table_name", NOSTR)
 
-    return mosass
+    return mosasn
 
 
 def mk_guidewindow_meta(**kwargs):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-769](https://jira.stsci.edu/browse/RCAL-769)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #310 

<!-- describe the changes comprising this PR here -->
This PR changes the mosaic association model variable name.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
