### PR TITLE
Add and use a custom Columns validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=5.3.0",
   # "rad >=0.23.1",
-  "rad @ git+https://github.com/spacetelescope/rad.git",
+  # "rad @ git+https://github.com/spacetelescope/rad.git",
+  "rad @ git+https://github.com/braingram/rad.git@columns_validator",
   "asdf-standard >=1.1.0",
   "pyarrow >=19.0.1",
 ]

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -426,8 +426,21 @@ def mk_mosaic_source_catalog(*, filepath=None, **kwargs):
     roman_datamodels.stnode.MosaicSourceCatalog
     """
     source_catalog = stnode.MosaicSourceCatalog()
+    if "source_catalog" in kwargs:
+        source_catalog["source_catalog"] = kwargs["source_catalog"]
+    else:
+        column_defs = source_catalog._schema()["properties"]["source_catalog"]["columns"]
+        columns = {}
+        for column_def in column_defs:
+            if not column_def.get("required", False):
+                continue
+            name = column_def["name"]
+            dtype = column_def.get("datatype", "float64")
+            if "bool" in dtype:
+                dtype = "bool"
+            columns[name] = np.array([], dtype)
+        source_catalog["source_catalog"] = Table(columns)
 
-    source_catalog["source_catalog"] = kwargs.get("source_catalog", Table([range(3), range(3)], names=["a", "b"]))
     source_catalog["meta"] = mk_mosaic_catalog_meta(**kwargs.get("meta", {}))
 
     return save_node(source_catalog, filepath=filepath)

--- a/src/roman_datamodels/stnode/_converters.py
+++ b/src/roman_datamodels/stnode/_converters.py
@@ -13,6 +13,7 @@ from ._registry import (
     SCALAR_NODE_CLASSES_BY_PATTERN,
 )
 from ._stnode import _MANIFESTS
+from ._validators import _VALIDATORS
 
 __all__ = [
     "NODE_EXTENSIONS",
@@ -114,4 +115,7 @@ class TaggedScalarNodeConverter(_RomanConverter):
 
 
 # Create the ASDF extension for the STNode classes.
-NODE_EXTENSIONS = [ManifestExtension.from_uri(manifest["id"], converters=NODE_CONVERTERS.values()) for manifest in _MANIFESTS]
+NODE_EXTENSIONS = [
+    ManifestExtension.from_uri(manifest["id"], converters=NODE_CONVERTERS.values(), validators=_VALIDATORS)
+    for manifest in _MANIFESTS
+]

--- a/src/roman_datamodels/stnode/_validators.py
+++ b/src/roman_datamodels/stnode/_validators.py
@@ -21,6 +21,8 @@ class TableValidator(Validator):
                 if name not in column_by_name:
                     yield ValidationError(f"Missing required column: {name}")
                     continue
+            elif name not in column_by_name:
+                continue
             column = column_by_name[name]
             if "datatype" in subschema:
                 datatype = column["data"].get("datatype", None)

--- a/src/roman_datamodels/stnode/_validators.py
+++ b/src/roman_datamodels/stnode/_validators.py
@@ -1,0 +1,31 @@
+from asdf.exceptions import ValidationError
+from asdf.extension import Validator
+
+
+class TableValidator(Validator):
+    schema_property = "columns"
+    tags = ("**",)
+
+    def validate(self, schema, node, parent_schema):
+        # node["columns"]  list of "columns"
+        # [{'data': {'shape': [3], 'source': 0, 'datatype': 'int64', 'byteorder': 'little'}, 'name': 'a'}, {'data': {'shape': [3], 'source': 1, 'datatype': 'int64', 'byteorder': 'little'}, 'name': 'b'}]
+        # colnamesk
+        # schema_property_value is the stuff under the property
+        # TODO fail if columns is not a list
+        # assume k = name v = subschema for column
+        column_by_name = {name: column for name, column in zip(node["colnames"], node["columns"], strict=False)}
+
+        for subschema in schema:
+            name = subschema["name"]
+            if "required" in subschema:
+                if name not in column_by_name:
+                    yield ValidationError(f"Missing required column: {name}")
+                    continue
+            column = column_by_name[name]
+            if "datatype" in subschema:
+                datatype = column["data"].get("datatype", None)
+                if subschema["datatype"] != datatype:
+                    yield ValidationError(f"Column {name} has datatype {datatype}, {subschema['datatype']} required")
+
+
+_VALIDATORS = [TableValidator()]

--- a/src/roman_datamodels/stnode/_validators.py
+++ b/src/roman_datamodels/stnode/_validators.py
@@ -7,12 +7,6 @@ class TableValidator(Validator):
     tags = ("**",)
 
     def validate(self, schema, node, parent_schema):
-        # node["columns"]  list of "columns"
-        # [{'data': {'shape': [3], 'source': 0, 'datatype': 'int64', 'byteorder': 'little'}, 'name': 'a'}, {'data': {'shape': [3], 'source': 1, 'datatype': 'int64', 'byteorder': 'little'}, 'name': 'b'}]
-        # colnamesk
-        # schema_property_value is the stuff under the property
-        # TODO fail if columns is not a list
-        # assume k = name v = subschema for column
         column_by_name = {name: column for name, column in zip(node["colnames"], node["columns"], strict=False)}
 
         for subschema in schema:


### PR DESCRIPTION
Paired with https://github.com/spacetelescope/rad/pull/566

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
