### PR TITLE
RCAL-861: by default compress all arrays

### DIFF
--- a/changes/440.feature.rst
+++ b/changes/440.feature.rst
@@ -1,0 +1,1 @@
+Change default compression to lz4.

--- a/changes/440.feature.rst
+++ b/changes/440.feature.rst
@@ -1,1 +1,1 @@
-Change default compression to lz4.
+Change default compression to lz4. The previous default was no compression.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "asdf >=3.3.0",
-    "lz4",
+    "lz4 >= 4.3.0",
     "asdf-astropy >=0.5.0",
     "gwcs >=0.19.0",
     "numpy >=1.24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "asdf >=3.3.0",
+    "lz4",
     "asdf-astropy >=0.5.0",
     "gwcs >=0.19.0",
     "numpy >=1.24",

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -233,6 +233,8 @@ class DataModel(abc.ABC):
         with validate.nuke_validation(), _temporary_update_filename(self, Path(init).name):
             asdf_file = self.open_asdf(**kwargs)
             asdf_file["roman"] = self._instance
+            if "all_array_compression" not in kwargs:
+                kwargs["all_array_compression"] = "zlib"
             asdf_file.write_to(init, *args, **kwargs)
 
     def get_primary_array_name(self):

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -230,12 +230,11 @@ class DataModel(abc.ABC):
             return asdf.AsdfFile(init, **kwargs)
 
     def to_asdf(self, init, *args, **kwargs):
+        all_array_compression = kwargs.pop("all_array_compression", "lz4")
         with validate.nuke_validation(), _temporary_update_filename(self, Path(init).name):
             asdf_file = self.open_asdf(**kwargs)
             asdf_file["roman"] = self._instance
