### PR TITLE
fix bug where nodes couldn't be deep copied

### DIFF
--- a/changes/511.bugfix.rst
+++ b/changes/511.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where nodes couldn't be deepcopied after use.

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -57,7 +57,7 @@ class SchemaProperties:
     """
 
     def __init__(self, explicit_properties, patterns):
-        self.explicit_properties = explicit_properties
+        self.explicit_properties = set(explicit_properties)
         self.patterns = patterns
 
     def __contains__(self, attr):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 import warnings
 from contextlib import nullcontext
+from copy import deepcopy
 
 import asdf
 import numpy as np
@@ -1301,3 +1302,14 @@ def test_wfi_wcs_no_wcs(caplog):
     assert not hasattr(wfi_wcs, "wcs_l2")
 
     assert "Model has no WCS defined" in caplog.text
+
+
+def test_deepcopy_after_use():
+    """
+    Test that nodes constructed from using models can be copied
+
+    See: https://github.com/spacetelescope/roman_datamodels/issues/486
+    """
+    m = datamodels.ImageModel()
+    m.meta = {}
+    deepcopy(m.meta)


### PR DESCRIPTION
Closes #486

Adds a test for and fixes an issue where a node could not be deepcopied after use (where `_schema_attributes` is cached).

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/14893660078

Oldest deps failure is unrelated.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
