### PR TITLE
Add all_array_storage save support

### DIFF
--- a/changes/540.feature.rst
+++ b/changes/540.feature.rst
@@ -1,0 +1,1 @@
+Add support for the ``all_array_storage`` save option for asdf files to ``DataModel.save`` method.

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -273,14 +273,16 @@ class DataModel(abc.ABC):
         target._files_to_close = []
         target._shape = source._shape
 
-    def save(self, path, dir_path=None, *args, **kwargs):
+    def save(self, path, dir_path=None, *args, all_array_compression="lz4", all_array_storage="internal", **kwargs):
         path = Path(path(self.meta.filename) if callable(path) else path)
         output_path = Path(dir_path) / path.name if dir_path else path
         ext = path.suffix.decode(sys.getfilesystemencoding()) if isinstance(path.suffix, bytes) else path.suffix
 
         # TODO: Support gzip-compressed fits
         if ext == ".asdf":
-            self.to_asdf(output_path, *args, **kwargs)
+            self.to_asdf(
+                output_path, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
+            )
         elif ext == ".parquet" and hasattr(self, "to_parquet"):
             self.to_parquet(output_path)
         else:
@@ -297,9 +299,7 @@ class DataModel(abc.ABC):
 
             return asdf.AsdfFile(init, **kwargs)
 
-    def to_asdf(self, init, *args, **kwargs):
-        all_array_compression = kwargs.pop("all_array_compression", "lz4")
-        all_array_storage = kwargs.pop("all_array_storage", "internal")
+    def to_asdf(self, init, *args, all_array_compression=None, all_array_storage=None, **kwargs):
         with validate.nuke_validation(), _temporary_update_filename(self, Path(init).name):
             asdf_file = self.open_asdf(**kwargs)
             asdf_file["roman"] = self._instance

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -299,10 +299,13 @@ class DataModel(abc.ABC):
 
     def to_asdf(self, init, *args, **kwargs):
         all_array_compression = kwargs.pop("all_array_compression", "lz4")
+        all_array_storage = kwargs.pop("all_array_storage", "internal")
         with validate.nuke_validation(), _temporary_update_filename(self, Path(init).name):
             asdf_file = self.open_asdf(**kwargs)
             asdf_file["roman"] = self._instance
-            asdf_file.write_to(init, *args, all_array_compression=all_array_compression, **kwargs)
+            asdf_file.write_to(
+                init, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
+            )
 
     def get_primary_array_name(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1265,6 +1265,19 @@ def test_array_compression_override(tmp_path, compression):
         assert af.get_array_compression(af["roman"]["data"]) == compression
 
 
+@pytest.mark.parametrize("storage", [None, "inline", "internal", "external"])
+def test_array_storage_override(tmp_path, storage):
+    """
+    Test that providing a compression argument changes the
+    array compression.
+    """
+    fn = tmp_path / "foo.asdf"
+    model = utils.mk_datamodel(datamodels.ImageModel, shape=(2, 2))
+    model.save(fn, all_array_storage=storage)
+    with asdf.open(fn) as af:
+        assert af.get_array_storage(af["roman"]["data"]) == "internal" if storage is None else storage
+
+
 def test_apcorr_none_array():
     """
     Check that ApcorrRefModel data arrays can be None.


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #481

<!-- describe the changes comprising this PR here -->
This PR adds support for the `all_array_storage` save option for asdf files.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
