### PR TITLE
Follow on for removal of tagged scalars from RAD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=6.0.0",
   # "rad >=0.25.0",
-  "rad @ git+https://github.com/spacetelescope/rad.git",
+  # "rad @ git+https://github.com/spacetelescope/rad.git",
+  "rad @ git+https://github.com/WilliamJamieson/rad.git@remove_tagged_scalars_v2",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
 ]

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -148,6 +148,13 @@ class _RomanDataModel(_DataModel):
 
         if init is not None:
             self.meta.model_type = self.__class__.__name__
+            self.meta.calibration_software_name = "RomanCAL"
+
+            if "file_date" not in self.meta:
+                self.meta.file_date = Time.now()
+
+            if "origin" not in self.meta:
+                self.meta.origin = "STSCI/SOC"
 
 
 class MosaicModel(_RomanDataModel):

--- a/src/roman_datamodels/maker_utils/_basic_meta.py
+++ b/src/roman_datamodels/maker_utils/_basic_meta.py
@@ -1,7 +1,5 @@
 from astropy import time
 
-from roman_datamodels import stnode
-
 from ._base import NOFN, NOSTR
 
 
@@ -13,7 +11,7 @@ def mk_calibration_software_name(**kwargs):
     -------
     roman_datamodels.stnode.CalibrationSoftwareName
     """
-    return stnode.CalibrationSoftwareName(kwargs.get("calibration_software_name", "RomanCAL"))
+    return kwargs.get("calibration_software_name", "RomanCAL")
 
 
 def mk_calibration_software_version(**kwargs):
@@ -24,7 +22,7 @@ def mk_calibration_software_version(**kwargs):
     -------
     roman_datamodels.stnode.CalibrationSoftwareVersion
     """
-    return stnode.CalibrationSoftwareVersion(kwargs.get("calibration_software_version", "9.9.0"))
+    return kwargs.get("calibration_software_version", "9.9.0")
 
 
 def mk_sdf_software_version(**kwargs):
@@ -36,7 +34,7 @@ def mk_sdf_software_version(**kwargs):
     roman_datamodels.stnode.SdfSoftwareVersion
     """
 
-    return stnode.SdfSoftwareVersion(kwargs.get("sdf_software_version", "7.7.7"))
+    return kwargs.get("sdf_software_version", "7.7.7")
 
 
 def mk_filename(**kwargs):
@@ -47,7 +45,7 @@ def mk_filename(**kwargs):
     -------
     roman_datamodels.stnode.Filename
     """
-    return stnode.Filename(kwargs.get("filename", NOFN))
+    return kwargs.get("filename", NOFN)
 
 
 def mk_file_date(**kwargs):
@@ -59,7 +57,7 @@ def mk_file_date(**kwargs):
     roman_datamodels.stnode.FileDate
     """
 
-    return stnode.FileDate(kwargs.get("file_date", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc")))
+    return kwargs.get("file_date", time.Time("2020-01-01T00:00:00.0", format="isot", scale="utc"))
 
 
 def mk_model_type(**kwargs):
@@ -70,7 +68,7 @@ def mk_model_type(**kwargs):
     -------
     roman_datamodels.stnode.ModelType
     """
-    return stnode.ModelType(kwargs.get("model_type", NOSTR))
+    return kwargs.get("model_type", NOSTR)
 
 
 def mk_origin(**kwargs):
@@ -82,7 +80,7 @@ def mk_origin(**kwargs):
     roman_datamodels.stnode.Origin
     """
 
-    return stnode.Origin(kwargs.get("origin", "STSCI/SOC"))
+    return kwargs.get("origin", "STSCI/SOC")
 
 
 def mk_prd_version(**kwargs):
@@ -93,7 +91,7 @@ def mk_prd_version(**kwargs):
     -------
     roman_datamodels.stnode.PrdVersion
     """
-    return stnode.PrdVersion(kwargs.get("prd_version", "8.8.8"))
+    return kwargs.get("prd_version", "8.8.8")
 
 
 def mk_product_type(**kwargs):
