### PR TITLE
relax pyarrow version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   # "rad >=0.23.1",
   "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
-  "pyarrow >=19.0.1",
+  "pyarrow >= 10.0.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Relax the required pyarrow version to allow https://github.com/spacetelescope/romancal/pull/1709

Regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/14523350619

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
