### PR TITLE
Update metadata for 0.23.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,47 @@
+0.23.0 (2025-01-16)
+===================
+
+Bug Fixes
+---------
+
+- Renamed mosaic association model variable name. (`#412
+  <https://github.com/spacetelescope/roman_datamodels/issues/412>`_)
+
+
+Documentation
+-------------
+
+- Updated the documentation to match the present code version. (`#437
+  <https://github.com/spacetelescope/roman_datamodels/issues/437>`_)
+
+
+New Features
+------------
+
+- Remove units from reference files. (`#408
+  <https://github.com/spacetelescope/roman_datamodels/issues/408>`_)
+- Rename source_detection to source_catalog to match romancal step. (`#428
+  <https://github.com/spacetelescope/roman_datamodels/issues/428>`_)
+- Change default compression to lz4. The previous default was no compression.
+  (`#440 <https://github.com/spacetelescope/roman_datamodels/issues/440>`_)
+- Add support for opening SSC models using ``rdm_open``. (`#448
+  <https://github.com/spacetelescope/roman_datamodels/issues/448>`_)
+
+
+Misc
+----
+
+- Bump min Python version to 3.11 per SPEC 0. (`#432
+  <https://github.com/spacetelescope/roman_datamodels/issues/432>`_)
+
+
+Deprecations and Removals
+-------------------------
+
+- Remove validation on assignment. (`#417
+  <https://github.com/spacetelescope/roman_datamodels/issues/417>`_)
+
+
 0.22.0 (2024-11-15)
 ===================
 

--- a/changes/408.feature.rst
+++ b/changes/408.feature.rst
@@ -1,1 +1,0 @@
-Remove units from reference files.

--- a/changes/412.bugfix.rst
+++ b/changes/412.bugfix.rst
@@ -1,1 +1,0 @@
-Renamed mosaic association model variable name.

--- a/changes/417.removal.rst
+++ b/changes/417.removal.rst
@@ -1,1 +1,0 @@
-Remove validation on assignment.

--- a/changes/428.feature.rst
+++ b/changes/428.feature.rst
@@ -1,1 +1,0 @@
-Rename source_detection to source_catalog to match romancal step.

--- a/changes/432.misc.rst
+++ b/changes/432.misc.rst
@@ -1,1 +1,0 @@
-Bump min Python version to 3.11 per SPEC 0.

--- a/changes/437.doc.rst
+++ b/changes/437.doc.rst
@@ -1,1 +1,0 @@
-Updated the documentation to match the present code version.

--- a/changes/440.feature.rst
+++ b/changes/440.feature.rst
@@ -1,1 +1,0 @@
-Change default compression to lz4. The previous default was no compression.

--- a/changes/448.feature.rst
+++ b/changes/448.feature.rst
@@ -1,1 +1,0 @@
-Add support for opening SSC models using ``rdm_open``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
     "gwcs >=0.19.0",
     "numpy >=1.24",
     "astropy >=5.3.0",
-    # "rad >=0.22.0, <0.23.0",
-    "rad @ git+https://github.com/spacetelescope/rad.git",
+    "rad >=0.23.0, <0.24.0",
+    # "rad @ git+https://github.com/spacetelescope/rad.git",
     "asdf-standard >=1.1.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Update for release 0.23.0

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
