### PR TITLE
Update and consolidate linting and other tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,12 +38,8 @@ repos:
   rev: 'v0.8.0'
   hooks:
     - id: ruff
-      args: ["--fix"]
-
-- repo: https://github.com/psf/black
-  rev: 24.10.0
-  hooks:
-    - id: black
+      args: ["--fix", "--show-fixes"]
+    - id: ruff-format
 
 - repo: https://github.com/twisted/towncrier
   rev: 24.8.0  # run 'pre-commit autoupdate' to update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     - id: check-yaml
       args: ["--unsafe"]
     - id: check-toml
+    - id: check-json
     - id: check-merge-conflict
     - id: check-symlinks
     - id: debug-statements
@@ -21,8 +22,6 @@ repos:
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0
   hooks:
-    - id: python-check-blanket-noqa
-    - id: python-check-mock-methods
     - id: rst-directive-colons
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
@@ -35,33 +34,16 @@ repos:
       additional_dependencies:
         - tomli
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: 'v3.19.0'
-  hooks:
-    - id: pyupgrade
-      args: ["--py38-plus"]
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: 'v0.8.0'
   hooks:
     - id: ruff
       args: ["--fix"]
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-    - id: isort
-
 - repo: https://github.com/psf/black
   rev: 24.10.0
   hooks:
     - id: black
-
-- repo: https://github.com/PyCQA/bandit
-  rev: 1.7.10
-  hooks:
-    - id: bandit
-      args: ["-r", "-ll"]
 
 - repo: https://github.com/twisted/towncrier
   rev: 24.8.0  # run 'pre-commit autoupdate' to update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,18 @@ write_to = "src/roman_datamodels/_version.py"
 where = ["src"]
 
 [tool.pytest.ini_options]
-minversion = 4.6
+minversion = 6
 doctest_plus = true
 doctest_rst = true
 text_file_format = "rst"
+log_cli_level = "INFO"
+xfail_strict = true
 addopts = [
-    "--color=yes",
-    "--doctest-rst",
+    "--color=yes",      # color test output
+    "--doctest-rst",    # enable doctests
+    "--strict-config",  # fail on unknown config options
+    "--strict-markers", # fail on unknown markers
+    "-ra",              # Show summary of all failures/errors
 ]
 testpaths = ["tests"]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,22 @@ force-exclude = "^/(\n  (\n      \\.eggs\n    | \\.git\n    | \\.pytest_cache\n 
 [tool.ruff]
 line-length = 130
 
+[tool.ruff.lint]
+extend-select = [
+    "UP",   # PyUpgrade
+    "I",    # isort
+    "S",    # Bandit
+    "RUF",  # ruff specific
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**.py" = [
+    "S101" # Bandit: Use of assert detected (fine in test files)
+]
+"src/roman_datamodels/testing.py" = [
+    "S101" # Bandit: Use of assert detected (useful public API for testing only)
+]
+
 [tool.codespell]
 skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ line-length = 130
 extend-select = [
     "UP",   # PyUpgrade
     "I",    # isort
+    "B",    # BugBear
     "S",    # Bandit
     "RUF",  # ruff specific
 ]

--- a/src/roman_datamodels/__init__.py
+++ b/src/roman_datamodels/__init__.py
@@ -2,4 +2,4 @@
 from ._version import version as __version__
 from .datamodels import DataModel, open
 
-__all__ = ["open", "DataModel", "__version__"]
+__all__ = ["DataModel", "__version__", "open"]

--- a/src/roman_datamodels/datamodels/__init__.py
+++ b/src/roman_datamodels/datamodels/__init__.py
@@ -2,5 +2,5 @@ from ._core import *  # noqa: F403
 from ._datamodels import *  # noqa: F403
 
 # rename rdm_open to open to match the current roman_datamodels API
-from ._utils import FilenameMismatchWarning  # noqa: F403, F401
-from ._utils import rdm_open as open  # noqa: F403, F401
+from ._utils import FilenameMismatchWarning  # noqa: F401
+from ._utils import rdm_open as open  # noqa: F401

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -24,7 +24,7 @@ from astropy.time import Time
 
 from roman_datamodels import stnode, validate
 
-__all__ = ["DataModel", "MODEL_REGISTRY"]
+__all__ = ["MODEL_REGISTRY", "DataModel"]
 
 MODEL_REGISTRY = {}
 
@@ -140,7 +140,7 @@ class DataModel(abc.ABC):
         if init is None:
             self._instance = self._node_type()
 
