### PR TITLE
Fix the dtype for the group dq flags

### DIFF
--- a/changes/616.bugfix.rst
+++ b/changes/616.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the integer type of the group DQ flags to be uint8 as indicated by the RAD
+schemas.

--- a/src/roman_datamodels/dqflags.py
+++ b/src/roman_datamodels/dqflags.py
@@ -66,7 +66,7 @@ class pixel(np.uint32, Enum):
 
 
 @unique
-class group(np.uint32, Enum):
+class group(np.uint8, Enum):
     """Group-specific data quality flags
         Once groups are combined, these flags are equivalent to the pixel-specific flags.
     """

--- a/tests/test_dqflags.py
+++ b/tests/test_dqflags.py
@@ -110,7 +110,7 @@ def test_group_flags(flag, ramp_schema):
     assert flag.dtype == asdf_datatype_to_numpy_dtype(group_dq_type)
 
     # Test that the group flags are ints
-    assert isinstance(flag, np.uint32)
+    assert isinstance(flag, np.uint8)
 
     # Test that the group flags are dict accessible
     assert dqflags.group[flag.name] is flag


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
In this comment: https://github.com/spacetelescope/roman_datamodels/pull/615#discussion_r2635969993 it was pointed out that the group dq flags are in fact unsigned 8 bit integers not unsigned 32 bit integers. This is confirmed by the `ramp` schema: https://github.com/spacetelescope/rad/blob/c063796494d7526840d9e3ca37cccff3fcc9ad43/latest/ramp.yaml#L47

This PR updates the `groupdq` flags to be `uint8` instead of `uint32` and adds tests to make sure the dq flags meet the type expectations of the schemas.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
