### PR TITLE
Minor bugfixes concerning attributes

### DIFF
--- a/changes/538.bugfix.rst
+++ b/changes/538.bugfix.rst
@@ -1,3 +1,3 @@
 Minor bugfixes for node and datamodels attributes including, raising explicit errors
-when attemppting to set private variables outside of RDM internal code and adding a
+when attempting to set private variables outside of RDM internal code and adding a
 ``__delattr__`` method to allow the deletion of attributes for both nodes and datamodels.

--- a/changes/538.bugfix.rst
+++ b/changes/538.bugfix.rst
@@ -1,0 +1,3 @@
+Minor bugfixes for node and datamodels attributes including, raising explicit errors
+when attemppting to set private variables outside of RDM internal code and adding a
+``__delattr__`` method to allow the deletion of attributes for both nodes and datamodels.

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -152,6 +152,8 @@ class DataModel(abc.ABC):
         """
         return cls(cls._node_type.create_fake_data(defaults, shape))
 
+    __slots__ = ("_asdf", "_files_to_close", "_instance", "_iscopy", "_shape")
+
     @classmethod
     def create_from_model(cls, model):
         """
@@ -168,11 +170,11 @@ class DataModel(abc.ABC):
             # Due to __new__ above, this is already initialized.
             return
 
-        self.__dict__["_iscopy"] = False
-        self.__dict__["_shape"] = None
-        self.__dict__["_instance"] = None
-        self.__dict__["_asdf"] = None
-        self.__dict__["_files_to_close"] = None
+        self._iscopy = False
+        self._shape = None
+        self._instance = None
+        self._asdf = None
+        self._files_to_close = None
 
         if isinstance(init, stnode.TaggedObjectNode):
             if not isinstance(self, MODEL_REGISTRY.get(init.__class__)):
@@ -332,8 +334,8 @@ class DataModel(abc.ABC):
         return self._shape
 
     def __setattr__(self, attr, value):
-        if attr.startswith("_") and attr in self.__dict__:
-            self.__dict__[attr] = value
+        if attr.startswith("_") and attr in DataModel.__slots__:
+            DataModel.__dict__[attr].__set__(self, value)
         else:
             setattr(self._instance, attr, value)
 
@@ -341,7 +343,7 @@ class DataModel(abc.ABC):
         return getattr(self._instance, attr)
 
     def __delattr__(self, attr):
-        if attr.startswith("_") and attr in self.__dict__:
+        if attr.startswith("_") and attr in DataModel.__slots__:
             super().__delattr__(attr)
         else:
             delattr(self._instance, attr)

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -168,10 +168,11 @@ class DataModel(abc.ABC):
             # Due to __new__ above, this is already initialized.
             return
 
-        self._iscopy = False
-        self._shape = None
-        self._instance = None
-        self._asdf = None
+        self.__dict__["_iscopy"] = False
+        self.__dict__["_shape"] = None
+        self.__dict__["_instance"] = None
+        self.__dict__["_asdf"] = None
+        self.__dict__["_files_to_close"] = None
 
         if isinstance(init, stnode.TaggedObjectNode):
             if not isinstance(self, MODEL_REGISTRY.get(init.__class__)):
@@ -331,7 +332,7 @@ class DataModel(abc.ABC):
         return self._shape
 
     def __setattr__(self, attr, value):
-        if attr.startswith("_"):
+        if attr.startswith("_") and attr in self.__dict__:
             self.__dict__[attr] = value
         else:
             setattr(self._instance, attr, value)

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -340,6 +340,12 @@ class DataModel(abc.ABC):
     def __getattr__(self, attr):
         return getattr(self._instance, attr)
 
+    def __delattr__(self, attr):
+        if attr.startswith("_") and attr in self.__dict__:
+            super().__delattr__(attr)
+        else:
+            delattr(self._instance, attr)
+
     def __setitem__(self, key, value):
         if key.startswith("_"):
             raise ValueError("May not specify attributes/keys that start with _")

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -31,6 +31,8 @@ log.setLevel(logging.DEBUG)
 
 
 class _SourceCatalogMixin:
