### PR TITLE
fix failing docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ New Features
   adjusted for the integer keywords in the datamodel. (`#469
   <https://github.com/spacetelescope/roman_datamodels/issues/469>`_)
 - MosaicSourceCatalogModel and ImageSourceCatalogModel now can be serialized to
-  parquet format using the `to_parquet` method. (`#473
+  parquet format using the ``to_parquet`` method. (`#473
   <https://github.com/spacetelescope/roman_datamodels/issues/473>`_)
 - Added epsf and apcorr to ref_files and ref_files to image_source_catalog.
   (`#474 <https://github.com/spacetelescope/roman_datamodels/issues/474>`_)


### PR DESCRIPTION
Fixes: #497

Once merged this can be backported to the 0.24.x and 0.24.1 released to fix the docs.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
