### PR TITLE
Bugfix for input modification in `create_*` methods

### DIFF
--- a/changes/573.bugfix.rst
+++ b/changes/573.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix for ``create_*`` methods modifying the input defaults dictionary.

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -203,10 +203,10 @@ class _RomanDataModel(_DataModel):
             return dict1
 
         return merge_dicts(
-            defaults or {},
+            # deepcopy to avoid modifying input
+            {} if defaults is None else copy.deepcopy(dict(defaults)),
             {
                 "meta": {
-                    "model_type": cls.__name__,
                     "calibration_software_name": "RomanCAL",
                     "file_date": time or Time.now(),
                     "origin": "STSCI/SOC",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #572

<!-- describe the changes comprising this PR here -->
This PR adds specific testing for how the specialized defaults are set for the RCAL products datamodels and fixes the issues uncovered.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