+    __slots__ = ()
+
     def create_empty_catalog(self, aperture_radii=None, filters=None):
         """
         Create an empty but valid source catalog table
@@ -59,6 +61,8 @@ class _SourceCatalogMixin:
 
 class _ParquetMixin:
     """Gives SourceCatalogModels the ability to save to parquet files."""
+
+    __slots__ = ()
 
     def to_parquet(self, filepath):
         """
@@ -128,6 +132,8 @@ class _DataModel(DataModel):
         documentation generation to work properly.
     """
 
+    __slots__ = ()
+
     def __init_subclass__(cls, **kwargs):
         """Register each subclass in the __all__ for this module"""
         super().__init_subclass__(**kwargs)
@@ -143,6 +149,8 @@ class _DataModel(DataModel):
 
 
 class _RomanDataModel(_DataModel):
+    __slots__ = ()
+
     def __init__(self, init=None, **kwargs):
         super().__init__(init, **kwargs)
 
@@ -151,14 +159,17 @@ class _RomanDataModel(_DataModel):
 
 
 class MosaicModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.WfiMosaic
 
 
 class ImageModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.WfiImage
 
 
 class ScienceRawModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.WfiScienceRaw
 
     @classmethod
@@ -214,10 +225,12 @@ class ScienceRawModel(_RomanDataModel):
 
 
 class MsosStackModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.MsosStack
 
 
 class RampModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.Ramp
 
     @classmethod
@@ -283,10 +296,12 @@ class RampModel(_RomanDataModel):
 
 
 class RampFitOutputModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.RampFitOutput
 
 
 class AssociationsModel(_DataModel):
+    __slots__ = ()
     # Need an init to allow instantiation from a JSON file
     _node_type = stnode.Associations
 
@@ -304,50 +319,62 @@ class AssociationsModel(_DataModel):
 
 
 class L1FaceGuidewindowModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.L1FaceGuidewindow
 
 
 class GuidewindowModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.Guidewindow
 
 
 class L1DetectorGuidewindowModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.L1DetectorGuidewindow
 
 
 class FlatRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.FlatRef
 
 
 class AbvegaoffsetRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.AbvegaoffsetRef
 
 
 class ApcorrRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.ApcorrRef
 
 
 class DarkRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.DarkRef
 
 
 class DistortionRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.DistortionRef
 
 
 class EpsfRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.EpsfRef
 
 
 class GainRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.GainRef
 
 
 class IpcRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.IpcRef
 
 
 class LinearityRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.LinearityRef
 
     def get_primary_array_name(self):
@@ -361,6 +388,7 @@ class LinearityRefModel(_DataModel):
 
 
 class InverselinearityRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.InverselinearityRef
 
     def get_primary_array_name(self):
@@ -374,6 +402,7 @@ class InverselinearityRefModel(_DataModel):
 
 
 class MaskRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.MaskRef
 
     def get_primary_array_name(self):
@@ -387,74 +416,92 @@ class MaskRefModel(_DataModel):
 
 
 class MATableRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.MatableRef
 
 
 class PixelareaRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.PixelareaRef
 
 
 class ReadnoiseRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.ReadnoiseRef
 
 
 class SkycellsRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.SkycellsRef
 
 
 class SuperbiasRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.SuperbiasRef
 
 
 class SaturationRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.SaturationRef
 
 
 class WfiImgPhotomRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.WfiImgPhotomRef
 
 
 class RefpixRefModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.RefpixRef
 
 
 class FpsModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.Fps
 
 
 class TvacModel(_DataModel):
+    __slots__ = ()
     _node_type = stnode.Tvac
 
 
 class MosaicSourceCatalogModel(_RomanDataModel, _ParquetMixin, _SourceCatalogMixin):
+    __slots__ = ()
     _node_type = stnode.MosaicSourceCatalog
 
 
 class MultibandSourceCatalogModel(_RomanDataModel, _ParquetMixin, _SourceCatalogMixin):
+    __slots__ = ()
     _node_type = stnode.MultibandSourceCatalog
 
 
 class ForcedImageSourceCatalogModel(_RomanDataModel, _ParquetMixin, _SourceCatalogMixin):
+    __slots__ = ()
     _node_type = stnode.ForcedImageSourceCatalog
 
 
 class ForcedMosaicSourceCatalogModel(_RomanDataModel, _ParquetMixin, _SourceCatalogMixin):
+    __slots__ = ()
     _node_type = stnode.ForcedMosaicSourceCatalog
 
 
 class MosaicSegmentationMapModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.MosaicSegmentationMap
 
 
 class ImageSourceCatalogModel(_RomanDataModel, _ParquetMixin, _SourceCatalogMixin):
+    __slots__ = ()
     _node_type = stnode.ImageSourceCatalog
 
 
 class SegmentationMapModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.SegmentationMap
 
 
 class WfiWcsModel(_RomanDataModel):
+    __slots__ = ()
     _node_type = stnode.WfiWcs
 
     @classmethod

--- a/src/roman_datamodels/stnode/_factories.py
+++ b/src/roman_datamodels/stnode/_factories.py
@@ -155,6 +155,7 @@ def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) ->
             "_default_tag": tag_def["tag_uri"],
             "__module__": "roman_datamodels.stnode",
             "__doc__": docstring_from_tag(tag_def),
+            "__slots__": (),
         },
     )
 

--- a/src/roman_datamodels/stnode/_mixins.py
+++ b/src/roman_datamodels/stnode/_mixins.py
@@ -44,6 +44,8 @@ class WfiModeMixin:
         Adds to indication properties
     """
 
