### PR TITLE
don't put dark.data in dark reference files anymore; it's not required

### DIFF
--- a/changes/547.bugfix.rst
+++ b/changes/547.bugfix.rst
@@ -1,0 +1,1 @@
+Removed dark.data from tests and maker utils.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=6.0.0",
   # "rad >=0.25.0",
-  "rad @ git+https://github.com/spacetelescope/rad.git",
+  "rad @ git+https://github.com/schlafly/rad.git@more-dark-data-removal",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=6.0.0",
   # "rad >=0.25.0",
-  "rad @ git+https://github.com/schlafly/rad.git@more-dark-data-removal",
+  "rad @ git+https://github.com/PaulHuwe/rad.git@RAD-215_OptionalDarkData",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=6.0.0",
   # "rad >=0.25.0",
-  "rad @ git+https://github.com/PaulHuwe/rad.git@RAD-215_OptionalDarkData",
+  "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
 ]

--- a/src/roman_datamodels/maker_utils/_ref_files.py
+++ b/src/roman_datamodels/maker_utils/_ref_files.py
@@ -199,7 +199,6 @@ def mk_dark(*, shape=(2, 4096, 4096), filepath=None, **kwargs):
     darkref = stnode.DarkRef()
     darkref["meta"] = mk_ref_dark_meta(**kwargs.get("meta", {}))
 
-    darkref["data"] = kwargs.get("data", np.zeros(shape, dtype=np.float32))
     darkref["dq"] = kwargs.get("dq", np.zeros(shape[1:], dtype=np.uint32))
     darkref["dark_slope"] = kwargs.get("dark_slope", np.zeros(shape[1:], dtype=np.float32))
     darkref["dark_slope_error"] = kwargs.get("dark_slope_error", np.zeros(shape[1:], dtype=np.float32))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -439,7 +439,6 @@ def test_flat_model(tmp_path):
 def test_make_dark():
     dark = utils.mk_dark(shape=(2, 8, 8))
     assert dark.meta.reftype == "DARK"
-    assert dark.data.dtype == np.float32
     assert dark.dq.dtype == np.uint32
     assert dark.dq.shape == (8, 8)
     assert dark.dark_slope.dtype == np.float32


### PR DESCRIPTION
This removes stops testing for the presence of dark.data and stops populating dark.data in the maker utils, since we no longer want to require it.