### PR TITLE
Update mk_mosaic_source_catalog for new schema

### DIFF
--- a/changes/475.feature.rst
+++ b/changes/475.feature.rst
@@ -1,0 +1,1 @@
+Update mk_mosaic_source_catalog for new schema.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=5.3.0",
   # "rad >=0.23.1",
-  "rad @ git+https://github.com/spacetelescope/rad.git",
+  # "rad @ git+https://github.com/spacetelescope/rad.git",
+  "rad @ git+https://github.com/braingram/rad.git@mosaic_source_catalog_schema",
   "asdf-standard >=1.1.0",
 ]
 dynamic = ["version"]

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -426,8 +426,19 @@ def mk_mosaic_source_catalog(*, filepath=None, **kwargs):
     roman_datamodels.stnode.MosaicSourceCatalog
     """
     source_catalog = stnode.MosaicSourceCatalog()
+    if "source_catalog" in kwargs:
+        source_catalog["source_catalog"] = kwargs["source_catalog"]
+    else:
+        column_defs = source_catalog._schema()["properties"]["source_catalog"]["allOf"][-1]["properties"]["columns"]["items"]
+        columns = {}
+        for column_def in column_defs:
+            name = column_def["properties"]["name"]["enum"][0]
+            dtype = column_def["properties"]["data"]["properties"]["datatype"]["enum"][0]
+            if "bool" in dtype:
+                dtype = "bool"
+            columns[name] = np.array([1], dtype)
+        source_catalog["source_catalog"] = Table(columns)
 
-    source_catalog["source_catalog"] = kwargs.get("source_catalog", Table([range(3), range(3)], names=["a", "b"]))
     source_catalog["meta"] = mk_mosaic_catalog_meta(**kwargs.get("meta", {}))
 
     return save_node(source_catalog, filepath=filepath)


### PR DESCRIPTION
Paired with https://github.com/spacetelescope/rad/pull/558

Update mk_mosaic_source_catalog to use the new schema that contains column definitions.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/14228736703

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
