### PR TITLE
Rename source_detection to source_catalog

### DIFF
--- a/changes/428.feature.rst
+++ b/changes/428.feature.rst
@@ -1,0 +1,1 @@
+Rename source_detection to source_catalog to match romancal step.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
     "gwcs >=0.19.0",
     "numpy >=1.24",
     "astropy >=5.3.0",
-    "rad >=0.22.0, <0.23.0",
-    # "rad @ git+https://github.com/spacetelescope/rad.git",
+    # "rad >=0.22.0, <0.23.0",
+    "rad @ git+https://github.com/braingram/rad.git@source_catalog",
     "asdf-standard >=1.1.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy >=1.24",
     "astropy >=5.3.0",
     # "rad >=0.22.0, <0.23.0",
-    "rad @ git+https://github.com/braingram/rad.git@source_catalog",
+    "rad @ git+https://github.com/spacetelescope/rad.git",
     "asdf-standard >=1.1.0",
 ]
 dynamic = ["version"]

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -334,8 +334,8 @@ class MosaicSegmentationMapModel(_RomanDataModel):
     _node_type = stnode.MosaicSegmentationMap
 
 
-class SourceCatalogModel(_RomanDataModel):
-    _node_type = stnode.SourceCatalog
+class ImageSourceCatalogModel(_RomanDataModel):
+    _node_type = stnode.ImageSourceCatalog
 
 
 class SegmentationMapModel(_RomanDataModel):

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -10,7 +10,7 @@ from roman_datamodels import stnode
 
 from ._base import NONUM, NOSTR
 from ._basic_meta import mk_basic_meta
-from ._tagged_nodes import mk_cal_logs, mk_photometry, mk_resample, mk_source_detection
+from ._tagged_nodes import mk_cal_logs, mk_photometry, mk_resample, mk_source_catalog
 
 
 def mk_exposure(**kwargs):
@@ -301,7 +301,7 @@ def mk_l2_cal_step(**kwargs):
     l2calstep["linearity"] = kwargs.get("linearity", "INCOMPLETE")
     l2calstep["outlier_detection"] = kwargs.get("outlier_detection", "INCOMPLETE")
     l2calstep["photom"] = kwargs.get("photom", "INCOMPLETE")
-    l2calstep["source_detection"] = kwargs.get("source_detection", "INCOMPLETE")
+    l2calstep["source_catalog"] = kwargs.get("source_catalog", "INCOMPLETE")
     l2calstep["ramp_fit"] = kwargs.get("ramp_fit", "INCOMPLETE")
     l2calstep["refpix"] = kwargs.get("refpix", "INCOMPLETE")
     l2calstep["saturation"] = kwargs.get("saturation", "INCOMPLETE")
@@ -441,7 +441,7 @@ def mk_l2_meta(**kwargs):
     meta["photometry"] = mk_photometry(**kwargs.get("photometry", {}))
     meta["outlier_detection"] = mk_outlier_detection(**kwargs.get("outlier_detection", {}))
     meta["background"] = mk_sky_background(**kwargs.get("background", {}))
-    meta["source_detection"] = mk_source_detection(**kwargs.get("source_detection", {}))
+    meta["source_catalog"] = mk_source_catalog(**kwargs.get("source_catalog", {}))
     meta["cal_logs"] = mk_cal_logs(**kwargs)
 
     return meta
@@ -851,7 +851,7 @@ def mk_individual_image_meta(**kwargs):
     # imm["program"] = kwargs.get("program", QTable(table_dct))
     # imm["rcs"] = kwargs.get("rcs", QTable(table_dct))
     # imm["ref_file"] = kwargs.get("ref_file", QTable(table_dct))
-    # imm["source_detection"] = kwargs.get("source_detection", QTable(table_dct))
+    # imm["source_catalog"] = kwargs.get("source_catalog", QTable(table_dct))
     # imm["velocity_aberration"] = kwargs.get("velocity_aberration", QTable(table_dct))
     # imm["visit"] = kwargs.get("visit", QTable(table_dct))
     # imm["wcsinfo"] = kwargs.get("wcsinfo", QTable(table_dct))

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -423,7 +423,7 @@ def mk_mosaic_source_catalog(*, filepath=None, **kwargs):
 
     Returns
     -------
