### PR TITLE
RCAL-1327: Add support to roman-photoz.

### DIFF
--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -304,3 +304,34 @@ class ForcedMosaicSourceCatalogMixin(ImageSourceCatalogMixin):
 
 class MultibandSourceCatalogMixin(ImageSourceCatalogMixin):
     __slots__ = ()
+
+    def get_roman_photoz_column_definition(self, name):
+        """
+        Get the definition of a named column in the roman_photoz table.
+
+        This function parses the "definitions" part of the roman_photoz
+        schema and returns the parsed content.
+
+        Parameters
+        ----------
+        name: str
+            Column name, may be prefixed with ``forced_``.
+
+        Returns
+        -------
+        dict or None
+            Dictionary containing unit, description, and datatype information
+            or None if the name does not match any definition.
+        """
+        if name.startswith("forced_"):
+            _, name = name.split("forced_", maxsplit=1)
+        definitions = _get_keyword(self.get_schema()["properties"]["roman_photoz"], "definitions")
+        for def_name, definition in definitions.items():
+            if def_name == name:
+                return {
+                    "unit": definition["unit"],
+                    "description": definition["description"],
+                    "datatype": asdf_datatype_to_numpy_dtype(
+                        definition["properties"]["data"]["properties"]["datatype"]["enum"][0]
+                    ),
+                }

--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -325,7 +325,7 @@ class MultibandSourceCatalogMixin(ImageSourceCatalogMixin):
         """
         if name.startswith("forced_"):
             _, name = name.split("forced_", maxsplit=1)
-        definitions = _get_keyword(self.get_schema()["properties"]["roman_photoz"], "definitions")
+        definitions = _get_keyword(self.get_schema()["properties"]["source_catalog"], "definitions")
         for def_name, definition in definitions.items():
             if def_name == name:
                 return {

--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -261,6 +261,8 @@ class ImageSourceCatalogMixin(_ObjectBase):
         for raw_col_def in dict(_get_properties(table_schema))["columns"]["allOf"]:
             col_def = raw_col_def["not"]["items"]["not"]
             properties = dict(_get_properties(col_def))
+            if "name" not in properties:
+                continue  # skip optional columns that don't have a name pattern
             name_regex = properties["name"]["pattern"]
             unit = _get_keyword(col_def, "unit")
             description = _get_keyword(col_def, "description")

--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -304,34 +304,3 @@ class ForcedMosaicSourceCatalogMixin(ImageSourceCatalogMixin):
 
 class MultibandSourceCatalogMixin(ImageSourceCatalogMixin):
     __slots__ = ()
-
-    def get_roman_photoz_column_definition(self, name):
-        """
-        Get the definition of a named column in the roman_photoz table.
-
-        This function parses the "definitions" part of the roman_photoz
-        schema and returns the parsed content.
-
-        Parameters
-        ----------
-        name: str
-            Column name, may be prefixed with ``forced_``.
-
-        Returns
-        -------
-        dict or None
-            Dictionary containing unit, description, and datatype information
-            or None if the name does not match any definition.
-        """
-        if name.startswith("forced_"):
-            _, name = name.split("forced_", maxsplit=1)
-        definitions = _get_keyword(self.get_schema()["properties"]["source_catalog"], "definitions")
-        for def_name, definition in definitions.items():
-            if def_name == name:
-                return {
-                    "unit": definition["unit"],
-                    "description": definition["description"],
-                    "datatype": asdf_datatype_to_numpy_dtype(
-                        definition["properties"]["data"]["properties"]["datatype"]["enum"][0]
-                    ),
-                }

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -78,6 +78,29 @@ class _SourceCatalogMixin:
     def get_column_definition(self, name):
         return self._instance.get_column_definition(name)
 
+    def get_roman_photoz_column_definition(self, name):
+        """
+        Get the definition of a named column from the roman_photoz schema.
+
+        This function parses the "definitions" part of the roman_photoz
+        schema and returns the parsed content.
+
+        Parameters
+        ----------
+        name: str
+            Column name (e.g., "photoz", "photoz_gof", "photoz_high68").
+
+        Returns
+        -------
+        dict or None
+            Dictionary containing unit, description, and datatype information
+            or None if the name does not match any definition.
+        """
+        # Only MultibandSourceCatalogModel has this method
+        if hasattr(self._instance, 'get_roman_photoz_column_definition'):
+            return self._instance.get_roman_photoz_column_definition(name)
+        return None
+
 
 class _ParquetMixin:
     """Gives SourceCatalogModels the ability to save to parquet files."""

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -78,29 +78,6 @@ class _SourceCatalogMixin:
     def get_column_definition(self, name):
         return self._instance.get_column_definition(name)
 
-    def get_roman_photoz_column_definition(self, name):
-        """
-        Get the definition of a named column from the roman_photoz schema.
-
-        This function parses the "definitions" part of the roman_photoz
-        schema and returns the parsed content.
-
-        Parameters
-        ----------
-        name: str
-            Column name (e.g., "photoz", "photoz_gof", "photoz_high68").
-
-        Returns
-        -------
-        dict or None
-            Dictionary containing unit, description, and datatype information
-            or None if the name does not match any definition.
-        """
-        # Only MultibandSourceCatalogModel has this method
-        if hasattr(self._instance, 'get_roman_photoz_column_definition'):
-            return self._instance.get_roman_photoz_column_definition(name)
-        return None
-
 
 class _ParquetMixin:
     """Gives SourceCatalogModels the ability to save to parquet files."""


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-1327](https://jira.stsci.edu/browse/RCAL-1327)

<!-- describe the changes comprising this PR here -->
This PR adds a guard in `_create_empty_catalog` (in `roman_datamodels/_stnode/_mixins.py`) to skip columns whose schema uses the `anyOf` pattern (optional columns like the new `photoz` fields). When `_get_properties` can't extract a "name" from the `anyOf` structure, it simply skips that column (since optional columns don't need to be present in an empty catalog).

We added that guard because until now, there was no precedent in RAD for optional columns in the table catalog schema specifically. The table schema use the `not: items: not: allOf` double-negation pattern exclusively for required columns, and no table schema in the project currently has optional columns.



<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
