### PR TITLE
RAD-195: Move `mosaic.cal_logs` to `mosaic.meta.cal_logs` 

### DIFF
--- a/changes/516.feature.rst
+++ b/changes/516.feature.rst
@@ -1,0 +1,2 @@
+Update ``roman_datamodels`` to support moving ``mosaic.cal_logs`` to
+``mosaic.meta.cal_logs`` for consistency with ``wfi_image.meta.cal_logs``.

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -460,6 +460,7 @@ def mk_mosaic_meta(**kwargs):
     meta = mk_basic_meta(**kwargs)
     meta["basic"] = mk_mosaic_basic(**kwargs.get("basic", {}))
     meta["asn"] = mk_mosaic_associations(**kwargs.get("asn", {}))
+    meta["cal_logs"] = mk_cal_logs(**kwargs)
     meta["cal_step"] = mk_l3_cal_step(**kwargs.get("cal_step", {}))
     meta["coordinates"] = mk_coordinates(**kwargs.get("coordinates", {}))
     meta["individual_image_meta"] = mk_individual_image_meta(**kwargs.get("individual_image_meta", {}))

--- a/src/roman_datamodels/maker_utils/_datamodels.py
+++ b/src/roman_datamodels/maker_utils/_datamodels.py
@@ -20,7 +20,6 @@ from ._common_meta import (
     mk_wcs,
     mk_wfi_wcs_common_meta,
 )
-from ._tagged_nodes import mk_cal_logs
 
 
 def mk_level1_science_raw(*, shape=(8, 4096, 4096), dq=False, filepath=None, **kwargs):
@@ -188,7 +187,6 @@ def mk_level3_mosaic(*, shape=(4088, 4088), n_images=2, filepath=None, **kwargs)
     wfi_mosaic["var_poisson"] = kwargs.get("var_poisson", np.zeros(shape, dtype=np.float32))
     wfi_mosaic["var_rnoise"] = kwargs.get("var_rnoise", np.zeros(shape, dtype=np.float32))
     wfi_mosaic["var_flat"] = kwargs.get("var_flat", np.zeros(shape, dtype=np.float32))
-    wfi_mosaic["cal_logs"] = mk_cal_logs(**kwargs)
 
     wfi_mosaic["meta"]["wcs"] = mk_wcs()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -732,7 +732,7 @@ def test_make_level3_mosaic():
     assert wfi_mosaic.var_poisson.dtype == np.float32
     assert wfi_mosaic.var_rnoise.dtype == np.float32
     assert wfi_mosaic.var_flat.dtype == np.float32
-    assert isinstance(wfi_mosaic.cal_logs[0], str)
+    assert isinstance(wfi_mosaic.meta.cal_logs[0], str)
 
     # Test validation
     wfi_mosaic_model = datamodels.MosaicModel(wfi_mosaic)


### PR DESCRIPTION
Resolves [RAD-195](https://jira.stsci.edu/browse/RAD-195)

<!-- describe the changes comprising this PR here -->
This PR is the update to `roman_datamodels` to support the changes in spacetelescope/rad#601

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
