### PR TITLE
Simple bugfix for the broken history extension recording

### DIFF
--- a/changes/637.bugfix.rst
+++ b/changes/637.bugfix.rst
@@ -1,0 +1,2 @@
+Bugfix for the recorded ``extension_uri`` for roman_datamodels in the ``history``
+section of an asdf file.

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -29,12 +29,9 @@ __all__ = ["NODE_CLASSES"]
 #   and this module creates the classes used by the ASDF extension.
 _MANIFEST_DIR = Path(str(importlib.resources.files(resources) / "manifests"))
 # sort manifests by version (newest first)
-_STATIC_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*static-*.yaml")], reverse=True)
-_STATIC_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _STATIC_MANIFEST_PATHS]
 _DATAMODEL_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")], reverse=True)
 _DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
-# Notice that the static manifests are first so that we defer to them
-_MANIFESTS = _STATIC_MANIFESTS + _DATAMODEL_MANIFESTS
+_MANIFESTS = _DATAMODEL_MANIFESTS
 
 
 def _factory(pattern, latest_manifest, tag_def):

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -1,0 +1,38 @@
+import asdf
+import pytest
+
+from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
+
+from ..conftest import MANIFESTS
+
+
+@pytest.mark.parametrize("tag", NODE_CLASSES_BY_TAG)
+def test_history(tmp_path, tag):
+    filename = tmp_path / "history_test.asdf"
+    node_cls = NODE_CLASSES_BY_TAG[tag]
+    node = node_cls.create_fake_data()
+
+    # Save asdf file
+    asdf.AsdfFile(tree={"roman": node}).write_to(filename)
+
+    # Read extension history
+    with asdf.open(filename) as af:
+        extensions = af.tree["history"]["extensions"]
+
+    # Find the roman extension uris
+    extension_uris = [
+        extension["extension_uri"]
+        for extension in extensions
+        if extension["extension_uri"].startswith("asdf://stsci.edu/datamodels/roman/extensions/")
+    ]
+
+    # There should be just one
+    assert len(extension_uris) == 1
+    extension_uri = extension_uris[0]
+    assert extension_uri.startswith("asdf://stsci.edu/datamodels/roman/extensions/datamodels-")
+
+    datamodels_uri = extension_uri.replace("extensions", "manifests")
+    assert datamodels_uri.startswith("asdf://stsci.edu/datamodels/roman/manifests/datamodels-")
+
+    assert extension_uri == MANIFESTS[0]["extension_uri"]
+    assert datamodels_uri == MANIFESTS[0]["id"]


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #592

<!-- describe the changes comprising this PR here -->
This PR is the simplest fix for the `extension_uri` being recorded incorrectly in the history section of the asdf file. In this case we simply don't create an extension for the static schemas.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
