### PR TITLE
fix meta.filename for parquet files

### DIFF
--- a/changes/513.bugfix.rst
+++ b/changes/513.bugfix.rst
@@ -1,0 +1,1 @@
+Fix meta.filename for writing to parquet.

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -14,7 +14,7 @@ import numpy as np
 from astropy.modeling import models
 
 from .. import stnode
-from ._core import DataModel
+from ._core import DataModel, _temporary_update_filename
 from ._utils import _node_update
 
 __all__ = []
@@ -60,8 +60,9 @@ class _ParquetMixin:
                 }
             )
 
-        # Construct flat metadata dict
-        flat_meta = self.to_flat_dict()
+        with _temporary_update_filename(self, filepath):
+            # Construct flat metadata dict
+            flat_meta = self.to_flat_dict()
         # select only meta items
         flat_meta = {k: str(v) for (k, v) in flat_meta.items() if k.startswith("roman.meta")}
         # Extract table metadata

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -42,6 +42,9 @@ def test_source_catalog(catalog_class, tmp_path):
     # Spot check column metadata.
     assert par_schema.field("a").metadata[b"unit"] == str(sc_dm.source_catalog["a"].unit).encode("ascii")
 
+    # check that the filename was recorded
+    assert tabmeta[b"roman.meta.filename"] == bytes(test_path)
+
     # Check that save() works
     test_path2 = tmp_path / "test2.parquet"
     sc_dm.save(test_path2)


### PR DESCRIPTION
Fix `meta.filename` when writing to parquet.

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/15000533374

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
