### PR TITLE
RCAL-1055: L1 Average FACE Guide Window File Datamodels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         - tomli
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.11.2'
+  rev: 'v0.11.5'
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]

--- a/changes/492.feature.rst
+++ b/changes/492.feature.rst
@@ -1,0 +1,1 @@
+Added L1 Average FACE Guide Window File Datamodels, maker utils, & test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=5.3.0",
   # "rad >=0.23.1",
-  "rad @ git+https://github.com/spacetelescope/rad.git",
+  # "rad @ git+https://github.com/spacetelescope/rad.git",
+  "rad @ git+https://github.com/paulhuwe/rad.git@RAD-204_L1GWFace",  
   "asdf-standard >=1.1.0",
   "pyarrow >=19.0.1",
 ]

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -334,6 +334,10 @@ class AssociationsModel(_DataModel):
         return isinstance(asn_data, dict) and "asn_id" in asn_data and "asn_pool" in asn_data
 
 
+class L1FaceGuidewindowModel(_RomanDataModel):
+    _node_type = stnode.L1FaceGuidewindow
+
+
 class GuidewindowModel(_RomanDataModel):
     _node_type = stnode.Guidewindow
 

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -550,7 +550,7 @@ def mk_l1_face_guidewindow_meta(mode="WSM", **kwargs):
     meta = {}
 
     meta["model_type"] = kwargs.get("model_type", NOSTR)
-    meta["instrument"] = mk_wfi_mode(**kwargs.get("instrument", {}))
+    meta["optical_element"] = kwargs.get("optical_element", "F158")
     meta["fgs_modes_used"] = kwargs.get("fgs_modes_used", ["NOT_CONFIGURED"])
     meta["ma_table_ids_used"] = kwargs.get("ma_table_ids_used", [NOSTR])
     meta["gw_cycles_per_sci_read_used"] = kwargs.get("gw_cycles_per_sci_read_used", [NONUM])

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -540,12 +540,13 @@ def mk_guidewindow_meta(**kwargs):
 
 def mk_l1_face_guidewindow_meta(mode="WSM", **kwargs):
     """
-    Create a dummy common metadata dictionary with valid values for attributes and add
-    the additional guidewindow metadata
+    Create a dummy level 1 face guidewindow metadata dictionary with valid values
+    for attributes
 
     Returns
     -------
-    dict (defined by the common-1.0.0 schema with additional guidewindow metadata)
+    dict (defined by the l1_face_guidewindow-1.0.0 schema with additional guidewindow
+    metadata)
     """
 
     meta = {}

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -536,6 +536,38 @@ def mk_guidewindow_meta(**kwargs):
     return meta
 
 
+
+
+def mk_l1_face_guidewindow_meta(mode="WSM", **kwargs):
+    """
+    Create a dummy common metadata dictionary with valid values for attributes and add
+    the additional guidewindow metadata
+
+    Returns
+    -------
+    dict (defined by the common-1.0.0 schema with additional guidewindow metadata)
+    """
+
+    meta = {}
+
+    meta["model_type"] = kwargs.get("model_type", NOSTR)
+    meta["instrument"] = mk_wfi_mode(**kwargs.get("instrument", {}))
+    meta["fgs_modes_used"] = kwargs.get("fgs_modes_used", ["NOT_CONFIGURED"])
+    meta["ma_table_ids_used"] = kwargs.get("ma_table_ids_used", [NOSTR])
+    meta["gw_cycles_per_sci_read_used"] = kwargs.get("gw_cycles_per_sci_read_used", [NONUM])
+    meta["guide_star_acq_num"] = kwargs.get("guide_star_acq_num", NONUM)
+    meta["guide_window_id"] = kwargs.get("guide_window_id", NOSTR)
+    meta["detector_gw_files"] = kwargs.get("detector_gw_files", {})
+    meta["expected_gw_acquisitions"] = kwargs.get("expected_gw_acquisitions", {})
+    meta["expected_gw_tracking"] = kwargs.get("expected_gw_tracking", {})
+
+    # WSM Only Keywords
+    if mode == "WSM":
+        meta["wsm_edge_used"] = kwargs.get("wsm_edge_used", "blue")
+
+    return meta
+
+
 def mk_msos_stack_meta(**kwargs):
     """
     Create a dummy common metadata dictionary with valid values for attributes and add

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 from astropy import time
-from astropy import time
 from astropy.table import Table
 
 from roman_datamodels import stnode
@@ -12,8 +11,8 @@ from ._common_meta import (
     mk_catalog_meta,
     mk_common_meta,
     mk_guidewindow_meta,
-    mk_l1_face_guidewindow_meta,
     mk_l1_detector_guidewindow_meta,
+    mk_l1_face_guidewindow_meta,
     mk_l2_meta,
     mk_mosaic_catalog_meta,
     mk_mosaic_meta,

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -385,19 +385,20 @@ def mk_l1_face_gw_face_data(*, shape=(16,), filepath=None, **kwargs):
     """
     Create a dummy L1FaceGuidewindow instance (or file) with arrays and valid values
     for attributes required by the schema.
