### PR TITLE
Update RDM to support a "static" manifest

### DIFF
--- a/changes/518.bugfix.rst
+++ b/changes/518.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in RDM caused by RAD's new "static" manifest.

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -226,9 +226,15 @@ class DataModel(abc.ABC):
         return MODEL_REGISTRY[asdf_file.tree["roman"].__class__] == self.__class__
 
     @property
+    def _latest_manifest_uri(self):
+        return self._node_type._latest_manifest
+
+    @property
     def schema_uri(self):
         # Determine the schema corresponding to this model's tag
-        return next(t for t in stnode.NODE_EXTENSIONS[0].tags if t.tag_uri == self._instance._tag).schema_uris[0]
+        return next(
+            t for t in stnode.NODE_EXTENSIONS[self._latest_manifest_uri].tags if t.tag_uri == self._instance._tag
+        ).schema_uris[0]
 
     def close(self):
         if not (self._iscopy or self._asdf is None):

--- a/src/roman_datamodels/stnode/_converters.py
+++ b/src/roman_datamodels/stnode/_converters.py
@@ -114,4 +114,6 @@ class TaggedScalarNodeConverter(_RomanConverter):
 
 
 # Create the ASDF extension for the STNode classes.
-NODE_EXTENSIONS = [ManifestExtension.from_uri(manifest["id"], converters=NODE_CONVERTERS.values()) for manifest in _MANIFESTS]
+NODE_EXTENSIONS = {
+    manifest["id"]: ManifestExtension.from_uri(manifest["id"], converters=NODE_CONVERTERS.values()) for manifest in _MANIFESTS
+}

--- a/src/roman_datamodels/stnode/_factories.py
+++ b/src/roman_datamodels/stnode/_factories.py
@@ -3,6 +3,8 @@ Factories for creating Tagged STNode classes from tag_uris.
     These are used to dynamically create classes from the RAD manifest.
 """
 
+from typing import Any
+
 from astropy.time import Time
 
 from . import _mixins
@@ -22,7 +24,7 @@ _NODE_TYPE_BY_PATTERN = {
 }
 
 
-def class_name_from_tag_uri(tag_uri):
+def class_name_from_tag_uri(tag_uri: str) -> str:
     """
     Construct the class name for the STNode class from the tag_uri
 
@@ -43,7 +45,7 @@ def class_name_from_tag_uri(tag_uri):
     return class_name
 
 
-def docstring_from_tag(tag_def):
+def docstring_from_tag(tag_def: dict[str, Any]) -> str:
     """
     Read the docstring (if it exists) from the RAD manifest and generate a docstring
         for the dynamically generated class.
@@ -62,7 +64,7 @@ def docstring_from_tag(tag_def):
     return docstring + f"Class generated from tag '{tag_def['tag_uri']}'"
 
 
-def scalar_factory(pattern, tag_def):
+def scalar_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedScalarNode]:
     """
     Factory to create a TaggedScalarNode class from a tag
 
@@ -70,6 +72,9 @@ def scalar_factory(pattern, tag_def):
     ----------
     pattern: str
         A tag pattern/wildcard
+
+    latest_manifest: str
+        URI for the latest manifest
 
     tag_def: dict
         A tag entry from the RAD manifest
@@ -102,6 +107,7 @@ def scalar_factory(pattern, tag_def):
         class_type,
         {
             "_pattern": pattern,
+            "_latest_manifest": latest_manifest,
             "_default_tag": tag_def["tag_uri"],
             "__module__": "roman_datamodels.stnode",
             "__doc__": docstring_from_tag(tag_def),
@@ -109,7 +115,7 @@ def scalar_factory(pattern, tag_def):
     )
 
 
-def node_factory(pattern, tag_def):
+def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedObjectNode | TaggedListNode]:
     """
     Factory to create a TaggedObjectNode or TaggedListNode class from a tag
 
@@ -117,6 +123,9 @@ def node_factory(pattern, tag_def):
     ----------
     pattern: str
         A tag pattern/wildcard
+
+    latest_manifest: str
+        URI for the latest manifest
 
     tag_def: dict
         A tag entry from the RAD manifest
@@ -142,6 +151,7 @@ def node_factory(pattern, tag_def):
         class_type,
         {
             "_pattern": pattern,
+            "_latest_manifest": latest_manifest,
             "_default_tag": tag_def["tag_uri"],
             "__module__": "roman_datamodels.stnode",
             "__doc__": docstring_from_tag(tag_def),
@@ -149,7 +159,9 @@ def node_factory(pattern, tag_def):
     )
 
 
-def stnode_factory(pattern, tag_def):
+def stnode_factory(
+    pattern: str, latest_manifest: str, tag_def: dict[str, Any]
+) -> type[TaggedObjectNode | TaggedListNode | TaggedScalarNode]:
     """
     Construct a tagged STNode class from a tag
 
