### PR TITLE
add zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Weekly Cron](https://github.com/spacetelescope/roman_datamodels/actions/workflows/ci_cron.yml/badge.svg)](https://github.com/spacetelescope/roman_datamodels/actions/workflows/ci_cron.yml)
 [![codecov](https://codecov.io/gh/spacetelescope/roman_datamodels/branch/main/graph/badge.svg)](https://codecov.io/gh/spacetelescope/roman_datamodels)
 [![Documentation Status](https://readthedocs.org/projects/roman-datamodels/badge/?version=latest)](https://roman-datamodels.readthedocs.io/en/latest/?badge=latest)
+[![DOI](https://zenodo.org/badge/338118033.svg)](https://doi.org/10.5281/zenodo.16048708)
 
 # Roman Datamodels Support
 


### PR DESCRIPTION
Now that zenodo integration is enabled we can add a badge to the README. The badge links to the latest zenodo archived released with citation information.

https://doi.org/10.5281/zenodo.16048708

Closes https://github.com/spacetelescope/roman_datamodels/issues/533

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
