### PR TITLE
Add astropy table metadata to parquet output

### DIFF
--- a/changes/488.feature.rst
+++ b/changes/488.feature.rst
@@ -1,0 +1,1 @@
+Added astropy table metadata to parquet catalog files.

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -7,8 +7,8 @@ This module provides all the specific datamodels used by the Roman pipeline.
 """
 
 import asdf
-import numpy as np
 import astropy.table.meta
+import numpy as np
 from astropy.table import QTable
 
 from roman_datamodels import stnode
@@ -76,7 +76,7 @@ class _ParquetMixin:
             pa.field(key, type=dtype, metadata={"unit": unit}) for (key, dtype, unit) in zip(keys, dtypes, units, strict=False)
         ]
         extra_astropy_metadata = astropy.table.meta.get_yaml_from_table(source_cat)
-        flat_meta['table_meta_yaml'] = '\n'.join(extra_astropy_metadata)
+        flat_meta["table_meta_yaml"] = "\n".join(extra_astropy_metadata)
         schema = pa.schema(fields, metadata=flat_meta)
         table = pa.Table.from_arrays(arrs, schema=schema)
         pq.write_table(table, filepath, compression=None)

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -8,6 +8,7 @@ This module provides all the specific datamodels used by the Roman pipeline.
 
 import asdf
 import numpy as np
+import astropy.table.meta
 from astropy.table import QTable
 
 from roman_datamodels import stnode
@@ -74,6 +75,8 @@ class _ParquetMixin:
         fields = [
             pa.field(key, type=dtype, metadata={"unit": unit}) for (key, dtype, unit) in zip(keys, dtypes, units, strict=False)
         ]
+        extra_astropy_metadata = astropy.table.meta.get_yaml_from_table(source_cat)
+        flat_meta['table_meta_yaml'] = '\n'.join(extra_astropy_metadata)
         schema = pa.schema(fields, metadata=flat_meta)
         table = pa.Table.from_arrays(arrs, schema=schema)
         pq.write_table(table, filepath, compression=None)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -27,8 +27,7 @@ def test_source_catalog(catalog_class, mk_catalog, tmp_path):
 
     # check that tables round trip
     for cname in ["a", "b"]:
-        assert (ptab[cname].description ==
-                sc_dm.source_catalog[cname].description)
+        assert ptab[cname].description == sc_dm.source_catalog[cname].description
         assert ptab[cname].unit == sc_dm.source_catalog[cname].unit
         assert np.all(ptab[cname] == sc_dm.source_catalog[cname])
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -16,13 +16,21 @@ source_catalogs = [
 def test_source_catalog(catalog_class, mk_catalog, tmp_path):
     sc_node = mk_catalog(save=False)
     sc_dm = catalog_class(sc_node)
+
+    sc_dm.source_catalog["a"].description = "a description"
+    sc_dm.source_catalog["b"].description = "b description"
+
     test_path = tmp_path / "test.parquet"
     sc_dm.to_parquet(test_path)
 
     ptab = astrotab.Table.read(test_path, format="parquet")
-    # Compare columns
-    assert np.all(ptab["a"] == sc_dm.source_catalog["a"])
-    assert np.all(ptab["b"] == sc_dm.source_catalog["b"])
+
+    # check that tables round trip
+    for cname in ["a", "b"]:
+        assert (ptab[cname].description ==
+                sc_dm.source_catalog[cname].description)
+        assert ptab[cname].unit == sc_dm.source_catalog[cname].unit
+        assert np.all(ptab[cname] == sc_dm.source_catalog[cname])
 
     # Spot check metadata.
     par_schema = pq.read_schema(test_path)


### PR DESCRIPTION
This PR adds a new field to the catalog parquet metadata output, table_meta_yaml, to better support astropy's Table.read(...) method.  astropy looks for information in this table to fill out things like table column descriptions and units.

With this PR, astropy tables look like this
```
label     xcentroid          ycentroid         ra_centroid        dec_centroid       aper_bkg_flux       aper_bkg_flux_err   ...       x_psf             x_psf_err             y_psf              y_psf_err            flux_psf          flux_psf_err   
                                                   deg                deg                 uJy                   uJy          ...                                                                                         uJy                 uJy        
int32      float64            float64            float64            float64             float64               float64        ...      float64             float64             float64              float64             float64             float64      
----- ------------------ ------------------ ------------------ ------------------ -------------------- --------------------- ... ------------------ -------------------- ------------------ --------------------- ------------------ -------------------
    1 3107.5641793848517  42.14478665707154 30.102411953272664 44.987236036377105 0.007506220601499081 0.0007226650379779104 ... 3107.5962567666916 0.008446006321761429  42.25312607943128   0.00935998330896384 29.550033445940997  0.3898450679056146
    2   3273.90443956451  46.85926543664257 30.108945192385907   44.9873609690276 0.011104788165539503 0.0009909254350552823 ... 3273.9429928233367 0.009654710513506604 46.991383087661205  0.005123868593818315 47.804684998804674  0.5102734075360951
    3 1027.5074820985774  75.28726347260708  30.02071818407146  44.98820055122564 0.009080739691853523 0.0008211355612551687 ... 1027.6290492829633 0.009623612158641267  75.41621165152297   0.01159528861751296 30.237856484401057   0.401374916753545
```
including the units, while without this they do not have the units.  One can also do things like
```
>>> cat['xcentroid'].description
'X pixel value of the source centroid (0 indexed)'
```

On the other hand, this is a frustrating thing to do because the change adds a new long yaml string to the metadata that recapitulates metadata that is already present in the file, so it's redundant.  But I expect most of our users to get access to these tables via Table.read(...) in astropy and so I think it makes sense overall to make that use case nice.

Thoughts?