### PR TITLE
backport: fix failing docs (#498) to 0.24.x release branch.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ New Features
   adjusted for the integer keywords in the datamodel. (`#469
   <https://github.com/spacetelescope/roman_datamodels/issues/469>`_)
 - MosaicSourceCatalogModel and ImageSourceCatalogModel now can be serialized to
-  parquet format using the `to_parquet` method. (`#473
+  parquet format using the ``to_parquet`` method. (`#473
   <https://github.com/spacetelescope/roman_datamodels/issues/473>`_)
 - Added epsf and apcorr to ref_files and ref_files to image_source_catalog.
   (`#474 <https://github.com/spacetelescope/roman_datamodels/issues/474>`_)


### PR DESCRIPTION
Once this is merged I think we need a 0.24.1 release to fix the docs.