-        elif isinstance(init, (str, bytes, PurePath)):
+        elif isinstance(init, str | bytes | PurePath):
             if isinstance(init, PurePath):
                 init = str(init)
             if isinstance(init, bytes):
@@ -305,7 +305,7 @@ class DataModel(abc.ABC):
         return {
             f"roman.{key}": convert_val(val)
             for (key, val) in self.items()
-            if include_arrays or not isinstance(val, (np.ndarray, NDArrayType))
+            if include_arrays or not isinstance(val, np.ndarray | NDArrayType)
         }
 
     def items(self):
@@ -337,7 +337,7 @@ class DataModel(abc.ABC):
         return {
             f"roman.meta.{key}": val
             for key, val in self.meta.to_flat_dict(include_arrays=False, recursive=True).items()
-            if isinstance(val, (str, int, float, complex, bool))
+            if isinstance(val, str | int | float | complex | bool)
         }
 
     def validate(self):

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -62,7 +62,7 @@ class MosaicModel(_RomanDataModel):
         """
 
         # Convert input to a dictionary, if necessary
-        if not isinstance(meta, (dict, asdf.lazy_nodes.AsdfDictNode)):
+        if not isinstance(meta, dict | asdf.lazy_nodes.AsdfDictNode):
             meta_dict = meta.to_flat_dict()
         else:
             meta_dict = meta
@@ -79,7 +79,7 @@ class MosaicModel(_RomanDataModel):
 
             # Keys that are themselves Dnodes (subdirectories)
             # neccessitate a new table
-            if isinstance(value, (dict, asdf.tags.core.ndarray.NDArrayType, QTable, asdf.lazy_nodes.AsdfDictNode)):
+            if isinstance(value, dict | asdf.tags.core.ndarray.NDArrayType | QTable | asdf.lazy_nodes.AsdfDictNode):
                 continue
 
             if isinstance(value, stnode.DNode):
@@ -90,13 +90,13 @@ class MosaicModel(_RomanDataModel):
                 # Loop over items within the node
                 for subkey, subvalue in meta_dict[key].items():
                     # Skip ndarrays and QTables
-                    if isinstance(subvalue, (asdf.tags.core.ndarray.NDArrayType, QTable)):
+                    if isinstance(subvalue, asdf.tags.core.ndarray.NDArrayType | QTable):
                         continue
 
                     subtable_cols.append(subkey)
                     subtable_vals.append(
                         [str(subvalue)]
-                        if isinstance(subvalue, (list, dict, asdf.lazy_nodes.AsdfDictNode, asdf.lazy_nodes.AsdfListNode))
+                        if isinstance(subvalue, list | dict | asdf.lazy_nodes.AsdfDictNode | asdf.lazy_nodes.AsdfListNode)
                         else [subvalue]
                     )
 
@@ -113,7 +113,7 @@ class MosaicModel(_RomanDataModel):
             else:
                 # Store Basic keyword
                 basic_cols.append(key)
-                basic_vals.append([str(value)] if isinstance(value, (list, asdf.lazy_nodes.AsdfListNode)) else [value])
+                basic_vals.append([str(value)] if isinstance(value, list | asdf.lazy_nodes.AsdfListNode) else [value])
 
         # Make Basic Table if needed
         if self.meta.individual_image_meta.basic.colnames == ["dummy"]:

--- a/src/roman_datamodels/datamodels/_utils.py
+++ b/src/roman_datamodels/datamodels/_utils.py
@@ -60,6 +60,7 @@ def _open_path_like(init, lazy_tree=True, **kwargs):
         warnings.warn(
             f"meta.filename: {asdf_file['roman']['meta']['filename']} does not match filename: {init.name}, updating the filename in memory!",
             FilenameMismatchWarning,
+            stacklevel=2,
         )
         asdf_file["roman"]["meta"]["filename"] = init.name
 
@@ -92,8 +93,8 @@ def rdm_open(init, memmap=False, **kwargs):
                 from romancal.datamodels.library import ModelLibrary
 
                 return ModelLibrary(init)
-            except ImportError:
-                raise ImportError("Please install romancal to allow opening associations with roman_datamodels")
+            except ImportError as err:
+                raise ImportError("Please install romancal to allow opening associations with roman_datamodels") from err
     with validate.nuke_validation():
         if isinstance(init, DataModel):
             # Copy the object so it knows not to close here

--- a/src/roman_datamodels/datamodels/_utils.py
+++ b/src/roman_datamodels/datamodels/_utils.py
@@ -13,7 +13,7 @@ from roman_datamodels import validate
 
 from ._core import MODEL_REGISTRY, DataModel
 
-__all__ = ["rdm_open", "FilenameMismatchWarning"]
+__all__ = ["FilenameMismatchWarning", "rdm_open"]
 
 
 class FilenameMismatchWarning(UserWarning):

--- a/src/roman_datamodels/dqflags.py
+++ b/src/roman_datamodels/dqflags.py
@@ -1,4 +1,4 @@
-""" Roman Data Quality Flags
+"""Roman Data Quality Flags
 
 The definitions are documented in the Roman RTD:
 

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -47,7 +47,7 @@ def mk_level1_science_raw(*, shape=(8, 4096, 4096), dq=False, filepath=None, **k
     """
     if len(shape) != 3:
         shape = (8, 4096, 4096)