-            if "all_array_compression" not in kwargs:
-                kwargs["all_array_compression"] = "lz4"
-            asdf_file.write_to(init, *args, **kwargs)
+            asdf_file.write_to(init, *args, all_array_compression=all_array_compression, **kwargs)
 
     def get_primary_array_name(self):
         """

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -234,7 +234,7 @@ class DataModel(abc.ABC):
             asdf_file = self.open_asdf(**kwargs)
             asdf_file["roman"] = self._instance
             if "all_array_compression" not in kwargs:
-                kwargs["all_array_compression"] = "zlib"
+                kwargs["all_array_compression"] = "lz4"
             asdf_file.write_to(init, *args, **kwargs)
 
     def get_primary_array_name(self):

--- a/src/roman_datamodels/maker_utils/_base.py
+++ b/src/roman_datamodels/maker_utils/_base.py
@@ -29,6 +29,6 @@ def save_node(node, filepath=None):
 
         af = asdf.AsdfFile()
         af.tree = {"roman": node}
-        af.write_to(filepath, all_array_compression="zlib")
+        af.write_to(filepath, all_array_compression="lz4")
 
     return node

--- a/src/roman_datamodels/maker_utils/_base.py
+++ b/src/roman_datamodels/maker_utils/_base.py
@@ -29,6 +29,6 @@ def save_node(node, filepath=None):
 
         af = asdf.AsdfFile()
         af.tree = {"roman": node}
-        af.write_to(filepath)
+        af.write_to(filepath, all_array_compression="zlib")
 
     return node

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1109,3 +1109,28 @@ def test_model_assignment_access_types(model_class):
     assert type(model["meta"]["filename"]) == type(model2.meta["filename"])  # noqa: E721
     assert type(model["meta"]["filename"]) == type(model2.meta.filename)  # noqa: E721
     assert type(model.meta.filename) == type(model2.meta["filename"])  # noqa: E721
+
+
+def test_default_array_compression(tmp_path):
+    """
+    Test that saving a model results in compressed arrays
+    for default options.
+    """
+    fn = tmp_path / "foo.asdf"
+    model = utils.mk_datamodel(datamodels.ImageModel)
+    model.save(fn)
+    with asdf.open(fn) as af:
+        assert af.get_array_compression(af["roman"]["data"]) == "lz4"
+
+
+@pytest.mark.parametrize("compression", [None, "bzp2"])
+def test_array_compression_override(tmp_path, compression):
+    """
+    Test that providing a compression argument changes the
+    array compression.
+    """
+    fn = tmp_path / "foo.asdf"
+    model = utils.mk_datamodel(datamodels.ImageModel)
+    model.save(fn, all_array_compression=compression)
+    with asdf.open(fn) as af:
+        assert af.get_array_compression(af["roman"]["data"]) == compression


### PR DESCRIPTION
Closes https://jira.stsci.edu/browse/RCAL-861

The above ticket description describes setting compression per array. However the discussion in the comments mentions that a "compress everything" approach is good enough for now and we can revisit per-array compression later (which would involve addressing some structural limitations in roman_datamodels).

This PR updates roman_datamodels to compress all array data when writing a file using `lz4` compression. The default compression can be overridden on save (assuming `model` is a `DataModel`):
```python
>>> model.save("foo.asdf", all_array_compression=None)  # for no compression
>>> model.save("foo.asdf", all_array_compression="bzp2")  # for bzip
```
As this builds off the compression infrastructure provided by asdf any algorithms supported by asdf (or asdf extensions) are supported:
https://asdf.readthedocs.io/en/latest/asdf/arrays.html#compression

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/12317452058

Regtests that intentionally break all compare_asdf calls (to trigger output files to be uploaded to artifactory) at: https://github.com/spacetelescope/RegressionTests/actions/runs/12188485915
and output files at:
https://bytesalad.stsci.edu/ui/repos/tree/General/roman-pipeline-results/regression-tests/runs/2024-12-11_GITHUB_CI_Linux-X64-py3.11-1447

Summary table with a few select files (using the 'truth' file as the uncompressed file).

| filename | uncompressed (MB) | compressed (MB) | compressed percent |
| - | - | - | - |
| r0099101001001001001_r274dp63x31y81_prompt_F158_coadd.asdf | 339.32 | 267.19 | 78.74 |
| r0000101001001001001_0001_wfi01_cal.asdf | 459.82 | 385.93 | 83.93 |
| r0000101001001001001_0001_wfi01_photom.asdf | 459.77 | 385.89 | 83.93 |
| r0000101001001001001_0003_wfi01_rampfit.asdf | 455.76 | 339.83 | 74.56 |
| r0000101001001001001_0001_wfi01_shift_tweakregstep.asdf | 459.79 | 385.90 | 83.93 |
| r0099101001001001001_F158_visit_coadd.asdf | 485.10 | 416.08 | 85.77 |
| r0000101001001001001_0001_wfi01_refpix.asdf | 1535.51 | 248.38 | 16.18 |
| r0000101001001001001_0001_wfi01_linearity.asdf | 1535.51 | 473.78 | 30.85 |
| r0000101001001001001_0001_wfi01_saturation.asdf | 1516.76 | 248.18 | 16.36 |
| r0000101001001001001_0001_wfi01_rampfit.asdf | 460.76 | 339.28 | 73.63 |
| r0000101001001001001_0001_wfi01_dqinit.asdf | 1516.76 | 248.05 | 16.35 |
| r0000101001001001001_0001_wfi01_flat.asdf | 459.77 | 385.89 | 83.93 |
| r0000101001001001001_0001_wfi01_darkcurrent.asdf | 1535.51 | 646.69 | 42.12 |
| r0000101001001001001_0001_wfi01_cal_repoint.asdf | 459.78 | 385.89 | 83.93 |
| r0000201001001001001_0001_wfi01_cal_repoint.asdf | 460.77 | 339.35 | 73.65 |
| r0000201001001001001_0003_wfi01_rampfit.asdf | 455.76 | 339.88 | 74.57 |
| r0000201001001001001_0001_wfi01_cal.asdf | 460.79 | 339.36 | 73.65 |
| r0000201001001001001_0001_wfi01_dqinit.asdf | 1516.76 | 248.04 | 16.35 |
| r0000201001001001001_0001_wfi01_saturation.asdf | 1516.76 | 248.17 | 16.36 |
| r0000201001001001001_0001_wfi01_rampfit.asdf | 460.76 | 339.34 | 73.65 |
| r0000201001001001001_0001_wfi01_flat.asdf | 460.77 | 339.35 | 73.65 |
| r0000101001001001001_0001_wfi01_ALL_SATURATED_cal.asdf | 332.77 | 1.34 | 0.40 |
| r0000101001001001001_0001_wfi01_star.asdf | 459.81 | 385.92 | 83.93 |


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