@@ -104,7 +102,7 @@ def mk_product_type(**kwargs):
     -------
     roman_datamodels.stnode.ProductType
     """
-    return stnode.ProductType(kwargs.get("product_type", "l2"))
+    return kwargs.get("product_type", "l2")
 
 
 def mk_telescope(**kwargs):
@@ -115,7 +113,7 @@ def mk_telescope(**kwargs):
     -------
     roman_datamodels.stnode.Telescope
     """
-    return stnode.Telescope(kwargs.get("telescope", "ROMAN"))
+    return kwargs.get("telescope", "ROMAN")
 
 
 def mk_basic_meta(**kwargs):

--- a/src/roman_datamodels/stnode/_mixins.py
+++ b/src/roman_datamodels/stnode/_mixins.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from asdf.tags.core.ndarray import asdf_datatype_to_numpy_dtype
 
+from ._node import TaggedScalarDNode
 from ._schema import Builder, _get_keyword, _get_properties
 from ._tagged import _get_schema_from_tag
 
@@ -280,4 +281,17 @@ class ForcedMosaicSourceCatalogMixin(ImageSourceCatalogMixin):
 
 
 class MultibandSourceCatalogMixin(ImageSourceCatalogMixin):
+    pass
+
+
+# Legacy support for tagged scalars in nodes
+class GuidewindowMixin(TaggedScalarDNode):
+    pass
+
+
+class FpsMixin(TaggedScalarDNode):
+    pass
+
+
+class TvacMixin(TaggedScalarDNode):
     pass

--- a/src/roman_datamodels/stnode/_node.py
+++ b/src/roman_datamodels/stnode/_node.py
@@ -38,22 +38,20 @@ class DNode(MutableMapping):
         self._parent = parent
         self._name = name
 
-    @staticmethod
-    def _convert_to_scalar(key, value, ref=None):
-        """Find and wrap scalars in the appropriate class, if its a tagged one."""
-        from ._tagged import TaggedScalarNode
+    def _wrap_value(self, key, value):
+        # Return objects as node classes, if applicable
+        if isinstance(value, dict | AsdfDictNode):
+            return DNode(value, parent=self, name=key)
 
-        if isinstance(ref, TaggedScalarNode):
-            # we want the exact class (not possible subclasses)
-            if type(value) == type(ref):  # noqa: E721
-                return value
-            return type(ref)(value)
+        elif isinstance(value, list | AsdfListNode):
+            return LNode(value)
 
-        if isinstance(value, TaggedScalarNode):
+        else:
             return value
 
-        if key in SCALAR_NODE_CLASSES_BY_KEY:
-            value = SCALAR_NODE_CLASSES_BY_KEY[key](value)
+    @staticmethod
+    def _convert_to_scalar(key, value, ref=None):
+        """For now this is a simple pass through so a mixin can override it."""
 
         return value
 
@@ -73,14 +71,7 @@ class DNode(MutableMapping):
             value = self._convert_to_scalar(key, self._data[key])
 
             # Return objects as node classes, if applicable
-            if isinstance(value, dict | AsdfDictNode):
-                return DNode(value, parent=self, name=key)
-
-            elif isinstance(value, list | AsdfListNode):
-                return LNode(value)
-
-            else:
-                return value
+            return self._wrap_value(key, value)
 
         # Raise the correct error for the attribute not being found
         raise AttributeError(f"No such attribute ({key}) found in node")
@@ -226,3 +217,37 @@ class LNode(UserList):
 
     def __asdf_traverse__(self):
         return list(self)
