### PR TITLE
Fix single test broken by the ref cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "numpy >=1.24",
     "astropy >=5.3.0",
     # "rad >=0.22.0, <0.23.0",
-    "rad @ git+https://github.com/spacetelescope/rad.git",
+    # "rad @ git+https://github.com/spacetelescope/rad.git",
+    "rad @ git+https://github.com/WilliamJamieson/rad.git@feature/cleanup_refs",
     "asdf-standard >=1.1.0",
 ]
 dynamic = ["version"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,7 +16,7 @@ from roman_datamodels.testing import assert_node_equal
 
 from .conftest import MANIFEST
 
-EXPECTED_COMMON_REFERENCE = {"$ref": "ref_common-1.0.0"}
+EXPECTED_COMMON_REFERENCE = {"$ref": "asdf://stsci.edu/datamodels/roman/schemas/reference_files/ref_common-1.0.0"}
 
 # Nodes for metadata schema that do not contain any archive_catalog keywords
 NODES_LACKING_ARCHIVE_CATALOG = [
@@ -322,21 +322,16 @@ def test_make_guidewindow():
 
 
 # Testing all reference file schemas
-def test_reference_file_model_base(tmp_path):
-    # Set temporary asdf file
-
-    # Get all reference file classes
-    tags = [t for t in stnode.NODE_EXTENSIONS[0].tags if "/reference_files/" in t.tag_uri]
-    for tag in tags:
-        schema = asdf.schema.load_schema(tag.schema_uris[0])
-        # Check that schema references common reference schema
-        allofs = schema["properties"]["meta"]["allOf"]
-        found_common = False
-        for item in allofs:
-            if item == EXPECTED_COMMON_REFERENCE:
-                found_common = True
-        if not found_common:
-            raise ValueError("Reference schema does not include ref_common")  # pragma: no cover
+@pytest.mark.parametrize("tag", [t for t in stnode.NODE_EXTENSIONS[0].tags if "/reference_files/" in t.tag_uri])
+def test_reference_file_model_base(tag):
+    schema = asdf.schema.load_schema(tag.schema_uris[0])
+    # Check that schema references common reference schema
+    allofs = schema["properties"]["meta"]["allOf"]
+    for item in allofs:
+        if item == EXPECTED_COMMON_REFERENCE:
+            break
+    else:
+        raise ValueError("Reference schema does not include ref_common")  # pragma: no cover
 
 
 # AB Vega Offset Correction tests


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR updates a unit test to be consistent with spacetelescope/rad#527 changes.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
