### PR TITLE
RTB-1027: Add the group-specific dqflag WFI18_TRANSIENT

### DIFF
--- a/changes/615.feature.rst
+++ b/changes/615.feature.rst
@@ -1,0 +1,1 @@
+Add a new group DQ flag ("WFI18_TRANSIENT", value 2**7) for pixels affected by the WFI18 transient anomaly.

--- a/src/roman_datamodels/dqflags.py
+++ b/src/roman_datamodels/dqflags.py
@@ -76,5 +76,6 @@ class group(np.uint8, Enum):
     JUMP_DET   = pixel.JUMP_DET
     DROPOUT    = pixel.DROPOUT
     AD_FLOOR   = pixel.AD_FLOOR
+    WFI18_TRANSIENT = 2**7  # Affected by the WFI18 transient anomaly
 
 # fmt: on

--- a/tests/test_dqflags.py
+++ b/tests/test_dqflags.py
@@ -116,7 +116,9 @@ def test_group_flags(flag, ramp_schema):
     assert dqflags.group[flag.name] is flag
 
     # Test that each group flag matches a pixel flag of the same name
-    assert dqflags.pixel[flag.name] == flag
+    # except for the WFI18_TRANSIENT flag
+    if flag.name != "WFI18_TRANSIENT":
+        assert dqflags.pixel[flag.name] == flag
 
 
 @pytest.mark.parametrize("flag", dqflags.group)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Partially resolves [RTB-1027](https://jira.stsci.edu/browse/RTB-1027)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
Add a group-specific flag for the WFI18 transient anomaly.  This flag will be used only in the group DQ array, prior to ramp fitting, for pixels masked by the wfi18_transient step.  The flag shares a bit with the OUTLIER flag, used only in the pixel DQ array.

Docs updated in the romancal PR: https://github.com/spacetelescope/romancal/pull/2096

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] Update or add relevant `roman_datamodels` tests.
- [x] Update relevant docstrings and / or `docs/` page.
- [x] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [x] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [x] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