-        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)")
+        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)", UserWarning, stacklevel=2)
 
     wfi_science_raw = stnode.WfiScienceRaw()
     wfi_science_raw["meta"] = mk_common_meta(**kwargs.get("meta", {}))
@@ -100,7 +100,9 @@ def mk_level2_image(*, shape=(4088, 4088), n_groups=8, filepath=None, **kwargs):
         shape = shape[1:3]
 
         warnings.warn(
-            f"{MESSAGE} assuming the first entry is n_groups followed by y, x. The remaining is thrown out!", UserWarning
+            f"{MESSAGE} assuming the first entry is n_groups followed by y, x. The remaining is thrown out!",
+            UserWarning,
+            stacklevel=2,
         )
 
     wfi_image = stnode.WfiImage()
@@ -168,7 +170,9 @@ def mk_level3_mosaic(*, shape=(4088, 4088), n_images=2, filepath=None, **kwargs)
         n_images = shape[0]
 
         warnings.warn(
-            f"{MESSAGE} assuming the first entry is n_images followed by y, x. The remaining is thrown out!", UserWarning
+            f"{MESSAGE} assuming the first entry is n_images followed by y, x. The remaining is thrown out!",
+            UserWarning,
+            stacklevel=2,
         )
 
     wfi_mosaic = stnode.WfiMosaic()
@@ -209,7 +213,9 @@ def mk_msos_stack(*, shape=(4096, 4096), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[1:3]
 
-        warnings.warn(f"{MESSAGE} assuming the the first two entries are y, x. The remaining is thrown out!", UserWarning)
+        warnings.warn(
+            f"{MESSAGE} assuming the the first two entries are y, x. The remaining is thrown out!", UserWarning, stacklevel=2
+        )
 
     msos_stack = stnode.MsosStack()
     msos_stack["meta"] = mk_msos_stack_meta(**kwargs.get("meta", {}))
@@ -243,7 +249,7 @@ def mk_ramp(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     """
     if len(shape) != 3:
         shape = (8, 4096, 4096)
-        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)")
+        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)", UserWarning, stacklevel=2)
 
     ramp = stnode.Ramp()
     # ramp["meta"] = mk_common_meta(**kwargs.get("meta", {}))
@@ -293,7 +299,7 @@ def mk_ramp_fit_output(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     """
     if len(shape) != 3:
         shape = (8, 4096, 4096)
-        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)")
+        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)", UserWarning, stacklevel=2)
 
     rampfitoutput = stnode.RampFitOutput()
     rampfitoutput["meta"] = mk_common_meta(**kwargs.get("meta", {}))
