### PR TITLE
RCAL-1004 Added support for writing source catalog data models to a parquet file

### DIFF
--- a/changes/473.feature.rst
+++ b/changes/473.feature.rst
@@ -1,0 +1,2 @@
+MosaicSourceCatalogModel and ImageSourceCatalogModel now can be serialized to 
+parquet format using the `to_parquet` method.

--- a/changes/473.feature.rst
+++ b/changes/473.feature.rst
@@ -1,2 +1,2 @@
-MosaicSourceCatalogModel and ImageSourceCatalogModel now can be serialized to 
+MosaicSourceCatalogModel and ImageSourceCatalogModel now can be serialized to
 parquet format using the `to_parquet` method.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
   # "rad >=0.23.1",
   "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
+  "pyarrow >=19.0.1",
+  "pyarrow.parquet"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
   "pyarrow >=19.0.1",
-  "pandas >=2.2.3",
 ]
 dynamic = ["version"]
 
@@ -34,6 +33,7 @@ test = [
   "pytest-doctestplus",
   "pytest-doctestplus >=1.2.1",
   "pytest-env >= 0.8",
+  "pandas >=2.2.3",
 ]
 docs = ["sphinx", "sphinx-automodapi", "sphinx-rtd-theme", "sphinx-astropy"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
   "pyarrow >=19.0.1",
+  "pandas >=2.2.3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
   "pyarrow >=19.0.1",
-  "pyarrow.parquet"
 ]
 dynamic = ["version"]
 

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -25,7 +25,7 @@ DTYPE_MAP = {}
 class _ParquetMixin:
     """Gives SourceCatalogModels the ability to save to parquet files."""
 
-    def to_parquet(self, file=None, fdir=None):
+    def to_parquet(self, filepath):
         """
         Save catalog in parquet format.
 
@@ -51,23 +51,6 @@ class _ParquetMixin:
                     "float64": pa.float64(),
                 }
             )
-
-        if file is None or isinstance(file, str):
-            # Construct output filename
-            if file is not None:
-                if file.endswith('.asdf'):
-                    file = file[:-5]
-                filename_root = pathlib.Path(file)
-            else:
-                    filename_root = pathlib.Path(self.meta.filename[:-5])
-            filename_root = filename_root.with_suffix(".parquet")
-            if fdir is not None:
-                filepath = pathlib.Path(fdir) / filename_root
-            else:
-                filepath = pathlib.Path('.') / filename_root
-        # Otherwise assume it is a file-like object
-        else:
-            filepath = file
 
         # Construct flat metadata dict
         flat_meta = self.to_flat_dict()

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,0 +1,34 @@
+import io
+import numpy as np
+import pytest
+import astropy.table as astrotab
+import pyarrow.parquet as pq
+
+from roman_datamodels import datamodels
+from roman_datamodels import maker_utils as utils
+
+source_catalogs = [
+    (datamodels.ImageSourceCatalogModel, utils.mk_image_source_catalog),
+    (datamodels.MosaicSourceCatalogModel, utils.mk_mosaic_source_catalog),
+]
+
+@pytest.mark.parametrize(("catalog_class","mk_catalog"), source_catalogs)
+def test_source_catalog(catalog_class, mk_catalog):
+    sc_node = mk_catalog(save=False)
+    sc_dm = catalog_class(sc_node)
+    bio = io.BytesIO()
+    sc_dm.to_parquet(file=bio)
+    bio.seek(0)
+
+    ptab = astrotab.Table.read(bio, format='parquet')
+    # Compare columns
+    assert np.all(ptab["a"] == sc_dm.source_catalog["a"])
+    assert np.all(ptab["b"] == sc_dm.source_catalog["b"])
+
+    bio.seek(0)
+    # Spot check metadata.
+    par_schema = pq.read_schema(bio)
+    tabmeta = par_schema.metadata
+    assert(tabmeta[b'roman.meta.telescope'] == sc_dm.meta.telescope.encode('ascii'))
+    # Spot check column metadata.
+    assert(par_schema.field('a').metadata[b'unit'] == str(sc_dm.source_catalog['a'].unit).encode('ascii'))

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,7 +1,7 @@
-import numpy as np
-import pytest
 import astropy.table as astrotab
+import numpy as np
 import pyarrow.parquet as pq
+import pytest
 
 from roman_datamodels import datamodels
 from roman_datamodels import maker_utils as utils
@@ -11,14 +11,15 @@ source_catalogs = [
     (datamodels.MosaicSourceCatalogModel, utils.mk_mosaic_source_catalog),
 ]
 
-@pytest.mark.parametrize(("catalog_class","mk_catalog"), source_catalogs)
+
+@pytest.mark.parametrize(("catalog_class", "mk_catalog"), source_catalogs)
 def test_source_catalog(catalog_class, mk_catalog, tmp_path):
     sc_node = mk_catalog(save=False)
     sc_dm = catalog_class(sc_node)
     test_path = tmp_path / "test.parquet"
     sc_dm.to_parquet(test_path)
 
-    ptab = astrotab.Table.read(test_path, format='parquet')
+    ptab = astrotab.Table.read(test_path, format="parquet")
     # Compare columns
     assert np.all(ptab["a"] == sc_dm.source_catalog["a"])
     assert np.all(ptab["b"] == sc_dm.source_catalog["b"])
@@ -26,6 +27,6 @@ def test_source_catalog(catalog_class, mk_catalog, tmp_path):
     # Spot check metadata.
     par_schema = pq.read_schema(test_path)
     tabmeta = par_schema.metadata
-    assert(tabmeta[b'roman.meta.telescope'] == sc_dm.meta.telescope.encode('ascii'))
+    assert tabmeta[b"roman.meta.telescope"] == sc_dm.meta.telescope.encode("ascii")
     # Spot check column metadata.
-    assert(par_schema.field('a').metadata[b'unit'] == str(sc_dm.source_catalog['a'].unit).encode('ascii'))
+    assert par_schema.field("a").metadata[b"unit"] == str(sc_dm.source_catalog["a"].unit).encode("ascii")


### PR DESCRIPTION
Resolves [RCAL-1004](https://jira.stsci.edu/browse/RCAL-1004)

Closes #472

This PR adds the ability to save source catalog data in I`mageSourceCatalogModel `and `MosaicSourceCatalogModel` in the parquet format. It saves the table metadata and the relevant table column metadata (primarily the unit).

