### PR TITLE
RCAL-991: support passing a file to rdm.open

### DIFF
--- a/changes/453.feature.rst
+++ b/changes/453.feature.rst
@@ -1,0 +1,1 @@
+Allow ``rdm.open`` to open file-like objects (like those returned by s3fs)

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -221,11 +221,11 @@ class DataModel(abc.ABC):
         return output_path
 
     def open_asdf(self, init=None, **kwargs):
-        from ._utils import _open_path_like
+        from ._utils import _open_asdf
 
         with validate.nuke_validation():
             if isinstance(init, str):
-                return _open_path_like(init, **kwargs)
+                return _open_asdf(init, **kwargs)
 
             return asdf.AsdfFile(init, **kwargs)
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -81,6 +81,17 @@ def test_model_input(tmp_path):
     reopened_model.close()
 
 
+def test_file_input(tmp_path):
+    file_path = tmp_path / "test.asdf"
+    tree = utils.mk_level2_image(shape=(8, 8))
+    with asdf.AsdfFile() as af:
+        af.tree = {"roman": tree}
+        af.write_to(file_path)
+    with open(file_path, "rb") as f:
+        with datamodels.open(f) as model:
+            assert model.meta.telescope == "ROMAN"
+
+
 def test_invalid_input():
     with pytest.raises(TypeError):
         datamodels.open(fits.HDUList())


### PR DESCRIPTION
Resolves [RCAL-991](https://jira.stsci.edu/browse/RCAL-991)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #449

This PR restores (unofficial) support for passing file-like objects to `rdm.open` and updates docstrings to make it "official".

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