@@ -312,7 +318,7 @@ def mk_ramp_fit_output(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
 
 
 def mk_rampfitoutput(**kwargs):
-    warnings.warn("mk_rampfitoutput is deprecated. Use mk_rampfit_output instead.", DeprecationWarning)
+    warnings.warn("mk_rampfitoutput is deprecated. Use mk_rampfit_output instead.", DeprecationWarning, stacklevel=2)
 
     return mk_ramp_fit_output(**kwargs)
 
@@ -393,7 +399,7 @@ def mk_guidewindow(*, shape=(2, 8, 16, 32, 32), filepath=None, **kwargs):
     """
     if len(shape) != 5:
         shape = (2, 8, 16, 32, 32)
-        warnings.warn("Input shape must be 5D. Defaulting to (2, 8, 16, 32, 32)")
+        warnings.warn("Input shape must be 5D. Defaulting to (2, 8, 16, 32, 32)", UserWarning, stacklevel=2)
 
     guidewindow = stnode.Guidewindow()
     guidewindow["meta"] = mk_guidewindow_meta(**kwargs.get("meta", {}))
@@ -448,7 +454,9 @@ def mk_mosaic_segmentation_map(*, filepath=None, shape=(4096, 4096), **kwargs):
         shape = shape[1:3]
 
         warnings.warn(
-            f"{MESSAGE} assuming the first entry is n_groups followed by y, x. The remaining is thrown out!", UserWarning
+            f"{MESSAGE} assuming the first entry is n_groups followed by y, x. The remaining is thrown out!",
+            UserWarning,
+            stacklevel=2,
         )
 
     segmentation_map = stnode.MosaicSegmentationMap()
@@ -501,7 +509,9 @@ def mk_segmentation_map(*, filepath=None, shape=(4096, 4096), **kwargs):
         shape = shape[1:3]
 
         warnings.warn(
-            f"{MESSAGE} assuming the first entry is n_groups followed by y, x. The remaining is thrown out!", UserWarning
+            f"{MESSAGE} assuming the first entry is n_groups followed by y, x. The remaining is thrown out!",
+            UserWarning,
+            stacklevel=2,
         )
 
     segmentation_map = stnode.SegmentationMap()

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -175,7 +175,7 @@ def mk_level3_mosaic(*, shape=(4088, 4088), n_images=2, filepath=None, **kwargs)
     wfi_mosaic["meta"] = mk_mosaic_meta(**kwargs.get("meta", {}))
     wfi_mosaic["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
     wfi_mosaic["err"] = kwargs.get("err", np.zeros(shape, dtype=np.float32))
-    wfi_mosaic["context"] = kwargs.get("context", np.zeros((n_images,) + shape, dtype=np.uint32))
+    wfi_mosaic["context"] = kwargs.get("context", np.zeros((n_images, *shape), dtype=np.uint32))
     wfi_mosaic["weight"] = kwargs.get("weight", np.zeros(shape, dtype=np.float32))
 
     wfi_mosaic["var_poisson"] = kwargs.get("var_poisson", np.zeros(shape, dtype=np.float32))

--- a/src/roman_datamodels/maker_utils/_fps.py
+++ b/src/roman_datamodels/maker_utils/_fps.py
@@ -119,7 +119,7 @@ def mk_fps(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
     """
     if len(shape) != 3:
         shape = (8, 4096, 4096)
-        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)")
+        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)", UserWarning, stacklevel=2)
 
     fps = stnode.Fps()
     fps["meta"] = mk_fps_meta(**kwargs.get("meta", {}))

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -94,7 +94,7 @@ def mk_ref_apcorr_data(shape=(10,), **kwargs):
     if len(shape) > 1:
         shape = shape[:1]
 
-        warnings.warn(f"{MESSAGE} assuming the first entry. The remaining are thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first entry. The remaining are thrown out!", UserWarning, stacklevel=2)
 
     data = {}
     for optical_elem in OPT_ELEM:
@@ -131,7 +131,7 @@ def mk_apcorr(*, shape=(10,), filepath=None, **kwargs):
     if len(shape) > 1:
         shape = shape[:1]
 
-        warnings.warn(f"{MESSAGE} assuming the first entry. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first entry. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     apcorrref = stnode.ApcorrRef()
     apcorrref["meta"] = mk_ref_common("APCORR", **kwargs.get("meta", {}))
@@ -161,7 +161,7 @@ def mk_flat(*, shape=(4096, 4096), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     flatref = stnode.FlatRef()
     flatref["meta"] = mk_ref_common("FLAT", **kwargs.get("meta", {}))
@@ -192,7 +192,7 @@ def mk_dark(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
     if len(shape) != 3:
         shape = (2, 4096, 4096)
-        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)")
+        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)", UserWarning, stacklevel=2)
 
     darkref = stnode.DarkRef()
     darkref["meta"] = mk_ref_dark_meta(**kwargs.get("meta", {}))
@@ -254,7 +254,7 @@ def mk_epsf(*, shape=(3, 6, 9, 361, 361), filepath=None, **kwargs):
     """
     if len(shape) != 5:
         shape = (3, 6, 9, 361, 361)
-        warnings.warn("Input shape must be 5D. Defaulting to (3, 6, 9, 361, 361)")
+        warnings.warn("Input shape must be 5D. Defaulting to (3, 6, 9, 361, 361)", UserWarning, stacklevel=2)
 
     epsfref = stnode.EpsfRef()
     epsfref["meta"] = mk_ref_epsf_meta(**kwargs.get("meta", {}))
@@ -286,7 +286,7 @@ def mk_gain(*, shape=(4096, 4096), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     gainref = stnode.GainRef()
     gainref["meta"] = mk_ref_common("GAIN", **kwargs.get("meta", {}))
@@ -317,7 +317,7 @@ def mk_ipc(*, shape=(3, 3), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     ipcref = stnode.IpcRef()
     ipcref["meta"] = mk_ref_common("IPC", **kwargs.get("meta", {}))
@@ -350,7 +350,7 @@ def mk_linearity(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
     if len(shape) != 3:
         shape = (2, 4096, 4096)
-        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)")
+        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)", UserWarning, stacklevel=2)
 
     linearityref = stnode.LinearityRef()
     linearityref["meta"] = mk_ref_units_dn_meta("LINEARITY", **kwargs.get("meta", {}))
@@ -380,7 +380,7 @@ def mk_inverselinearity(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     """
     if len(shape) != 3:
         shape = (2, 4096, 4096)
-        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)")
+        warnings.warn("Input shape must be 3D. Defaulting to (2, 4096, 4096)", UserWarning, stacklevel=2)
 
     inverselinearityref = stnode.InverselinearityRef()
     inverselinearityref["meta"] = mk_ref_units_dn_meta("INVERSELINEARITY", **kwargs.get("meta", {}))
