### PR TITLE
Allow source catalog models to be saved with parquet extension

### DIFF
--- a/changes/484.feature.rst
+++ b/changes/484.feature.rst
@@ -1,0 +1,1 @@
+Allow source catalog models to be saved with parquet extension.

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -215,6 +215,8 @@ class DataModel(abc.ABC):
         # TODO: Support gzip-compressed fits
         if ext == ".asdf":
             self.to_asdf(output_path, *args, **kwargs)
+        elif ext == ".parquet" and hasattr(self, "to_parquet"):
+            self.to_parquet(output_path)
         else:
             raise ValueError(f"unknown filetype {ext}")
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -30,3 +30,9 @@ def test_source_catalog(catalog_class, mk_catalog, tmp_path):
     assert tabmeta[b"roman.meta.telescope"] == sc_dm.meta.telescope.encode("ascii")
     # Spot check column metadata.
     assert par_schema.field("a").metadata[b"unit"] == str(sc_dm.source_catalog["a"].unit).encode("ascii")
+
+    # Check that save() works
+    test_path2 = tmp_path / "test2.parquet"
+    sc_dm.save(test_path2)
+    with open(test_path2, "rb") as f:
+        assert f.read(4) == b"PAR1"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Part of [RCAL-1046](https://jira.stsci.edu/browse/RCAL-1046)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR allows source catalog models to use the `save()` method to save the catalog in parquet format.

https://github.com/spacetelescope/romancal/pull/1690 depends on this PR.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
