### PR TITLE
Fix the romancal CI job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ requires =
 
 [main]
 rad_repo = https://github.com/spacetelescope/rad.git
-romancal_repo = https://github.com/spacetelescope/romancal.git
+# romancal_repo = https://github.com/spacetelescope/romancal.git
+romancal_repo = https://github.com/WilliamJamieson/romancal.git
 
 [testenv]
 description =
@@ -37,7 +38,8 @@ deps =
     xdist: pytest-xdist
     cov: pytest-cov >= 4.1.0
     rad: rad @ git+{[main]rad_repo}
-    romancal: romancal[test] @ git+{[main]romancal_repo}
+    # romancal: romancal[test] @ git+{[main]romancal_repo}
+    romancal: romancal[test] @ git+{[main]romancal_repo}@fix_upstream_testing
     devdeps: -r requirements-dev.txt
     oldestdeps: minimum_dependencies
 change_dir =


### PR DESCRIPTION
The failing CI jobs we are seeing for the `romancal` tests, see https://github.com/spacetelescope/roman_datamodels/actions/runs/19817116498/job/56770786450, are due to the introduction of the `romanisim` dependency in `romancal` via spacetelescope/romancal#2036. While on the surface this seems like the same issue what was fixed by spacetelescope/rad#774, it turns out there are two related issues blocking the `romancal` CI job from functioning:

1. The `setuptools` install for `romancal`, https://github.com/spacetelescope/roman_datamodels/blob/304fe763d20b7150263e0c783b8df9d5e7179910/tox.ini#L39 appears to be causing some sort of issue when `galsim` (`romanisim` dependency) is installed. For reasons I can't explain this triggers `galsim` to attempt to build itself from source. Removing it resolves this issue.
2. Removing `setuptools` has a secondary effect; namely, `romancal`'s installation does not include every test module. In particular, `skycell/tests` does not have an `__init__.py` so it does not get installed. Since other test files depend on that subpackage the testing then fails. This `__init__.py` does not effect `romancal` at all so this part of the fix is in spacetelescope/romancal#2081.

Note that the last commit on this PR currently retargets the `tox.ini` to point at the downstream `romancal` fix mentioned above. This should be removed before merging this PR.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