@@ -157,6 +169,9 @@ def stnode_factory(pattern, tag_def):
     ----------
     pattern: str
         A tag pattern/wildcard
+
+    latest_manifest: str
+        URI for the latest manifest
 
     tag_def: dict
         A tag entry from the RAD manifest
@@ -168,6 +183,6 @@ def stnode_factory(pattern, tag_def):
     # TaggedScalarNodes are a special case because they are not a subclass of a
     #   _node class, but rather a subclass of the type of the scalar.
     if "tagged_scalar" in tag_def["schema_uri"]:
-        return scalar_factory(pattern, tag_def)
+        return scalar_factory(pattern, latest_manifest, tag_def)
     else:
-        return node_factory(pattern, tag_def)
+        return node_factory(pattern, latest_manifest, tag_def)

--- a/src/roman_datamodels/stnode/_integration.py
+++ b/src/roman_datamodels/stnode/_integration.py
@@ -10,4 +10,4 @@ def get_extensions():
     """
     from ._converters import NODE_EXTENSIONS
 
-    return NODE_EXTENSIONS
+    return list(NODE_EXTENSIONS.values())

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -23,6 +23,7 @@ class DNode(MutableMapping):
     """
 
     _pattern = None
+    _latest_manifest = None
 
     def __init__(self, node=None, parent=None, name=None):
         # Handle if we are passed different data types
@@ -202,6 +203,7 @@ class LNode(UserList):
     """
 
     _pattern = None
+    _latest_manifest = None
 
     def __init__(self, node=None):
         if node is None:

--- a/src/roman_datamodels/stnode/_stnode.py
+++ b/src/roman_datamodels/stnode/_stnode.py
@@ -30,8 +30,12 @@ __all__ = [
 #   and this module creates the classes used by the ASDF extension.
 _MANIFEST_DIR = importlib.resources.files(resources) / "manifests"
 # sort manifests by version (newest first)
-_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*.yaml")], reverse=True)
-_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _MANIFEST_PATHS]
+_STATIC_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*static-*.yaml")], reverse=True)
+_STATIC_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _STATIC_MANIFEST_PATHS]
+_DATAMODEL_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")], reverse=True)
+_DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
+# Notice that the static manifests are first so that we defer to them
+_MANIFESTS = _STATIC_MANIFESTS + _DATAMODEL_MANIFESTS
 
 
 def _factory(pattern, latest_manifest, tag_def):

--- a/src/roman_datamodels/stnode/_stnode.py
+++ b/src/roman_datamodels/stnode/_stnode.py
@@ -34,12 +34,12 @@ _MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*.yaml")], revers
 _MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _MANIFEST_PATHS]
 
 
-def _factory(pattern, tag_def):
+def _factory(pattern, latest_manifest, tag_def):
     """
     Wrap the __all__ append and class creation in a function to avoid the linter
         getting upset
     """
-    cls = stnode_factory(pattern, tag_def)
+    cls = stnode_factory(pattern, latest_manifest, tag_def)
 
     class_name = cls.__name__
     globals()[class_name] = cls  # Add to namespace of module
@@ -51,13 +51,14 @@ def _factory(pattern, tag_def):
 #   Reads each tag entry from the manifest and creates a class for it
 _generated = {}
 for manifest in _MANIFESTS:
+    manifest_uri = manifest["id"]
     for tag_def in manifest["tags"]:
         SCHEMA_URIS_BY_TAG[tag_def["tag_uri"]] = tag_def["schema_uri"]
         # make pattern from tag
         base, _ = tag_def["tag_uri"].rsplit("-", maxsplit=1)
         pattern = f"{base}-*"
         if pattern not in _generated:
-            _generated[pattern] = _factory(pattern, tag_def)
+            _generated[pattern] = _factory(pattern, manifest_uri, tag_def)
         NODE_CLASSES_BY_TAG[tag_def["tag_uri"]] = _generated[pattern]
 
 

--- a/src/roman_datamodels/stnode/_tagged.py
+++ b/src/roman_datamodels/stnode/_tagged.py
@@ -126,6 +126,7 @@ class TaggedScalarNode:
     """
 
     _pattern = None
+    _latest_manifest = None
 
     def __init_subclass__(cls, **kwargs) -> None:
         """


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses some tiny issues that arise in RDM when introducing the "static" manifest in spacetelescope/rad#617. This should resolve those issues.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
