### PR TITLE
validate before saving to parquet

### DIFF
--- a/changes/503.bugfix.rst
+++ b/changes/503.bugfix.rst
@@ -1,0 +1,1 @@
+Use asdf to validate before saving catalog to parquet.

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -35,6 +35,9 @@ class _ParquetMixin:
 
         Defers import of parquet to minimize import overhead for all other models.
         """
+        # parquet does not provide validation so validate first with asdf
+        self.validate()
+
         global DTYPE_MAP
         import pyarrow as pa
         import pyarrow.parquet as pq


### PR DESCRIPTION
This PR adds a call to `validate` before saving a catalog to parquet in `to_parquet`. This is required to make use of a catalog schema.

regtests pass: https://github.com/spacetelescope/RegressionTests/actions/runs/14718494431

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