-    roman_datamodels.stnode.SourceCatalog
+    roman_datamodels.stnode.MosaicSourceCatalog
     """
     source_catalog = stnode.MosaicSourceCatalog()
 
@@ -466,7 +466,7 @@ def mk_mosaic_segmentation_map(*, filepath=None, shape=(4096, 4096), **kwargs):
     return save_node(segmentation_map, filepath=filepath)
 
 
-def mk_source_catalog(*, filepath=None, **kwargs):
+def mk_image_source_catalog(*, filepath=None, **kwargs):
     """
     Create a dummy Source Catalog instance (or file) with arrays and valid values
     for attributes required by the schema.
@@ -478,9 +478,9 @@ def mk_source_catalog(*, filepath=None, **kwargs):
 
     Returns
     -------
-    roman_datamodels.stnode.SourceCatalog
+    roman_datamodels.stnode.ImageSourceCatalog
     """
-    source_catalog = stnode.SourceCatalog()
+    source_catalog = stnode.ImageSourceCatalog()
 
     source_catalog["source_catalog"] = kwargs.get("source_catalog", Table([range(3), range(3)], names=["a", "b"]))
     source_catalog["meta"] = mk_catalog_meta(**kwargs.get("meta", {}))

--- a/src/roman_datamodels/maker_utils/_tagged_nodes.py
+++ b/src/roman_datamodels/maker_utils/_tagged_nodes.py
@@ -61,16 +61,16 @@ def mk_cal_logs(**kwargs):
     )
 
 
-def mk_source_detection(**kwargs):
+def mk_source_catalog(**kwargs):
     """
-    Create a dummy Source Detection instance with valid values for attributes
+    Create a dummy Source Catalog instance with valid values for attributes
     required by the schema. Utilized by the model maker utilities below.
 
     Returns
     -------
-    roman_datamodels.stnode.SourceDetection
+    roman_datamodels.stnode.SourceCatalog
     """
-    sd = stnode.SourceDetection()
+    sd = stnode.SourceCatalog()
     sd["tweakreg_catalog_name"] = kwargs.get("tweakreg_catalog_name", "catalog")
 
     return sd

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -778,9 +778,9 @@ def test_make_tvac():
     assert tvac_model.validate() is None
 
 
-def test_make_source_catalog():
-    source_catalog = utils.mk_source_catalog()
-    source_catalog_model = datamodels.SourceCatalogModel(source_catalog)
+def test_make_image_source_catalog():
+    source_catalog = utils.mk_image_source_catalog()
+    source_catalog_model = datamodels.ImageSourceCatalogModel(source_catalog)
 
     assert isinstance(source_catalog_model.source_catalog, Table)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,7 +26,7 @@ NODES_LACKING_ARCHIVE_CATALOG = [
     stnode.IndividualImageMeta,
     stnode.Resample,
     stnode.SkyBackground,
-    stnode.SourceDetection,
+    stnode.SourceCatalog,
 ]
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -211,7 +211,7 @@ def test_opening_model(tmp_path, node_class):
             assert model.asn_type == "image"
         elif node_class == stnode.WfiMosaic:
             assert model.meta.basic.optical_element == "F158"
-        elif node_class in (stnode.SegmentationMap, stnode.SourceCatalog):
+        elif node_class in (stnode.SegmentationMap, stnode.ImageSourceCatalog):
             assert model.meta.optical_element == "F158"
         elif node_class in (stnode.MosaicSegmentationMap, stnode.MosaicSourceCatalog):
             assert hasattr(model.meta, "basic")

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -289,7 +289,7 @@ def test_node_representation(model):
             assert mdl.meta.model_type == model_types[type(mdl)]
             assert mdl.meta.telescope == "ROMAN"
             assert mdl.meta.filename == NOFN
-        elif isinstance(mdl, datamodels.SegmentationMapModel | datamodels.SourceCatalogModel):
+        elif isinstance(mdl, datamodels.SegmentationMapModel | datamodels.ImageSourceCatalogModel):
             assert mdl.meta.optical_element == "F158"
         else:
             assert repr(mdl.meta.instrument) == repr(


### PR DESCRIPTION
This PR updates this package for the rad changes in https://github.com/spacetelescope/rad/pull/513

See https://github.com/spacetelescope/romancal/pull/1533 for more details.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