+
     Parameters
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+    mode
+        (optional, keyword-only) Mode of the instrument, image (WIM) or spectrograph (WSM).
     filepath
         (optional, keyword-only) File name and path to write model to.
+
     Returns
     -------
-    roman_datamodels.stnode.L1FaceGuidewindow
+    dict
     """
-    # if len(shape) != 1:
-    #     shape = tuple(shape[0])
-
     if len(shape) != 1:
         shape = (16,)
         warnings.warn("Input shape must be 1D. Defaulting to (16,)", UserWarning, stacklevel=2)
@@ -415,7 +416,6 @@ def mk_l1_face_gw_face_data(*, shape=(16,), filepath=None, **kwargs):
     l1facegw_fd["vertical_variance"] = kwargs.get("vertical_variance", np.zeros(shape, dtype=np.float32))
     l1facegw_fd["num_stars_used"] = kwargs.get("num_stars_used", np.zeros(shape, dtype=np.uint8))
     l1facegw_fd["num_centroid_cycles"] = kwargs.get("num_centroid_cycles", np.zeros(shape, dtype=np.uint8))
-    # l1facegw_fd["attitude_estimate_quality"] = kwargs.get("attitude_estimate_quality", ["AQ_FAILED_IN_PHASE_TRANSITION"] * shape[0])
     l1facegw_fd["attitude_estimate_quality"] = kwargs.get(
         "attitude_estimate_quality", np.array(["AQ_FAILED_IN_PHASE_TRANSITION"] * shape[0], dtype="<U1")
     )
@@ -434,26 +434,27 @@ def mk_l1_face_guidewindow(*, shape=(16,), mode="WSM", filepath=None, **kwargs):
     """
     Create a dummy L1FaceGuidewindow instance (or file) with arrays and valid values
     for attributes required by the schema.
+
     Parameters
     ----------
     shape
         (optional, keyword-only) Shape of arrays in the model.
+    mode
+        (optional, keyword-only) Mode of the instrument, image (WIM) or spectrograph (WSM).
     filepath
         (optional, keyword-only) File name and path to write model to.
