### PR TITLE
Bump min Python to 3.11 per SPEC 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,14 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d68193b68216da64eafaa618f53c59f5d271c56e  # v1.14.0
     with:
       envs: |
-        - linux: py310-oldestdeps-cov
+        - linux: py311-oldestdeps-cov
           coverage: codecov
-        - linux: py310
         - linux: py311-cov
           coverage: codecov
         - linux: py312-withromancal-cov
           coverage: codecov
         - linux: py313
-        - macos: py311
+        - macos: py312
   test_upstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d68193b68216da64eafaa618f53c59f5d271c56e  # v1.14.0
     with:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -20,5 +20,5 @@ jobs:
     if: (github.repository == 'spacetelescope/roman_datamodels' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     with:
       envs: |
-        - macos: py310
-        - linux: py312-devdeps
+        - macos: py311
+        - linux: py313-devdeps

--- a/changes/432.misc.rst
+++ b/changes/432.misc.rst
@@ -1,0 +1,1 @@
+Bump min Python version to 3.11 per SPEC 0.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,16 +14,11 @@ import datetime
 import importlib
 import os
 import sys
+import tomllib
 from distutils.version import LooseVersion
 from pathlib import Path
 
 import sphinx
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
-
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "roman_datamodels"
 description = "data models supporting calibration of the Nancy Grace Roman Space Telescope"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [{ name = "STScI", email = "help@stsci.edu" }]
 classifiers = [
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ name = "roman_datamodels"
 description = "data models supporting calibration of the Nancy Grace Roman Space Telescope"
 readme = "README.md"
 requires-python = ">=3.11"
-authors = [{ name = "STScI", email = "help@stsci.edu" }]
+authors = [
+    { name = "STScI", email = "help@stsci.edu" },
+]
 classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Astronomy",
@@ -32,7 +34,6 @@ test = [
     "pytest-doctestplus >=1.2.1",
     "pytest-env >= 0.8",
 ]
-aws = ["stsci-aws-utils >= 0.1.2"]
 docs = [
     "sphinx",
     "sphinx-automodapi",
@@ -49,7 +50,10 @@ repository = "https://github.com/spacetelescope/roman_datamodels"
 roman_datamodels = "roman_datamodels.stnode._integration:get_extensions"
 
 [build-system]
-requires = ["setuptools >=61", "setuptools_scm[toml] >=3.4", "wheel"]
+requires = [
+    "setuptools >=61",
+    "setuptools_scm[toml] >=3.4",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ docs = [
     "sphinx-automodapi",
     "sphinx-rtd-theme",
     "sphinx-astropy",
-    "tomli; python_version <\"3.11\"",
 ]
 
 [project.urls]

--- a/src/roman_datamodels/dqflags.py
+++ b/src/roman_datamodels/dqflags.py
@@ -19,24 +19,16 @@ which provides 32 bits. Bits of an integer are most easily referred to using
 the formula `2**bit_number` where `bit_number` is the 0-index bit of interest.
 """
 
-import sys
-from enum import unique
-
 # Something with pickling of multiclassed enums was changed in 3.11 + allowing
 # us to directly us `np.uint32` as the enum object rather than a python `int`.
-if sys.version_info < (3, 11):
-    from enum import IntEnum
-else:
-    from enum import Enum
+from enum import Enum, unique
 
-    import numpy as np
-
-    class IntEnum(np.uint32, Enum): ...
+import numpy as np
 
 
 # fmt: off
 @unique
-class pixel(IntEnum):
+class pixel(np.uint32, Enum):
     """Pixel-specific data quality flags"""
 
     GOOD             = 0      # No bits set, all is good
@@ -74,7 +66,7 @@ class pixel(IntEnum):
 
 
 @unique
-class group(IntEnum):
+class group(np.uint32, Enum):
     """Group-specific data quality flags
         Once groups are combined, these flags are equivalent to the pixel-specific flags.
     """

--- a/tests/test_dqflags.py
+++ b/tests/test_dqflags.py
@@ -1,4 +1,3 @@
-import sys
 from math import log10
 
 import numpy as np
@@ -32,10 +31,7 @@ def test_pixel_flags(flag):
     assert isinstance(flag, dqflags.pixel)
 
     # Test that the pixel flags are ints
-    if sys.version_info < (3, 11):
-        assert isinstance(flag, int)
-    else:
-        assert isinstance(flag, np.uint32)
+    assert isinstance(flag, np.uint32)
 
     # Test that the pixel flags are dict accessible
     assert dqflags.pixel[flag.name] is flag
@@ -83,10 +79,7 @@ def test_group_flags(flag):
     assert isinstance(flag, dqflags.group)
 
     # Test that the group flags are ints
-    if sys.version_info < (3, 11):
-        assert isinstance(flag, int)
-    else:
-        assert isinstance(flag, np.uint32)
+    assert isinstance(flag, np.uint32)
 
     # Test that the group flags are dict accessible
     assert dqflags.group[flag.name] is flag


### PR DESCRIPTION
This PR bumps min python to 3.11 per [SPEC 0](https://scientific-python.org/specs/spec-0000/#support-window). `astropy` 7 has already made this bump.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