+    __slots__ = ()
+
     # Every optical element is a grating or a filter
     #   There are less gratings than filters so its easier to list out the
     #   gratings.
@@ -133,6 +135,8 @@ class TelescopeMixin:
 
 
 class RefFileMixin:
+    __slots__ = ()
+
     @classmethod
     def create_minimal(cls, defaults=None, builder=None):
         # copy defaults as we may modify them below
@@ -155,6 +159,8 @@ class RefFileMixin:
 
 
 class L2CalStepMixin:
+    __slots__ = ()
+
     @classmethod
     def create_minimal(cls, defaults=None, builder=None):
         defaults = defaults or {}
@@ -163,10 +169,12 @@ class L2CalStepMixin:
 
 
 class L3CalStepMixin(L2CalStepMixin):  # same as L2CalStepMixin
-    pass
+    __slots__ = ()
 
 
 class WfiImgPhotomRefMixin:
+    __slots__ = ()
+
     @classmethod
     def create_fake_data(cls, defaults=None, shape=None, builder=None):
         defaults = defaults or {}
@@ -188,6 +196,8 @@ class WfiImgPhotomRefMixin:
 
 
 class ImageSourceCatalogMixin:
+    __slots__ = ()
+
     def get_column_definition(self, name):
         """
         Get the definition of a named column in the catalog table.
@@ -268,16 +278,16 @@ class ImageSourceCatalogMixin:
 
 
 class ForcedImageSourceCatalogMixin(ImageSourceCatalogMixin):
-    pass
+    __slots__ = ()
 
 
 class MosaicSourceCatalogMixin(ImageSourceCatalogMixin):
-    pass
+    __slots__ = ()
 
 
 class ForcedMosaicSourceCatalogMixin(ImageSourceCatalogMixin):
-    pass
+    __slots__ = ()
 
 
 class MultibandSourceCatalogMixin(ImageSourceCatalogMixin):
-    pass
+    __slots__ = ()

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -84,7 +84,7 @@ class DNode(MutableMapping):
                 return value
 
         # Raise the correct error for the attribute not being found
-        raise AttributeError(f"No such attribute ({key}) found in node")
+        raise AttributeError(f"No such attribute ({key}) found in node: {type(self)}")
 
     def __setattr__(self, key, value):
         """

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -104,6 +104,17 @@ class DNode(MutableMapping):
             else:
                 raise AttributeError(f"Cannot set private attribute {key}")
 
