### PR TITLE
Remove duplicate build section from readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,15 +23,6 @@ conda:
   environment: docs/rtd_environment.yaml
 
 # Optionally set the version of Python and requirements required to build your docs
-build:
-  os: ubuntu-22.04
-  tools:
-    python: mambaforge-4.10
-
-conda:
-  environment: docs/rtd_environment.yaml
-
-# Optionally set the version of Python and requirements required to build your docs
 python:
   install:
     - method: pip

--- a/changes/501.doc.rst
+++ b/changes/501.doc.rst
@@ -1,0 +1,1 @@
+Remove duplicate build section from readthedocs config.


### PR DESCRIPTION
Closes #500 

This PR removes the 2nd (duplicate) `build` section in `.readthedocs.yaml`. This was causing readthedocs to not build the changelog for PRs (since that command was in the first, ignored, build section).

Here is an example of how it correctly fails with this PR:
https://app.readthedocs.org/projects/roman-datamodels/builds/27931940/
when an invalid changelog fragment is added: https://github.com/spacetelescope/roman_datamodels/pull/501/commits/2f7fd8c312dbcc2c000d49cb3f7bd36122d1f048

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
