### PR TITLE
remove unused pytest-env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ test = [
   "pytest >=6.0.0",
   "pytest-doctestplus",
   "pytest-doctestplus >=1.2.1",
-  "pytest-env >= 0.8",
   "pandas >=2.2.3",
 ]
 docs = ["sphinx", "sphinx-automodapi", "sphinx-rtd-theme", "sphinx-astropy"]


### PR DESCRIPTION
Follow-up to https://github.com/spacetelescope/roman_datamodels/pull/561
as noted https://github.com/spacetelescope/roman_datamodels/pull/561#issuecomment-3304455813
pytest-env was only used for nuke_validation testing. Since that has been removed we can drop pytest-env as a test dependency.

This PR removes the unused test dependency pytest-env.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