+    def __delattr__(self, name):
+        print(name)
+        if name in self.__dict__:
+            super().__delattr__(name)
+
+        elif name[0] != "_":
+            self.__delitem__(name)
+
+        else:
+            raise AttributeError(f"No such attribute ({name}) found in node")
+
     def _recursive_items(self):
         def recurse(tree, path=None):
             path = path or []  # Avoid mutable default arguments

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -4,8 +4,7 @@ Base node classes for all STNode classes.
 """
 
 import datetime
-from collections import UserList
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, MutableSequence
 
 import numpy as np
 from asdf.lazy_nodes import AsdfDictNode, AsdfListNode
@@ -22,22 +21,24 @@ class DNode(MutableMapping):
     Base class describing all "object" (dict-like) data nodes for STNode classes.
     """
 
+    __slots__ = ("_data", "_name", "_parent", "_read_tag")
+
     _pattern = None
     _latest_manifest = None
 
     def __init__(self, node=None, parent=None, name=None):
         # Handle if we are passed different data types
         if node is None:
-            self.__dict__["_data"] = {}
+            self._data = {}
         elif isinstance(node, dict | AsdfDictNode):
-            self.__dict__["_data"] = node
+            self._data = node
         else:
             raise ValueError("Initializer only accepts dicts")
 
         # Set the metadata tracked by the node
-        self.__dict__["_parent"] = parent
-        self.__dict__["_name"] = name
-        self.__dict__["_read_tag"] = None
+        self._parent = parent
+        self._name = name
+        self._read_tag = None
 
     @staticmethod
     def _convert_to_scalar(key, value, ref=None):
@@ -99,14 +100,13 @@ class DNode(MutableMapping):
             # Finally set the value
             self._data[key] = value
         else:
-            if key in self.__dict__:
-                self.__dict__[key] = value
+            if key in DNode.__slots__:
+                DNode.__dict__[key].__set__(self, value)
             else:
-                raise AttributeError(f"Cannot set private attribute {key}")
+                raise AttributeError(f"Cannot set private attribute {key}, only allowed are {DNode.__slots__}")
 
     def __delattr__(self, name):
-        print(name)
-        if name in self.__dict__:
+        if name in self.__slots__:
             super().__delattr__(name)
 
         elif name[0] != "_":
@@ -206,16 +206,17 @@ class DNode(MutableMapping):
     def copy(self):
         """Handle copying of the node"""
         instance = self.__class__.__new__(self.__class__)
-        instance.__dict__.update(self.__dict__.copy())
-        instance.__dict__["_data"] = self.__dict__["_data"].copy()
+        instance._data = self._data.copy()
 
         return instance
 
 
-class LNode(UserList):
+class LNode(MutableSequence):
     """
     Base class describing all "array" (list-like) data nodes for STNode classes.
     """
+
+    __slots__ = ("_read_tag", "data")
 
     _pattern = None
     _latest_manifest = None
@@ -230,7 +231,7 @@ class LNode(UserList):
         else:
             raise ValueError("Initializer only accepts lists")
 
-        self.__dict__["_read_tag"] = None
+        self._read_tag = None
 
     def __getitem__(self, index):
         value = self.data[index]
@@ -241,5 +242,37 @@ class LNode(UserList):
         else:
             return value
 
+    def __setitem__(self, index, value):
+        self.data[index] = value
+
+    def __delitem__(self, index):
+        del self.data[index]
+
+    def __len__(self):
+        return len(self.data)
+
+    def insert(self, index, value):
+        self.data.insert(index, value)
+
     def __asdf_traverse__(self):
         return list(self)
