### PR TITLE
clarify that builder argument is private

### DIFF
--- a/changes/569.bugfix.rst
+++ b/changes/569.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect naming of private builder argument to node creation methods.

--- a/src/roman_datamodels/stnode/_mixins.py
+++ b/src/roman_datamodels/stnode/_mixins.py
@@ -86,7 +86,7 @@ class WfiModeMixin:
 
 class FileDateMixin(_TimeBase):
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
         new = cls(defaults) if defaults else cls.now()
         if tag:
             new._read_tag = tag
@@ -94,7 +94,7 @@ class FileDateMixin(_TimeBase):
         return new
 
     @classmethod
-    def create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag: str | None = None):
+    def create_fake_data(cls, defaults=None, shape=None, _builder=None, *, tag: str | None = None):
         new = cls(defaults) if defaults else cls("2020-01-01T00:00:00.0", format="isot", scale="utc")
         if tag:
             new._read_tag = tag
@@ -112,7 +112,7 @@ class TvacFileDateMixin(FileDateMixin):
 
 class CalibrationSoftwareNameMixin(_ScalarBase):
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
         new = cls(defaults) if defaults else cls("RomanCAL")
         if tag:
             new._read_tag = tag
@@ -122,7 +122,7 @@ class CalibrationSoftwareNameMixin(_ScalarBase):
 
 class PrdVersionMixin(_ScalarBase):
     @classmethod
-    def create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag: str | None = None):
+    def create_fake_data(cls, defaults=None, shape=None, _builder=None, *, tag: str | None = None):
         new = cls(defaults) if defaults else cls("8.8.8")
         if tag:
             new._read_tag = tag
@@ -132,7 +132,7 @@ class PrdVersionMixin(_ScalarBase):
 
 class SdfSoftwareVersionMixin(_ScalarBase):
     @classmethod
-    def create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag: str | None = None):
+    def create_fake_data(cls, defaults=None, shape=None, _builder=None, *, tag: str | None = None):
         new = cls(defaults) if defaults else cls("7.7.7")
         if tag:
             new._read_tag = tag
@@ -142,7 +142,7 @@ class SdfSoftwareVersionMixin(_ScalarBase):
 
 class OriginMixin(_ScalarBase):
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
         new = cls(defaults) if defaults else cls("STSCI/SOC")
         if tag:
             new._read_tag = tag
@@ -152,7 +152,7 @@ class OriginMixin(_ScalarBase):
 
 class TelescopeMixin(_ScalarBase):
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
         new = cls(defaults) if defaults else cls("ROMAN")
         if tag:
             new._read_tag = tag
@@ -164,7 +164,7 @@ class RefFileMixin(_ObjectBase):
     __slots__ = ()
 
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
         # copy defaults as we may modify them below
         if defaults:
             defaults = deepcopy(defaults)
@@ -177,9 +177,9 @@ class RefFileMixin(_ObjectBase):
             if k in defaults:
                 continue
             defaults[k] = "N/A"
-        if not builder:
-            builder = Builder()
-        data = builder.from_object(schema, defaults)
+        if not _builder:
+            _builder = Builder()
+        data = _builder.from_object(schema, defaults)
         new = cls(data)
         if tag:
             new._read_tag = tag
@@ -191,7 +191,7 @@ class L2CalStepMixin(_ObjectBase):
     __slots__ = ()
 
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
         defaults = defaults or {}
         schema = _get_schema_from_tag(tag or cls._default_tag)
         new = cls({k: defaults.get(k, "INCOMPLETE") for k in schema["properties"]})
@@ -209,7 +209,7 @@ class WfiImgPhotomRefMixin(_ObjectBase):
     __slots__ = ()
 
     @classmethod
-    def create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag: str | None = None):
+    def create_fake_data(cls, defaults=None, shape=None, _builder=None, *, tag: str | None = None):
         defaults = defaults or {}
         if "phot_table" not in defaults:
             defaults["phot_table"] = {
@@ -225,7 +225,7 @@ class WfiImgPhotomRefMixin(_ObjectBase):
                 "PRISM": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1e-13},
                 "DARK": {"photmjsr": None, "uncertainty": None, "pixelareasr": 1e-13},
             }
-        return super().create_fake_data(defaults, shape, builder, tag=tag)
+        return super().create_fake_data(defaults, shape, _builder, tag=tag)
 
 
 class ImageSourceCatalogMixin(_ObjectBase):
@@ -303,11 +303,11 @@ class ImageSourceCatalogMixin(_ObjectBase):
         return Table(columns)
 
     @classmethod
-    def create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag: str | None = None):
+    def create_fake_data(cls, defaults=None, shape=None, _builder=None, *, tag: str | None = None):
         defaults = defaults or {}
         if "source_catalog" not in defaults:
             defaults["source_catalog"] = cls._create_empty_catalog()
-        return super().create_fake_data(defaults, shape, builder, tag=tag)
+        return super().create_fake_data(defaults, shape, _builder, tag=tag)
 
 
 class ForcedImageSourceCatalogMixin(ImageSourceCatalogMixin):

--- a/src/roman_datamodels/stnode/_schema.py
+++ b/src/roman_datamodels/stnode/_schema.py
@@ -318,7 +318,7 @@ class Builder:
     def from_tagged(self, schema, defaults):
         tag = _get_keyword(schema, "tag")
         if property_class := NODE_CLASSES_BY_TAG.get(tag):
