### PR TITLE
drop err array from RampModel

### DIFF
--- a/changes/620.removal.rst
+++ b/changes/620.removal.rst
@@ -1,0 +1,1 @@
+Remove ``err`` array assignment to output ``RampModel`` in ``from_science_raw``.

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -394,7 +394,6 @@ class RampModel(_RomanDataModel):
         ramp_model.pixeldq = np.zeros(shape[1:], dtype=np.uint32)
         ramp_model.groupdq = np.zeros(shape, dtype=np.uint8)
         ramp_model.data = model.data.astype(np.float32)
-        ramp_model.err = np.zeros_like(ramp_model.data)
         ramp_model.amp33 = model.amp33.copy()
 
         # check if the input model has a resultantdq from SDF


### PR DESCRIPTION
Follow-up to https://github.com/spacetelescope/rad/pull/803

Removes assigning the unused `err` array to `RampModel` in `from_science_raw`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
