### PR TITLE
add test that ApcorrRefModel arrays can be None

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1092,3 +1092,14 @@ def test_array_compression_override(tmp_path, compression):
     model.save(fn, all_array_compression=compression)
     with asdf.open(fn) as af:
         assert af.get_array_compression(af["roman"]["data"]) == compression
+
+
+def test_apcorr_none_array():
+    """
+    Check that ApcorrRefModel data arrays can be None.
+    """
+    m = utils.mk_datamodel(datamodels.ApcorrRefModel)
+    # data uses a pattern property so no need to test all
+    for name in ("ap_corrections", "ee_fractions", "ee_radii", "sky_background_rin", "sky_background_rout"):
+        setattr(m.data.GRISM, name, None)
+    assert m.validate() is None


### PR DESCRIPTION
This PR adds a test that checks if `ApcorrRefModel` arrays can be `None`.

The test fails with rad main and all versions of asdf due to a bug in the datatype validator.

https://github.com/spacetelescope/rad/pull/542 works around the issue until an upstream fix and release can be made by reordering the `None` check in the `anyOf` combiner. The test added in this PR will provide some safeguard against reintroduction of this bug.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