+
+    def __setattr__(self, key, value):
+        if key in LNode.__slots__:
+            LNode.__dict__[key].__set__(self, value)
+        else:
+            raise AttributeError(f"Cannot set attribute {key}, only allowed are {LNode.__slots__}")
+
+    def __eq__(self, other):
+        if isinstance(other, LNode):
+            return self.data == other.data
+        elif isinstance(other, list | AsdfListNode):
+            return self.data == other
+        else:
+            return False
+
+    def copy(self):
+        """Handle copying of the node"""
+        instance = self.__class__.__new__(self.__class__)
+        instance.data = self.data.copy()
+        return instance

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -35,8 +35,9 @@ class DNode(MutableMapping):
             raise ValueError("Initializer only accepts dicts")
 
         # Set the metadata tracked by the node
-        self._parent = parent
-        self._name = name
+        self.__dict__["_parent"] = parent
+        self.__dict__["_name"] = name
+        self.__dict__["_read_tag"] = None
 
     @staticmethod
     def _convert_to_scalar(key, value, ref=None):
@@ -98,7 +99,10 @@ class DNode(MutableMapping):
             # Finally set the value
             self._data[key] = value
         else:
-            self.__dict__[key] = value
+            if key in self.__dict__:
+                self.__dict__[key] = value
+            else:
+                raise AttributeError(f"Cannot set private attribute {key}")
 
     def _recursive_items(self):
         def recurse(tree, path=None):
@@ -214,6 +218,8 @@ class LNode(UserList):
             self.data = node.data
         else:
             raise ValueError("Initializer only accepts lists")
+
+        self.__dict__["_read_tag"] = None
 
     def __getitem__(self, index):
         value = self.data[index]

--- a/src/roman_datamodels/stnode/_tagged.py
+++ b/src/roman_datamodels/stnode/_tagged.py
@@ -72,8 +72,10 @@ class TaggedObjectNode(DNode):
 
     @property
     def _tag(self):
-        # _tag is required by asdf to allow __asdf_traverse__
-        return getattr(self, "_read_tag", self._default_tag)
+        if self._read_tag is None:
+            return self._default_tag
+
+        return self._read_tag
 
     @property
     def tag(self):
@@ -117,8 +119,10 @@ class TaggedListNode(LNode):
 
     @property
     def _tag(self):
-        # _tag is required by asdf to allow __asdf_traverse__
-        return getattr(self, "_read_tag", self._default_tag)
+        if self._read_tag is None:
+            return self._default_tag
+
+        return self._read_tag
 
     @property
     def tag(self):

--- a/src/roman_datamodels/stnode/_tagged.py
+++ b/src/roman_datamodels/stnode/_tagged.py
@@ -46,6 +46,8 @@ class TaggedObjectNode(DNode):
         base type: object.
     """
 
+    __slots__ = ()
+
     def __init_subclass__(cls, **kwargs) -> None:
         """
         Register any subclasses of this class in the OBJECT_NODE_CLASSES_BY_PATTERN