-            return property_class.create_minimal(defaults, builder=self, tag=tag)
+            return property_class.create_minimal(defaults, _builder=self, tag=tag)
         if defaults is not _NO_VALUE:
             return copy.deepcopy(defaults)
         return _NO_VALUE
@@ -424,7 +424,7 @@ class FakeDataBuilder(Builder):
                 return _NO_VALUE
         if property_class := NODE_CLASSES_BY_TAG.get(tag):
             # Pass control to the class for create_fake_data overrides
-            return property_class.create_fake_data(defaults, builder=self, tag=tag)
+            return property_class.create_fake_data(defaults, _builder=self, tag=tag)
         if defaults is not _NO_VALUE:
             return copy.deepcopy(defaults)
         if tag == "tag:stsci.edu:asdf/time/time-1.*":
@@ -576,7 +576,7 @@ class NodeBuilder(Builder):
         tag = _get_keyword(schema, "tag")
         if property_class := NODE_CLASSES_BY_TAG.get(tag):
             try:
-                return property_class.create_from_node(defaults, builder=self)
+                return property_class.create_from_node(defaults, _builder=self)
             except ValueError:
                 # Providing an incompatible value (list to a dict expecting class)
                 # will result in a ValueError. Don't let this stop the conversion

--- a/src/roman_datamodels/stnode/_tagged.py
+++ b/src/roman_datamodels/stnode/_tagged.py
@@ -68,8 +68,8 @@ class TaggedObjectNode(DNode):
             OBJECT_NODE_CLASSES_BY_PATTERN[cls._pattern] = cls
 
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
-        builder = builder or Builder()
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
+        builder = _builder or Builder()
         new = cls(builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults))
 
         if tag:
@@ -78,12 +78,12 @@ class TaggedObjectNode(DNode):
         return new
 
     @classmethod
-    def create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag: str | None = None):
-        return cls.create_minimal(defaults, builder or FakeDataBuilder(shape), tag=tag)
+    def create_fake_data(cls, defaults=None, shape=None, _builder=None, *, tag: str | None = None):
+        return cls.create_minimal(defaults, _builder or FakeDataBuilder(shape), tag=tag)
 
     @classmethod
-    def create_from_node(cls, node, builder=None, *, tag: str | None = None):
-        return cls.create_minimal(node, builder or NodeBuilder(), tag=tag)
+    def create_from_node(cls, node, _builder=None, *, tag: str | None = None):
+        return cls.create_minimal(node, _builder or NodeBuilder(), tag=tag)
 
     @property
     def _tag(self):
@@ -124,8 +124,8 @@ class TaggedListNode(LNode):
             LIST_NODE_CLASSES_BY_PATTERN[cls._pattern] = cls
 
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
-        builder = builder or Builder()
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
+        builder = _builder or Builder()
         new = cls(builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults))
 
         if tag:
@@ -134,12 +134,12 @@ class TaggedListNode(LNode):
         return new
 
     @classmethod
-    def create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag: str | None = None):
-        return cls.create_minimal(defaults, builder or FakeDataBuilder(shape), tag=tag)
+    def create_fake_data(cls, defaults=None, shape=None, _builder=None, *, tag: str | None = None):
+        return cls.create_minimal(defaults, _builder or FakeDataBuilder(shape), tag=tag)
 
     @classmethod
-    def create_from_node(cls, node, builder=None, *, tag: str | None = None):
-        return cls.create_minimal(node, builder or NodeBuilder(), tag=tag)
+    def create_from_node(cls, node, _builder=None, *, tag: str | None = None):
+        return cls.create_minimal(node, _builder or NodeBuilder(), tag=tag)
 
     @property
     def _tag(self):
@@ -186,8 +186,8 @@ class TaggedScalarNode:
         pass
 
     @classmethod
-    def create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
-        builder = builder or Builder()
+    def create_minimal(cls, defaults=None, _builder=None, *, tag: str | None = None):
+        builder = _builder or Builder()
         value = builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults)
         if value is _NO_VALUE:
             return value
@@ -199,12 +199,12 @@ class TaggedScalarNode:
         return new
 
     @classmethod
-    def create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag: str | None = None):
-        return cls.create_minimal(defaults, builder or FakeDataBuilder(shape), tag=tag)
+    def create_fake_data(cls, defaults=None, shape=None, _builder=None, *, tag: str | None = None):
+        return cls.create_minimal(defaults, _builder or FakeDataBuilder(shape), tag=tag)
 
     @classmethod
-    def create_from_node(cls, node, builder=None, *, tag: str | None = None):
-        return cls.create_minimal(node, builder or NodeBuilder(), tag=tag)
+    def create_from_node(cls, node, _builder=None, *, tag: str | None = None):
+        return cls.create_minimal(node, _builder or NodeBuilder(), tag=tag)
 
     @property
     def _tag(self):


### PR DESCRIPTION
This fixes a bug (revealed during review of https://github.com/spacetelescope/roman_datamodels/pull/568) in the `create_*` methods where the `builder` argument was not prefixed with an underscore to make it more explicit that this is not intended to an argument for public use. The "builder" argument is already (on main) not exposed for `DataModel.create_*` for the same reasons and this PR makes the node API more closely agree with the datamodels.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/17928445903

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
