### PR TITLE
Bugfix for enums in python 3.10

### DIFF
--- a/changes/425.bugfix.rst
+++ b/changes/425.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Enum bug in python < 3.11 for the dqflags.

--- a/src/roman_datamodels/dqflags.py
+++ b/src/roman_datamodels/dqflags.py
@@ -19,14 +19,24 @@ which provides 32 bits. Bits of an integer are most easily referred to using
 the formula `2**bit_number` where `bit_number` is the 0-index bit of interest.
 """
 
-from enum import Enum, unique
+import sys
+from enum import unique
 
-import numpy as np
+# Something with pickling of multiclassed enums was changed in 3.11 + allowing
+# us to directly us `np.uint32` as the enum object rather than a python `int`.
+if sys.version_info < (3, 11):
+    from enum import IntEnum
+else:
+    from enum import Enum
+
+    import numpy as np
+
+    class IntEnum(np.uint32, Enum): ...
 
 
 # fmt: off
 @unique
-class pixel(np.uint32, Enum):
+class pixel(IntEnum):
     """Pixel-specific data quality flags"""
 
     GOOD             = 0      # No bits set, all is good
@@ -64,7 +74,7 @@ class pixel(np.uint32, Enum):
 
 
 @unique
-class group(np.uint32, Enum):
+class group(IntEnum):
     """Group-specific data quality flags
         Once groups are combined, these flags are equivalent to the pixel-specific flags.
     """

--- a/tests/test_dqflags.py
+++ b/tests/test_dqflags.py
@@ -1,3 +1,4 @@
+import sys
 from math import log10
 
 import numpy as np
@@ -31,7 +32,10 @@ def test_pixel_flags(flag):
     assert isinstance(flag, dqflags.pixel)
 
     # Test that the pixel flags are ints
-    assert isinstance(flag, np.uint32)
+    if sys.version_info < (3, 11):
+        assert isinstance(flag, int)
+    else:
+        assert isinstance(flag, np.uint32)
 
     # Test that the pixel flags are dict accessible
     assert dqflags.pixel[flag.name] is flag
@@ -79,7 +83,10 @@ def test_group_flags(flag):
     assert isinstance(flag, dqflags.group)
 
     # Test that the group flags are ints
-    assert isinstance(flag, np.uint32)
+    if sys.version_info < (3, 11):
+        assert isinstance(flag, int)
+    else:
+        assert isinstance(flag, np.uint32)
 
     # Test that the group flags are dict accessible
     assert dqflags.group[flag.name] is flag


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #424

<!-- describe the changes comprising this PR here -->
This PR fixes and odd bug found for python 3.10 in `romancal`. See #424 for more details.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