+
+
+class TaggedScalarDNode(DNode):
+    """Legacy class for nodes that have tagged scalars"""
+
+    @staticmethod
+    def _convert_to_scalar(key, value, ref=None):
+        """Find and wrap scalars in the appropriate class, if its a tagged one."""
+        from ._tagged import TaggedScalarNode
+
+        if isinstance(ref, TaggedScalarNode):
+            # we want the exact class (not possible subclasses)
+            if type(value) == type(ref):  # noqa: E721
+                return value
+            return type(ref)(value)
+
+        if isinstance(value, TaggedScalarNode):
+            return value
+
+        if key in SCALAR_NODE_CLASSES_BY_KEY:
+            value = SCALAR_NODE_CLASSES_BY_KEY[key](value)
+
+        return value
+
+    def _wrap_value(self, key, value):
+        # Return objects as node classes, if applicable
+        if isinstance(value, dict | AsdfDictNode):
+            return TaggedScalarDNode(value, parent=self, name=key)
+
+        elif isinstance(value, list | AsdfListNode):
+            return LNode(value)
+
+        else:
+            return value

--- a/tests/test_maker_utils.py
+++ b/tests/test_maker_utils.py
@@ -14,12 +14,16 @@ from roman_datamodels.testing import assert_node_equal
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
-def test_maker_utility_implemented(node_class):
+def test_maker_utility_implemented(node_class, request):
     """
     Confirm that a subclass of TaggedObjectNode has a maker utility.
 
     (note: will be using full defaults for this one)
     """
+    if issubclass(node_class, stnode.TaggedScalarNode) and "Fps" not in node_class.__name__ and "Tvac" not in node_class.__name__:
+        request.applymarker(
+            pytest.mark.xfail(reason=f"{node_class.__name__} is a deprecated TaggedScalarNode and does not have a maker utility.")
+        )
     instance = maker_utils.mk_node(node_class)
     assert isinstance(instance, node_class)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1356,7 +1356,10 @@ def test_wfi_wcs_from_wcsmodel():
     for key in wfi_wcs.meta:
         wfi_wcs_value = getattr(wfi_wcs.meta, key)
         model_value = getattr(model.meta, key)
-        assert_node_equal(wfi_wcs_value, model_value)
+        if isinstance(wfi_wcs_value, str | Time):
+            assert wfi_wcs_value == model_value
+        else:
+            assert_node_equal(wfi_wcs_value, model_value)
 
     # Test wcs fidelity
     border = 4.0  # Default extra border for L1

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -38,8 +38,12 @@ def test_node_classes_available_via_stnode(node_class):
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
-def test_copy(node_class):
+def test_copy(node_class, request):
     """Demonstrate nodes can copy themselves, but don't always deepcopy."""
+    if issubclass(node_class, stnode.TaggedScalarNode) and "Fps" not in node_class.__name__ and "Tvac" not in node_class.__name__:
+        request.applymarker(
+            pytest.mark.xfail(reason=f"{node_class.__name__} is a deprecated TaggedScalarNode and does not have a maker utility.")
+        )
     node = maker_utils.mk_node(node_class, shape=(8, 8, 8))
     node_copy = node.copy()
 
@@ -101,7 +105,12 @@ def test_wfi_mode():
 @pytest.mark.filterwarnings("ignore:This function assumes shape is 2D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 4D")
 @pytest.mark.filterwarnings("ignore:Input shape must be 5D")
-def test_serialization(node_class, tmp_path):
+def test_serialization(node_class, tmp_path, request):
+    if issubclass(node_class, stnode.TaggedScalarNode) and "Fps" not in node_class.__name__ and "Tvac" not in node_class.__name__:
+        request.applymarker(
+            pytest.mark.xfail(reason=f"{node_class.__name__} is a deprecated TaggedScalarNode and does not have a maker utility.")
+        )
+
     file_path = tmp_path / "test.asdf"
 
     node = maker_utils.mk_node(node_class, shape=(8, 8, 8))


### PR DESCRIPTION
This PR includes the changes for `roman_datamodels` that are necessary to support spacetelescope/rad#688. The vast majority of the changes are simply the result of needing to control when scalars need to be wrapped and when they don't. For legacy reasons with things like TVAC and FPS we still need to support auto wrapping of the `TaggedScalar` values.

Note that since we no longer have a specific tagged object for a special class to be involved. The `create_minimal` mixins used for a few of the tagged scalars to assign values no longer works. Those values appear to be pretty much the same always so I moved the setting of them to the datamodel initializer.  I am open to suggestions there.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
