### PR TITLE
Fixes for `maxLength` and `nvarchar` updates to RAD

### DIFF
--- a/changes/517.bugfix.rst
+++ b/changes/517.bugfix.rst
@@ -1,0 +1,2 @@
+Fixes for the FPS/TVAC ``maker_utils`` to include fields now actively required by
+the schemas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "astropy >=5.3.0",
   "rad >=0.25.0",
   # "rad @ git+https://github.com/spacetelescope/rad.git",
+  "rad @ git+https://github.com/WilliamJamieson/rad.git@maxLength",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
 ]

--- a/src/roman_datamodels/maker_utils/_fps_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_fps_common_meta.py
@@ -139,6 +139,7 @@ def mk_fps_ref_file(**kwargs):
     ref_file["linearity"] = kwargs.get("linearity", "N/A")
     ref_file["mask"] = kwargs.get("mask", "N/A")
     ref_file["readnoise"] = kwargs.get("readnoise", "N/A")
+    ref_file["area"] = kwargs.get("area", "N/A")
     ref_file["saturation"] = kwargs.get("saturation", "N/A")
     ref_file["photom"] = kwargs.get("photom", "N/A")
     ref_file["crds"] = kwargs.get("crds", {"sw_version": "12.3.1", "context_used": "roman_0815.pmap"})

--- a/src/roman_datamodels/maker_utils/_tvac_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_tvac_common_meta.py
@@ -139,6 +139,7 @@ def mk_tvac_ref_file(**kwargs):
     ref_file["linearity"] = kwargs.get("linearity", "N/A")
     ref_file["mask"] = kwargs.get("mask", "N/A")
     ref_file["readnoise"] = kwargs.get("readnoise", "N/A")
+    ref_file["area"] = kwargs.get("area", "N/A")
     ref_file["saturation"] = kwargs.get("saturation", "N/A")
     ref_file["photom"] = kwargs.get("photom", "N/A")
     ref_file["crds"] = kwargs.get("crds", {"sw_version": "12.3.1", "context_used": "roman_0815.pmap"})


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR updates `roman_datamodels` to fix issues arising from the changes in spacetelescope/rad#611. In that PR, the TVAC/FPS schemas experienced a version bump which meant that the long standing issue of required items in the schemas could finally be resolved. This meant that `fps/tvac.meta.ref_file.area` became actively required, which was not being included by the maker utils.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
