### PR TITLE
fix DataModel.__deepcopy__

### DIFF
--- a/changes/522.bugfix.rst
+++ b/changes/522.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where DataModel.__deepcopy__ returned a shallow copy.

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -249,7 +249,10 @@ class DataModel(abc.ABC):
         self.clone(result, self, deepcopy=deepcopy, memo=memo)
         return result
 
-    __copy__ = __deepcopy__ = copy
+    __copy__ = copy
+
+    def __deepcopy__(self, memo=None):
+        return self.copy(deepcopy=True, memo=memo)
 
     @staticmethod
     def clone(target, source, deepcopy=False, memo=None):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels, stnode, validate
 from roman_datamodels import maker_utils as utils
-from roman_datamodels.testing import assert_node_equal
+from roman_datamodels.testing import assert_node_equal, assert_node_is_copy
 
 from .conftest import MANIFESTS
 
@@ -1342,3 +1342,14 @@ def test_create_minimal_copies(model, tmp_path):
     del opened_model
     gc.collect(2)
     assert new_model.validate() is None
+
+
+def test_deepcopy_is_deep():
+    """
+    Test that a deepcopy of a datamodel results in a deep copy.
+    """
+    model = datamodels.ImageModel(utils.mk_level2_image(shape=(8, 8)))
+    model_copy = deepcopy(model)
+    assert model_copy is not model
+    assert model_copy.data is not model.data
+    assert_node_is_copy(model_copy._instance, model._instance, True)


### PR DESCRIPTION
Fixes an issue where a deepcopy of a `DataModel` resulted in a shallow copy.

Closes #521

Romancal regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/15348453481

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
