### PR TITLE
RCAL-1204: Add psf to MSOS Datamodel

### DIFF
--- a/changes/560.feature.rst
+++ b/changes/560.feature.rst
@@ -1,0 +1,2 @@
+Added psf to the MSOS Datamodel.
+

--- a/changes/560.feature.rst
+++ b/changes/560.feature.rst
@@ -1,2 +1,1 @@
 Added psf to the MSOS Datamodel.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=6.0.0",
   # "rad >=0.25.0",
-  "rad @ git+https://github.com/wlim-ipac/rad.git@issue-635-add-psf",
+  "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "numpy >=1.24",
   "astropy >=6.0.0",
   # "rad >=0.25.0",
-  "rad @ git+https://github.com/spacetelescope/rad.git",
+  "rad @ git+https://github.com/wlim-ipac/rad.git@issue-635-add-psf",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
 ]

--- a/src/roman_datamodels/_maker_utils/_datamodels.py
+++ b/src/roman_datamodels/_maker_utils/_datamodels.py
@@ -217,6 +217,7 @@ def mk_msos_stack(*, shape=(4096, 4096), filepath=None, **kwargs):
     msos_stack["uncertainty"] = kwargs.get("uncertainty", np.zeros(shape, dtype=np.float64))
     msos_stack["mask"] = kwargs.get("mask", np.zeros(shape, dtype=np.uint8))
     msos_stack["coverage"] = kwargs.get("coverage", np.zeros(shape, dtype=np.uint8))
+    msos_stack["psf"] = kwargs.get("psf", np.zeros(shape, dtype=np.float64))
 
     return save_node(msos_stack, filepath=filepath)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1204](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1204

<!-- describe the changes comprising this PR here -->
This PR adds psf to the MSOS Datamodel.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