@@ -92,6 +94,8 @@ class TaggedListNode(LNode):
         There will be one of these for any tagged object defined by RAD, which has
         base type: array.
     """
+
+    __slots__ = ()
 
     def __init_subclass__(cls, **kwargs) -> None:
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -829,10 +829,22 @@ def test_create_fake_data(model):
 
 @pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
 def test_no_hidden(model):
-    """Test that create_minimal produces a model instance"""
+    """Test that no hidden attributes are allowed"""
     m = model.create_minimal()
     with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
         m._foo = "bar"  # Add a hidden attribute
+
+
+@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
+def test_delattr(model):
+    """Test that delattr works as expected"""
+    m = model.create_minimal()
+
+    m.foo = "bar"
+    assert hasattr(m, "foo")
+
+    del m.foo
+    assert not hasattr(m, "foo")
 
 
 @pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -848,6 +848,16 @@ def test_delattr(model):
 
 
 @pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
+def test_slotted(model):
+    """Test that the model is slotted as expected"""
+    m = model.create_minimal()
+
+    with pytest.raises(AttributeError, match=r"No attribute .*"):
+        # slotted object instances do not have a __dict__
+        m.__dict__  # noqa: B018
+
+
+@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
 def test_create_minimal_copies(model, tmp_path):
     """Test that create_minimal does not retain references to input"""
     fn = tmp_path / "test.asdf"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -828,6 +828,14 @@ def test_create_fake_data(model):
 
 
 @pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
+def test_no_hidden(model):
+    """Test that create_minimal produces a model instance"""
+    m = model.create_minimal()
+    with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
+        m._foo = "bar"  # Add a hidden attribute
+
+
+@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
 def test_create_minimal_copies(model, tmp_path):
     """Test that create_minimal does not retain references to input"""
     fn = tmp_path / "test.asdf"

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -99,16 +99,11 @@ def test_serialization(node_class, tmp_path):
         assert_node_equal(af["node"], node)
 
 
-@pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
-@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
-@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
-@pytest.mark.filterwarnings("ignore:Input shape must be 4D")
-@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
+@pytest.mark.parametrize("node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedObjectNode)])
 def test_no_hidden(node_class):
-    if issubclass(node_class, stnode.TaggedObjectNode):
-        node = maker_utils.mk_node(node_class, shape=(8, 8, 8))
-        with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
-            node._foo = "bar"  # Add a hidden attribute
+    node = node_class.create_fake_data()
+    with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
+        node._foo = "bar"  # Add a hidden attribute
 
 
 def test_info(capsys):

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -99,6 +99,18 @@ def test_serialization(node_class, tmp_path):
         assert_node_equal(af["node"], node)
 
 
+@pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
+@pytest.mark.filterwarnings("ignore:Input shape must be 1D")
+@pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 4D")
+@pytest.mark.filterwarnings("ignore:Input shape must be 5D")
+def test_no_hidden(node_class):
+    if issubclass(node_class, stnode.TaggedObjectNode):
+        node = maker_utils.mk_node(node_class, shape=(8, 8, 8))
+        with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
+            node._foo = "bar"  # Add a hidden attribute
+
+
 def test_info(capsys):
     node = stnode.WfiMode({"optical_element": "GRISM", "detector": "WFI18", "name": "WFI"})
     tree = dict(wfimode=node)

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -106,6 +106,30 @@ def test_no_hidden(node_class):
         node._foo = "bar"  # Add a hidden attribute
 
 
+@pytest.mark.parametrize("node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedListNode)])
+def test_list_node_no_new_attributes(node_class):
+    """Test that no new attributes can be added to a list node."""
+    node = node_class.create_fake_data()
+    with pytest.raises(AttributeError, match=r"Cannot set attribute .*, only allowed are .*"):
+        node.foo = "bar"
+
+    with pytest.raises(AttributeError, match=r"Cannot set attribute .*, only allowed are .*"):
+        node._foo = "bar"
+
+
+@pytest.mark.parametrize(
+    "node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedObjectNode | stnode.TaggedListNode)]
+)
+def test_slotted(node_class):
+    """
+    Test that slotted nodes do not allow new attributes to be added.
+    """
+    node = node_class.create_fake_data()
+    with pytest.raises(AttributeError, match=r".* attribute .*__dict__.*"):
+        # Attempt to access __dict__ directly, slotted classes do not have __dict__
+        node.__dict__  # noqa: B018
+
+
 def test_info(capsys):
     node = stnode.WfiMode({"optical_element": "GRISM", "detector": "WFI18", "name": "WFI"})
     tree = dict(wfimode=node)


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #418 and closes #479

<!-- describe the changes comprising this PR here -->
This PR fixes two small issues with attributes on nodes.

1. Hidden attributes should not be allowed outside of the internal rdm code.
2. `__delattr__` was not defined on nodes and datamodels.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
