### PR TITLE
use a module named not the root logger

### DIFF
--- a/changes/506.bugfix.rst
+++ b/changes/506.bugfix.rst
@@ -1,0 +1,1 @@
+Use a non-root logger.

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -22,7 +22,7 @@ __all__ = []
 DTYPE_MAP = {}
 
 # Define logging
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 


### PR DESCRIPTION
https://github.com/spacetelescope/roman_datamodels/pull/477 introduced code that set the root logger level to DEBUG.

This PR switches the logger to use a non-root logger (named by the module) which is likely what was intended in the original PR.

Given the disruption to downstream I think this is worth a bugfix release.

Closes #505

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
