### PR TITLE
remove AssociationsModel

### DIFF
--- a/changes/562.removal.rst
+++ b/changes/562.removal.rst
@@ -1,0 +1,1 @@
+Remove unused ``AssociationsModel``.

--- a/src/roman_datamodels/_maker_utils/_datamodels.py
+++ b/src/roman_datamodels/_maker_utils/_datamodels.py
@@ -322,7 +322,7 @@ def mk_associations(*, shape=(2, 3, 1), filepath=None, **kwargs):
 
     Returns
     -------
-    roman_datamodels.stnode.AssociationsModel
+    roman_datamodels.stnode.Associations
     """
 
     associations = stnode.Associations()

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -306,24 +306,6 @@ class RampFitOutputModel(_RomanDataModel):
     _node_type = stnode.RampFitOutput  # type: ignore[attr-defined]
 
 
-class AssociationsModel(_DataModel):
-    __slots__ = ()
-    # Need an init to allow instantiation from a JSON file
-    _node_type = stnode.Associations  # type: ignore[attr-defined]
-
-    @classmethod
-    def is_association(cls, asn_data):
-        """
-        Test if an object is an association by checking for required fields
-
-        Parameters
-        ----------
-        asn_data :
-            The data to be tested.
-        """
-        return isinstance(asn_data, dict) and "asn_id" in asn_data and "asn_pool" in asn_data
-
-
 class L1FaceGuidewindowModel(_RomanDataModel):
     __slots__ = ()
     _node_type = stnode.L1FaceGuidewindow  # type: ignore[attr-defined]


### PR DESCRIPTION
Requires https://github.com/spacetelescope/romancal/pull/1954

Removes the unused `AssociationsModel`.

See https://github.com/spacetelescope/romancal/issues/1846 for more details.

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/17917081333

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
