### PR TITLE
support patternProperties required in schema

### DIFF
--- a/changes/591.feature.rst
+++ b/changes/591.feature.rst
@@ -1,0 +1,1 @@
+Support patternProperties for create_minimal/fake_data/from_model.

--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -8,7 +8,6 @@ import re
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-import numpy as np
 from asdf.tags.core.ndarray import asdf_datatype_to_numpy_dtype
 
 from ._schema import Builder, _get_keyword, _get_properties
@@ -50,7 +49,6 @@ __all__ = [
     "SdfSoftwareVersionMixin",
     "TelescopeMixin",
     "TvacFileDateMixin",
-    "WfiImgPhotomRefMixin",
     "WfiModeMixin",
 ]
 
@@ -208,61 +206,6 @@ class L2CalStepMixin(_ObjectBase):
 
 class L3CalStepMixin(L2CalStepMixin):  # same as L2CalStepMixin
     __slots__ = ()
-
-
-class WfiImgPhotomRefMixin(_ObjectBase):
-    __slots__ = ()
-
-    @classmethod
-    def _create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag=None):
-        defaults = defaults or {}
-        _shape = shape or (0,)
-        _shape = _shape[:1]
-        if "phot_table" not in defaults:
-            phot_table = {}
-            for entry in (
-                "F062",
-                "F087",
-                "F106",
-                "F129",
-                "F146",
-                "F158",
-                "F184",
-                "F213",
-                "GRISM",
-                "GRISM_0",
-                "PRISM",
-                "DARK",
-                "NOT_CONFIGURED",
-            ):
-                table_entry = {
-                    "photmjsr": None,
-                    "uncertainty": None,
-                    "pixelareasr": None,
-                    "collecting_area": None,
-                    "wavelength": None,
-                    "effective_area": None,
-                }
-                if entry not in ("DARK", "NOT_CONFIGURED"):
-                    table_entry.update(
-                        {
-                            "collecting_area": 1.0,
-                            "wavelength": np.zeros(_shape, dtype=np.float32),
-                            "effective_area": np.zeros(_shape, dtype=np.float32),
-                        }
-                    )
-                    if entry not in ("GRISM", "GRISM_0", "PRISM"):
-                        table_entry.update(
-                            {
-                                "photmjsr": 1e-15,
-                                "uncertainty": 1e-16,
-                                "pixelareasr": 1e-13,
-                            }
-                        )
-                phot_table[entry] = table_entry
-
-            defaults["phot_table"] = phot_table
-        return super()._create_fake_data(defaults, shape, builder, tag=tag)
 
 
 class ImageSourceCatalogMixin(_ObjectBase):

--- a/tests/stnode/test_schema.py
+++ b/tests/stnode/test_schema.py
@@ -78,6 +78,10 @@ def test_type(schema, type_):
         ({"minItems": 3, "items": [{"enum": [42]}]}, [0, 1], [0, 1]),
         ({"minItems": 3, "items": {"enum": [42]}}, [0, 1], [0, 1, 42]),
         ({"minItems": 2, "items": {"enum": [42]}}, [0, 1], [0, 1]),
+        ({"patternProperties": {"^(A|B)$": {"enum": [0]}}}, {}, {}),
+        ({"required": ["B"], "patternProperties": {"^(A|B)$": {"enum": [0]}}}, {}, {"B": 0}),
+        ({"required": ["B"], "patternProperties": {"^(A|B)$": {"enum": [0]}}}, {"B": 1}, {"B": 1}),
+        ({"required": ["A", "B"], "patternProperties": {"^(A|B)$": {"enum": [0]}}}, {}, {"A": 0, "B": 0}),
     ),
 )
 def test_build(schema, defaults, expected):


### PR DESCRIPTION
This updates the from-schema building code to handle `patternProperties` to:
- allow possibly adding `required` to some reference files (see https://github.com/spacetelescope/rad/pull/712)
- drop `WfiImgPhotomRefMixin` which existed only to work around our lack of `patternProperties` support

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/18477730458

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
