### PR TITLE
fix version on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/roman_datamodels/_version.py"
+version_scheme = "release-branch-semver"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
Installing rdm main currently produces an incorrect version:
```
Successfully installed roman_datamodels-0.27.0.dev14+g6277ff0ec
```
Due to the https://github.com/spacetelescope/roman_datamodels/releases/tag/0.27.0.dev tag and the setuptools-scm configuration.

This PR updates the setuptools-scm configuration to be aware of the release branches and produces an install with a correct version:
```
Successfully installed roman_datamodels-0.28.0.dev14+g6277ff0ec.d20250917
```

No tag changes are needed after this PR is merged and we should no longer need to add `*.dev` tags.

See https://github.com/spacetelescope/stdatamodels/pull/583 for a related change.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
