### PR TITLE
Remove units from guidewindow

### DIFF
--- a/changes/415.removal.rst
+++ b/changes/415.removal.rst
@@ -1,0 +1,1 @@
+Remove units from Guidewindow related data models.

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -1,7 +1,6 @@
 import warnings
 
 import numpy as np
-from astropy import units as u
 from astropy.table import Table
 
 from roman_datamodels import stnode
@@ -399,13 +398,9 @@ def mk_guidewindow(*, shape=(2, 8, 16, 32, 32), filepath=None, **kwargs):
     guidewindow = stnode.Guidewindow()
     guidewindow["meta"] = mk_guidewindow_meta(**kwargs.get("meta", {}))
 
-    guidewindow["pedestal_frames"] = kwargs.get(
-        "pedestal_frames", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
-    )
-    guidewindow["signal_frames"] = kwargs.get(
-        "signal_frames", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16)
-    )
-    guidewindow["amp33"] = kwargs.get("amp33", u.Quantity(np.zeros(shape, dtype=np.uint16), u.DN, dtype=np.uint16))
+    guidewindow["pedestal_frames"] = kwargs.get("pedestal_frames", np.zeros(shape, dtype=np.uint16))
+    guidewindow["signal_frames"] = kwargs.get("signal_frames", np.zeros(shape, dtype=np.uint16))
+    guidewindow["amp33"] = kwargs.get("amp33", np.zeros(shape, dtype=np.uint16))
 
     return save_node(guidewindow, filepath=filepath)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -311,11 +311,8 @@ def test_make_guidewindow():
 
     assert guidewindow.meta.exposure.type == "WFI_IMAGE"
     assert guidewindow.pedestal_frames.dtype == np.uint16
-    assert guidewindow.pedestal_frames.unit == u.DN
     assert guidewindow.signal_frames.dtype == np.uint16
-    assert guidewindow.signal_frames.unit == u.DN
     assert guidewindow.amp33.dtype == np.uint16
-    assert guidewindow.amp33.unit == u.DN
     assert guidewindow.pedestal_frames.shape == (2, 2, 2, 2, 2)
     assert guidewindow.signal_frames.shape == (2, 2, 2, 2, 2)
     assert guidewindow.amp33.shape == (2, 2, 2, 2, 2)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR updates `roman_datamodels` to support spacetelescope/rad#499.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