+
     Returns
     -------
     roman_datamodels.stnode.L1FaceGuidewindow
     """
-    # if len(shape) != 1:
-    #     shape = tuple(shape[0])
-
     if len(shape) != 1:
         shape = (16,)
-        warnings.warn("Input shape must be 1D. Defaulting to (16,)", UserWarning, stacklevel=2)
+        warnings.warn("Input shape must be 1D. Defaulting to (16,).", UserWarning, stacklevel=2)
 
     if mode not in ["WIM", "WSM"]:
         mode = "WSM"
-        warnings.warn("Mode must be in [WIM, WSM]", UserWarning, stacklevel=2)
+        warnings.warn("Mode must be in [WIM, WSM]. Defaulting to WSM.", UserWarning, stacklevel=2)
 
     l1facegw = stnode.L1FaceGuidewindow()
     l1facegw["meta"] = mk_l1_face_guidewindow_meta(mode, **kwargs.get("meta", {}))

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -416,7 +416,7 @@ def mk_l1_face_gw_face_data(*, shape=(16,), filepath=None, **kwargs):
     l1facegw_fd["num_stars_used"] = kwargs.get("num_stars_used", np.zeros(shape, dtype=np.uint8))
     l1facegw_fd["num_centroid_cycles"] = kwargs.get("num_centroid_cycles", np.zeros(shape, dtype=np.uint8))
     l1facegw_fd["attitude_estimate_quality"] = kwargs.get(
-        "attitude_estimate_quality", np.array(["AQ_FAILED_IN_PHASE_TRANSITION"] * shape[0], dtype="<U1")
+        "attitude_estimate_quality", np.array(["AQ_FAILED_IN_PHASE_TRANSITION"] * shape[0], dtype="<U30")
     )
 
     l1facegw_fd["centroid_times"] = kwargs.get(

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 from astropy.table import Table
+from astropy import time
 
 from roman_datamodels import stnode
 
@@ -17,6 +18,7 @@ from ._common_meta import (
     mk_ramp_meta,
     mk_wcs,
     mk_wfi_wcs_common_meta,
+    mk_l1_face_guidewindow_meta,
 )
 from ._tagged_nodes import mk_cal_logs
 
@@ -376,6 +378,89 @@ def mk_associations(*, shape=(2, 3, 1), filepath=None, **kwargs):
             associations["products"].append({"name": f"product{product_idx}", "members": members_lst})
 
     return save_node(associations, filepath=filepath)
+
+
+
+def mk_l1_face_gw_face_data(*, shape=(16,), filepath=None, **kwargs):
+    """
+    Create a dummy L1FaceGuidewindow instance (or file) with arrays and valid values
+    for attributes required by the schema.
+    Parameters
+    ----------
+    shape
+        (optional, keyword-only) Shape of arrays in the model.
+    filepath
+        (optional, keyword-only) File name and path to write model to.
+    Returns
+    -------
+    roman_datamodels.stnode.L1FaceGuidewindow
+    """
+    # if len(shape) != 1:
+    #     shape = tuple(shape[0])
+
+    if len(shape) != 1:
+        shape = (16,)
+        warnings.warn("Input shape must be 1D. Defaulting to (16,)", UserWarning, stacklevel=2)
+
+    l1facegw_fd = {}
+    l1facegw_fd["delta"] = kwargs.get("delta", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["delta2"] = kwargs.get("delta2", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["epsilon"] = kwargs.get("epsilon", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["epsilon2"] = kwargs.get("epsilon2", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["zeta"] = kwargs.get("zeta", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["delta_var"] = kwargs.get("delta_var", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["epsilon_var"] = kwargs.get("epsilon_var", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["zeta_var"] = kwargs.get("zeta_var", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["horizontal_variance"] = kwargs.get("horizontal_variance", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["vertical_variance"] = kwargs.get("vertical_variance", np.zeros(shape, dtype=np.float32))
+    l1facegw_fd["num_stars_used"] = kwargs.get("num_stars_used", np.zeros(shape, dtype=np.uint8))
+    l1facegw_fd["num_centroid_cycles"] = kwargs.get("num_centroid_cycles", np.zeros(shape, dtype=np.uint8))
+    # l1facegw_fd["attitude_estimate_quality"] = kwargs.get("attitude_estimate_quality", ["AQ_FAILED_IN_PHASE_TRANSITION"] * shape[0])
+    l1facegw_fd["attitude_estimate_quality"] = kwargs.get(
+        "attitude_estimate_quality", np.array(["AQ_FAILED_IN_PHASE_TRANSITION"] * shape[0], dtype="<U1")
+    )
+
+    l1facegw_fd["centroid_times"] = kwargs.get("centroid_times",
+        [time.Time("2024-01-01T12:00:00", format="isot", scale="utc")] * shape[0])
+    l1facegw_fd["fgs_op_phase"] = kwargs.get("fgs_op_phase", ["NOT_CONFIGURED"] * shape[0])
+
+    return l1facegw_fd
+
+
+
+
+
+def mk_l1_face_guidewindow(*, shape=(16,), mode="WSM", filepath=None, **kwargs):
+    """
+    Create a dummy L1FaceGuidewindow instance (or file) with arrays and valid values
+    for attributes required by the schema.
+    Parameters
+    ----------
+    shape
+        (optional, keyword-only) Shape of arrays in the model.
+    filepath
+        (optional, keyword-only) File name and path to write model to.
+    Returns
+    -------
+    roman_datamodels.stnode.L1FaceGuidewindow
+    """
+    # if len(shape) != 1:
+    #     shape = tuple(shape[0])
+
+    if len(shape) != 1:
+        shape = (16,)
+        warnings.warn("Input shape must be 1D. Defaulting to (16,)", UserWarning, stacklevel=2)
+
+    if mode not in ["WIM", "WSM"]:
+        mode = "WSM"
+        warnings.warn("Mode must be in [WIM, WSM]", UserWarning, stacklevel=2)
+
+    l1facegw = stnode.L1FaceGuidewindow()
+    l1facegw["meta"] = mk_l1_face_guidewindow_meta(mode, **kwargs.get("meta", {}))
+    l1facegw["face_data"] = mk_l1_face_gw_face_data(**kwargs.get("face_data", {}))
+
+    return save_node(l1facegw, filepath=filepath)
+
 
 
 def mk_guidewindow(*, shape=(2, 8, 16, 32, 32), filepath=None, **kwargs):

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -25,6 +25,7 @@ def test_maker_utility_implemented(node_class):
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
@@ -39,6 +40,7 @@ def test_instance_valid(node_class):
 
 
 @pytest.mark.parametrize("node_class", [c for c in stnode.NODE_CLASSES if issubclass(c, stnode.TaggedObjectNode)])
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
@@ -101,6 +103,7 @@ def test_deprecated():
 
 
 @pytest.mark.parametrize("model_class", [mdl for mdl in maker_utils.NODE_REGISTRY])
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
@@ -122,6 +125,7 @@ def test_datamodel_maker(model_class):
 
 
 @pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -312,7 +312,7 @@ def test_make_l1_face_guidewindow():
     shape = (12,)
     l1facegw = utils.mk_l1_face_guidewindow(shape=shape, mode="WSM")
 
-    assert l1facegw.meta.instrument.name == "WFI"
+    assert l1facegw.meta.optical_element == "F158"
     assert l1facegw.meta.guide_star_acq_num == -999999
     assert l1facegw.meta.fgs_modes_used == ["NOT_CONFIGURED"]
     assert l1facegw.face_data.delta.dtype == np.float32

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,6 +55,7 @@ def test_datamodel_exists(name):
 
 
 @pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
@@ -304,6 +305,26 @@ def test_read_pattern():
         [11],
     ]
     assert (isinstance(rp, list) for rp in exposure.read_pattern)
+
+
+# L1 Face Guide Window tests
+def test_make_l1_face_guidewindow():
+    shape = (12,)
+    l1facegw = utils.mk_l1_face_guidewindow(shape=shape, mode="WSM")
+
+    assert l1facegw.meta.instrument.name == "WFI"
+    assert l1facegw.meta.guide_star_acq_num == -999999
+    assert l1facegw.meta.fgs_modes_used == ["NOT_CONFIGURED"]
+    assert l1facegw.face_data.delta.dtype == np.float32
+
+    # Ensure WIM model lacks the WSM array set
+    l1facegw_wim = utils.mk_l1_face_guidewindow(shape=(12,), mode="WIM")
+    assert "wsm_edge_used" in l1facegw.meta
+    assert "wsm_edge_used" not in l1facegw_wim.meta
+
+    # Test validation
+    l1facegw_model = datamodels.L1FaceGuidewindowModel(l1facegw)
+    assert l1facegw_model.validate() is None
 
 
 # Guide Window tests
@@ -964,6 +985,7 @@ def test_model_validate_without_save():
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
 @pytest.mark.parametrize("node", datamodels.MODEL_REGISTRY.keys())
 @pytest.mark.parametrize("correct, model", datamodels.MODEL_REGISTRY.items())
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
@@ -1082,6 +1104,7 @@ def test_science_raw_from_tvac_raw(mk_tvac):
 
 
 @pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -193,6 +193,7 @@ def test_no_memmap(tmp_path, kwargs):
 
 
 @pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
@@ -206,6 +207,7 @@ def test_node_round_trip(tmp_path, node_class):
 
 
 @pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -224,7 +224,7 @@ def test_opening_model(tmp_path, node_class):
             assert model.asn_type == "image"
         elif node_class == stnode.WfiMosaic:
             assert model.meta.basic.optical_element == "F158"
-        elif node_class in (stnode.SegmentationMap, stnode.ImageSourceCatalog):
+        elif node_class in (stnode.SegmentationMap, stnode.ImageSourceCatalog, stnode.L1FaceGuidewindow):
             assert model.meta.optical_element == "F158"
         elif node_class in (stnode.MosaicSegmentationMap, stnode.MosaicSourceCatalog):
             assert hasattr(model.meta, "basic")

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -301,7 +301,7 @@ def test_node_representation(model):
             assert mdl.meta.model_type == model_types[type(mdl)]
             assert mdl.meta.telescope == "ROMAN"
             assert mdl.meta.filename == NOFN
-        elif isinstance(mdl, datamodels.SegmentationMapModel | datamodels.ImageSourceCatalogModel):
+        elif isinstance(mdl, datamodels.SegmentationMapModel | datamodels.ImageSourceCatalogModel | datamodels.L1FaceGuidewindowModel):
             assert mdl.meta.optical_element == "F158"
         else:
             assert repr(mdl.meta.instrument) == repr(

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -35,6 +35,7 @@ def test_node_classes_available_via_stnode(node_class):
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
@@ -54,6 +55,7 @@ def test_copy(node_class):
 
 
 @pytest.mark.parametrize("node_class", datamodels.MODEL_REGISTRY.keys())
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
@@ -96,6 +98,7 @@ def test_wfi_mode():
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -301,7 +301,9 @@ def test_node_representation(model):
             assert mdl.meta.model_type == model_types[type(mdl)]
             assert mdl.meta.telescope == "ROMAN"
             assert mdl.meta.filename == NOFN
-        elif isinstance(mdl, datamodels.SegmentationMapModel | datamodels.ImageSourceCatalogModel | datamodels.L1FaceGuidewindowModel):
+        elif isinstance(
+            mdl, datamodels.SegmentationMapModel | datamodels.ImageSourceCatalogModel | datamodels.L1FaceGuidewindowModel
+        ):
             assert mdl.meta.optical_element == "F158"
         else:
             assert repr(mdl.meta.instrument) == repr(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1055](https://jira.stsci.edu/browse/RCAL-1055)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1708

<!-- describe the changes comprising this PR here -->
This PR adds L1 Average FACE Guide Window File Datamodels, maker utils, & test.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] Update or add relevant `roman_datamodels` tests.
- [x] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [x] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
