### PR TITLE
Remove usage of outdated exposure types

### DIFF
--- a/changes/537.bugfix.rst
+++ b/changes/537.bugfix.rst
@@ -1,0 +1,1 @@
+Remove use of out of date ``exposure_types``.

--- a/src/roman_datamodels/maker_utils/_common_meta.py
+++ b/src/roman_datamodels/maker_utils/_common_meta.py
@@ -763,7 +763,7 @@ def _mk_ref_exposure(**kwargs):
     """
     exposure = {}
     exposure["type"] = kwargs.get("type", "WFI_IMAGE")
-    exposure["p_exptype"] = kwargs.get("p_exptype", "WFI_IMAGE|WFI_GRISM|WFI_PRISM|")
+    exposure["p_exptype"] = kwargs.get("p_exptype", "WFI_IMAGE|WFI_SPECTRAL|WFI_FLAT|")
 
     return exposure
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR fixes spacetelescope/rad#636 changes in RDM, by changing the usage of some of the exposure_types to non-outdated ones.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
