### PR TITLE
Add python 3.14 testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   # "rad >=0.25.0",
   "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
-  "pyarrow >= 10.0.1, ; python_version < '3.14'",
+  "pyarrow >= 10.0.1",
   "semantic_version>=2.8",
 ]
 license-files = ["LICENSE"]

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,11 +1,10 @@
 import astropy.table as astrotab
 import numpy as np
+import pyarrow.parquet as pq
 import pytest
 from asdf.exceptions import ValidationError
 
 from roman_datamodels import datamodels
-
-pq = pytest.importorskip("pyarrow.parquet")
 
 CATALOG_CLASSES = (
     datamodels.ImageSourceCatalogModel,


### PR DESCRIPTION
Same as https://github.com/spacetelescope/rad/pull/732

Update CI for 3.14 testing (now that pyarrow has a 3.14 compatible release).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
