### PR TITLE
Clean up tox.ini and romancal downstream job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ requires =
 
 [main]
 rad_repo = https://github.com/spacetelescope/rad.git
-# romancal_repo = https://github.com/spacetelescope/romancal.git
-romancal_repo = https://github.com/WilliamJamieson/romancal.git
+romancal_repo = https://github.com/spacetelescope/romancal.git
 
 [testenv]
 description =
@@ -38,8 +37,7 @@ deps =
     xdist: pytest-xdist
     cov: pytest-cov >= 4.1.0
     rad: rad @ git+{[main]rad_repo}
-    # romancal: romancal[test] @ git+{[main]romancal_repo}
-    romancal: romancal[test] @ git+{[main]romancal_repo}@fix_upstream_testing
+    romancal: romancal[test] @ git+{[main]romancal_repo}
     devdeps: -r requirements-dev.txt
     oldestdeps: minimum_dependencies
 change_dir =


### PR DESCRIPTION
This PR fixes the reference to a PR branch in romancal left in by #607 ~and then cleans up the downstream CI by making it simpler.~

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