@@ -412,7 +412,7 @@ def mk_mask(*, shape=(4096, 4096), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     maskref = stnode.MaskRef()
     maskref["meta"] = mk_ref_common("MASK", **kwargs.get("meta", {}))
@@ -443,7 +443,7 @@ def mk_pixelarea(*, shape=(4096, 4096), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     pixelarearef = stnode.PixelareaRef()
     pixelarearef["meta"] = mk_ref_pixelarea_meta(**kwargs.get("meta", {}))
@@ -523,7 +523,7 @@ def mk_readnoise(*, shape=(4096, 4096), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     readnoiseref = stnode.ReadnoiseRef()
     readnoiseref["meta"] = mk_ref_readnoise_meta(**kwargs.get("meta", {}))
@@ -554,7 +554,7 @@ def mk_saturation(*, shape=(4096, 4096), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     saturationref = stnode.SaturationRef()
     saturationref["meta"] = mk_ref_common("SATURATION", **kwargs.get("meta", {}))
@@ -586,7 +586,7 @@ def mk_superbias(*, shape=(4096, 4096), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     superbiasref = stnode.SuperbiasRef()
     superbiasref["meta"] = mk_ref_common("BIAS", **kwargs.get("meta", {}))
@@ -633,7 +633,7 @@ def mk_refpix(*, shape=(32, 286721), filepath=None, **kwargs):
     if len(shape) > 2:
         shape = shape[:2]
 
-        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning)
+        warnings.warn(f"{MESSAGE} assuming the first two entries. The remaining is thrown out!", UserWarning, stacklevel=2)
 
     refpix = stnode.RefpixRef()
     refpix["meta"] = mk_ref_units_dn_meta("REFPIX", **kwargs.get("meta", {}))

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -20,21 +20,21 @@ from ._common_meta import (
 __all__ = [
     "mk_abvegaoffset",
     "mk_apcorr",
-    "mk_flat",
     "mk_dark",
     "mk_distortion",
     "mk_epsf",
+    "mk_flat",
     "mk_gain",
+    "mk_inverselinearity",
     "mk_ipc",
     "mk_linearity",
-    "mk_inverselinearity",
     "mk_mask",
     "mk_pixelarea",
-    "mk_wfi_img_photom",
     "mk_readnoise",
+    "mk_refpix",
     "mk_saturation",
     "mk_superbias",
-    "mk_refpix",
+    "mk_wfi_img_photom",
 ]
 
 OPT_ELEM = ("F062", "F087", "F106", "F129", "F146", "F158", "F184", "F213", "GRISM", "PRISM", "DARK")

--- a/src/roman_datamodels/maker_utils/_tvac.py
+++ b/src/roman_datamodels/maker_utils/_tvac.py
@@ -166,7 +166,7 @@ def mk_tvac(*, shape=(8, 4096, 4096), filepath=None, **kwargs):
 
     if len(shape) != 3:
         shape = (8, 4096, 4096)
-        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)")
+        warnings.warn("Input shape must be 3D. Defaulting to (8, 4096, 4096)", UserWarning, stacklevel=2)
 
     tvac = stnode.Tvac()
     tvac["meta"] = mk_tvac_meta(**kwargs.get("meta", {}))

--- a/src/roman_datamodels/stnode/_converters.py
+++ b/src/roman_datamodels/stnode/_converters.py
@@ -8,10 +8,10 @@ from astropy.time import Time
 from ._registry import LIST_NODE_CLASSES_BY_TAG, NODE_CONVERTERS, OBJECT_NODE_CLASSES_BY_TAG, SCALAR_NODE_CLASSES_BY_TAG
 
 __all__ = [
-    "TaggedObjectNodeConverter",
-    "TaggedListNodeConverter",
-    "TaggedScalarNodeConverter",
     "NODE_EXTENSIONS",
+    "TaggedListNodeConverter",
+    "TaggedObjectNodeConverter",
+    "TaggedScalarNodeConverter",
 ]
 
 

--- a/src/roman_datamodels/stnode/_mixins.py
+++ b/src/roman_datamodels/stnode/_mixins.py
@@ -2,6 +2,13 @@
 Mixin classes for additional functionality for STNode classes
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+
 __all__ = ["WfiModeMixin"]
 
 
@@ -14,7 +21,7 @@ class WfiModeMixin:
     # Every optical element is a grating or a filter
     #   There are less gratings than filters so its easier to list out the
     #   gratings.
-    _GRATING_OPTICAL_ELEMENTS = {"GRISM", "PRISM"}
+    _GRATING_OPTICAL_ELEMENTS: ClassVar = {"GRISM", "PRISM"}
 
     @property
     def filter(self):

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -107,7 +107,7 @@ class DNode(MutableMapping):
         # Handle if we are passed different data types
         if node is None:
             self.__dict__["_data"] = {}
-        elif isinstance(node, (dict, AsdfDictNode)):
+        elif isinstance(node, dict | AsdfDictNode):
             self.__dict__["_data"] = node
         else:
             raise ValueError("Initializer only accepts dicts")
@@ -161,10 +161,10 @@ class DNode(MutableMapping):
             value = self._convert_to_scalar(key, self._data[key])
 
             # Return objects as node classes, if applicable
-            if isinstance(value, (dict, AsdfDictNode)):
+            if isinstance(value, dict | AsdfDictNode):
                 return DNode(value, parent=self, name=key)
 
-            elif isinstance(value, (list, AsdfListNode)):
+            elif isinstance(value, list | AsdfListNode):
                 return LNode(value)
 
             else:
@@ -203,12 +203,12 @@ class DNode(MutableMapping):
 
     def _recursive_items(self):
         def recurse(tree, path=[]):
-            if isinstance(tree, (DNode, dict, AsdfDictNode)):
+            if isinstance(tree, DNode | dict | AsdfDictNode):
                 for key, val in tree.items():
-                    yield from recurse(val, path + [key])
-            elif isinstance(tree, (LNode, list, tuple, AsdfListNode)):
+                    yield from recurse(val, [*path, key])
+            elif isinstance(tree, LNode | list | tuple | AsdfListNode):
                 for i, val in enumerate(tree):
-                    yield from recurse(val, path + [i])
+                    yield from recurse(val, [*path, i])
             elif tree is not None:
                 yield (".".join(str(x) for x in path), tree)
 
@@ -242,7 +242,7 @@ class DNode(MutableMapping):
             return {key: convert_val(val) for (key, val) in item_getter()}
         else:
             return {
-                key: convert_val(val) for (key, val) in item_getter() if not isinstance(val, (np.ndarray, ndarray.NDArrayType))
+                key: convert_val(val) for (key, val) in item_getter() if not isinstance(val, np.ndarray | ndarray.NDArrayType)
             }
 
     def _schema(self):
@@ -279,7 +279,7 @@ class DNode(MutableMapping):
         value = self._convert_to_scalar(key, value, self._data.get(key))
 
         # If the value is a dictionary, loop over its keys and convert them to tagged scalars
-        if isinstance(value, (dict, AsdfDictNode)):
+        if isinstance(value, dict | AsdfDictNode):
             for sub_key, sub_value in value.items():
                 value[sub_key] = self._convert_to_scalar(sub_key, sub_value)
 
@@ -316,7 +316,7 @@ class LNode(UserList):
     def __init__(self, node=None):
         if node is None:
             self.data = []
-        elif isinstance(node, (list, AsdfListNode)):
+        elif isinstance(node, list | AsdfListNode):
             self.data = node
         elif isinstance(node, self.__class__):
             self.data = node.data
@@ -325,9 +325,9 @@ class LNode(UserList):
 
     def __getitem__(self, index):
         value = self.data[index]
-        if isinstance(value, (dict, AsdfDictNode)):
+        if isinstance(value, dict | AsdfDictNode):
             return DNode(value)
-        elif isinstance(value, (list, AsdfListNode)):
+        elif isinstance(value, list | AsdfListNode):
             return LNode(value)
         else:
             return value

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -201,7 +201,8 @@ class DNode(MutableMapping):
         return self._x_schema_attributes
 
     def _recursive_items(self):
-        def recurse(tree, path=[]):
+        def recurse(tree, path=None):
+            path = path or []  # Avoid mutable default arguments
             if isinstance(tree, DNode | dict | AsdfDictNode):
                 for key, val in tree.items():
                     yield from recurse(val, [*path, key])

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -180,7 +180,6 @@ class DNode(MutableMapping):
 
         # Private keys should just be in the normal __dict__
         if key[0] != "_":
-
             # Wrap things in the tagged scalar classes if necessary
             value = self._convert_to_scalar(key, value, self._data.get(key))
 

--- a/src/roman_datamodels/stnode/_tagged.py
+++ b/src/roman_datamodels/stnode/_tagged.py
@@ -17,8 +17,8 @@ from ._registry import (
 )
 
 __all__ = [
-    "TaggedObjectNode",
     "TaggedListNode",
+    "TaggedObjectNode",
     "TaggedScalarNode",
 ]
 

--- a/src/roman_datamodels/testing.py
+++ b/src/roman_datamodels/testing.py
@@ -52,9 +52,9 @@ def assert_node_equal(node1, node2):
 
 
 def _assert_value_equal(value1, value2):
-    if isinstance(value1, (TaggedObjectNode, TaggedListNode, TaggedScalarNode, DNode)):
+    if isinstance(value1, TaggedObjectNode | TaggedListNode | TaggedScalarNode | DNode):
         assert_node_equal(value1, value2)
-    elif isinstance(value1, (np.ndarray, NDArrayType)):
+    elif isinstance(value1, np.ndarray | NDArrayType):
         assert_array_equal(value1, value2)
     elif isinstance(value1, Model):
         assert_model_equal(value1, value2)
@@ -104,7 +104,7 @@ def assert_node_is_copy(node1, node2, deepcopy=False):
 
 def _assert_value_is_copy(value1, value2, deepcopy=False):
     if deepcopy:
-        if isinstance(value1, (TaggedObjectNode, TaggedListNode, TaggedScalarNode)):
+        if isinstance(value1, TaggedObjectNode | TaggedListNode | TaggedScalarNode):
             assert_node_is_copy(value1, value2)
         elif isinstance(value1, Model):
             assert value1 is not value2
@@ -141,7 +141,7 @@ def wraps_hashable(node):
 
 
 def _wraps_hashable(value):
-    if isinstance(value, (TaggedObjectNode, TaggedListNode, TaggedScalarNode)):
+    if isinstance(value, TaggedObjectNode | TaggedListNode | TaggedScalarNode):
         return wraps_hashable(value)
 
     # Immutable types are usually hashable

--- a/src/roman_datamodels/testing.py
+++ b/src/roman_datamodels/testing.py
@@ -40,7 +40,7 @@ def assert_node_equal(node1, node2):
     elif isinstance(node1, TaggedListNode):
         assert len(node1) == len(node2)
 
-        for value1, value2 in zip(node1, node2):
+        for value1, value2 in zip(node1, node2, strict=True):
             _assert_value_equal(value1, value2)
     elif isinstance(node1, TaggedScalarNode):
         value1 = node1.__class__.__bases__[0](node1)
@@ -91,7 +91,7 @@ def assert_node_is_copy(node1, node2, deepcopy=False):
             value2 = node2[key]
             _assert_value_is_copy(value1, value2, deepcopy=deepcopy)
     elif isinstance(node1, TaggedListNode):
-        for value1, value2 in zip(node1, node2):
+        for value1, value2 in zip(node1, node2, strict=True):
             _assert_value_is_copy(value1, value2, deepcopy=deepcopy)
     elif isinstance(node1, TaggedScalarNode):
         value1 = node1.__class__.__bases__[0](node1)

--- a/src/roman_datamodels/validate.py
+++ b/src/roman_datamodels/validate.py
@@ -35,7 +35,7 @@ def validation_is_disabled():
             to "true".
         """
     )
-    warnings.warn(MESSAGE, ValidationWarning)
+    warnings.warn(MESSAGE, ValidationWarning, stacklevel=2)
 
 
 def will_validate():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,9 +10,8 @@ from astropy.modeling import Model
 from astropy.table import QTable, Table
 from numpy.testing import assert_array_equal
 
-from roman_datamodels import datamodels
+from roman_datamodels import datamodels, stnode, validate
 from roman_datamodels import maker_utils as utils
-from roman_datamodels import stnode, validate
 from roman_datamodels.testing import assert_node_equal
 
 from .conftest import MANIFEST
@@ -443,7 +442,7 @@ def test_make_epsf():
     assert isinstance(epsf.meta["pixel_x"], list)
     assert isinstance(epsf.meta["pixel_x"][0], float)
     assert epsf["psf"].shape == (2, 3, 4, 8, 8)
-    assert isinstance(epsf["psf"][0, 0, 0, 0, 0], (float, np.float32))
+    assert isinstance(epsf["psf"][0, 0, 0, 0, 0], float | np.float32)
 
     # Test validation
     epsf_model = datamodels.EpsfRefModel(epsf)
@@ -911,7 +910,7 @@ def test_datamodel_schema_info_existence(name):
         info = model.schema_info("archive_catalog")
         for keyword in model.meta.keys():
             # Only DNodes or LNodes need to be canvassed
-            if isinstance(model.meta[keyword], (stnode.DNode, stnode.LNode)):
+            if isinstance(model.meta[keyword], stnode.DNode | stnode.LNode):
                 # Ignore metadata schemas that lack archive_catalog entries
                 if type(model.meta[keyword]) not in NODES_LACKING_ARCHIVE_CATALOG:
                     assert keyword in info["roman"]["meta"]

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -8,9 +8,8 @@ import pytest
 from astropy.io import fits
 from numpy.testing import assert_array_equal
 
-from roman_datamodels import datamodels
+from roman_datamodels import datamodels, stnode
 from roman_datamodels import maker_utils as utils
-from roman_datamodels import stnode
 from roman_datamodels.testing import assert_node_equal
 
 

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -4,10 +4,8 @@ from contextlib import nullcontext
 import asdf
 import pytest
 
-from roman_datamodels import datamodels
-from roman_datamodels import maker_utils
+from roman_datamodels import datamodels, maker_utils, stnode, validate
 from roman_datamodels import maker_utils as utils
-from roman_datamodels import stnode, validate
 from roman_datamodels.maker_utils._base import NOFN, NONUM, NOSTR
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy, wraps_hashable
 
@@ -19,7 +17,7 @@ def test_generated_node_classes(tag):
     class_name = stnode._factories.class_name_from_tag_uri(tag["tag_uri"])
     node_class = getattr(stnode, class_name)
 
-    assert issubclass(node_class, (stnode.TaggedObjectNode, stnode.TaggedListNode, stnode.TaggedScalarNode))
+    assert issubclass(node_class, stnode.TaggedObjectNode | stnode.TaggedListNode | stnode.TaggedScalarNode)
     assert node_class._tag == tag["tag_uri"]
     assert tag["description"] in node_class.__doc__
     assert tag["tag_uri"] in node_class.__doc__
@@ -264,7 +262,7 @@ def test_node_representation(model):
     mdl = maker_utils.mk_datamodel(model)
 
     if hasattr(mdl, "meta"):
-        if isinstance(mdl, (datamodels.MosaicModel, datamodels.MosaicSegmentationMapModel, datamodels.MosaicSourceCatalogModel)):
+        if isinstance(mdl, datamodels.MosaicModel | datamodels.MosaicSegmentationMapModel | datamodels.MosaicSourceCatalogModel):
             assert repr(mdl.meta.basic) == repr(
                 {
                     "time_first_mjd": NONUM,
@@ -291,7 +289,7 @@ def test_node_representation(model):
             assert mdl.meta.model_type == model_types[type(mdl)]
             assert mdl.meta.telescope == "ROMAN"
             assert mdl.meta.filename == NOFN
-        elif isinstance(mdl, (datamodels.SegmentationMapModel, datamodels.SourceCatalogModel)):
+        elif isinstance(mdl, datamodels.SegmentationMapModel | datamodels.SourceCatalogModel):
             assert mdl.meta.optical_element == "F158"
         else:
             assert repr(mdl.meta.instrument) == repr(


### PR DESCRIPTION
This PR switches to using Ruff for code formatting, import sorting, upgrading, and security checking rather than using separate tooling (these are drop in replacements). It also adds the `RUF` and `B` rule sets as both of those are useful (`RUF` has rules governing `noqa` marks and `B` is a collection of common but difficult to debug potential issues). Finally, this cleans up the pytest config.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
