### PR TITLE
vendorize and fix contexts workflow from crds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
     outputs:
       data_path: ${{ steps.data_path.outputs.path }}
   crds_contexts:
-    uses: spacetelescope/crds/.github/workflows/contexts.yml@master
+    uses: braingram/crds/.github/workflows/contexts.yml@per_observatory_workflow
+    with:
+      observatory: roman
   romancal:
     needs: [ environment, crds_contexts ]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
     outputs:
       data_path: ${{ steps.data_path.outputs.path }}
   crds_contexts:
-    uses: braingram/crds/.github/workflows/contexts.yml@per_observatory_workflow
-    with:
-      observatory: roman
+    uses: ./.github/workflows/contexts.yml
   romancal:
     needs: [ environment, crds_contexts ]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -1,0 +1,26 @@
+name: contexts
+
+on:
+  workflow_call:
+    outputs:
+      roman:
+        value: ${{ jobs.contexts.outputs.roman }}
+  workflow_dispatch:
+
+jobs:
+  contexts:
+    name: retrieve latest CRDS contexts
+    runs-on: ubuntu-latest
+    outputs:
+      roman: ${{ steps.roman_crds_context.outputs.pmap }}
+    steps:
+      - id: roman_crds_context
+        env:
+          OBSERVATORY: roman
+          CRDS_SERVER_URL: https://roman-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - run: if [[ ! -z "${{ steps.roman_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.roman_crds_context.outputs.pmap }}; else exit 1; fi


### PR DESCRIPTION
The CI is currently failing because hst-crds is down. There is nothing in the tests that require this server and it's use is a byproduct of roman_datamodels using the [contexts](https://github.com/spacetelescope/crds/blob/master/.github/workflows/contexts.yml) workflow from crds.

For "context" the [contexts](https://github.com/spacetelescope/romancal/blob/main/.github/workflows/contexts.yml) workflow was previously copied to romancal (https://github.com/spacetelescope/romancal/pull/1467).

This PR copies the contexts workflow from crds to roman_datamodels and removes jwst and hst server uses.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
