### PR TITLE
fix changelog for docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,7 +45,7 @@ New Features
 Misc
 ----
 
-- Use multiclass of `np.uint32` and `Enum` rather than a subclass of `IntEnum`
+- Use multiclass of ``np.uint32`` and ``Enum`` rather than a subclass of ``IntEnum``
   for
   the dqflags as suggested by the numpy devs. (`#402
   <https://github.com/spacetelescope/roman_datamodels/issues/402>`_)


### PR DESCRIPTION
This PR fixes the changelog so it can be added to the sphinx documentation without warnings (that turn into errors).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
