### PR TITLE
Add numpy lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ extend-select = [
     "B",    # BugBear
     "S",    # Bandit
     "RUF",  # ruff specific
+    "NPY",  # numpy specific
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Romancal uses this, specifically it catches issues with misuse of random number generation to create non-deterministic tests. I missed adding this in #433.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
