### PR TITLE
update rad pin to main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
   "gwcs >=0.19.0",
   "numpy >=1.24",
   "astropy >=5.3.0",
-  "rad >=0.25.0",
-  # "rad @ git+https://github.com/spacetelescope/rad.git",
+  # "rad >=0.25.0",
+  "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
 ]


### PR DESCRIPTION
This PR updates the rad pin to main. This will be required for upcoming rad/roman_datamodels changes. This will also cause the romancal nightly run to show some of the failures that are on the devdeps run (the ones corresponding to existing rad changes).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
