### PR TITLE
Fix docs build and oldestdeps

### DIFF
--- a/changes/638.bugfix.rst
+++ b/changes/638.bugfix.rst
@@ -1,0 +1,1 @@
+Bump the version of ``semantic-version`` required to stay in line with ``RAD``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,6 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", (None, "http://data.astropy.org/intersphinx/matplotlib.inv")),
     "astropy": ("https://docs.astropy.org/en/stable/", None),
     "asdf": ("https://asdf.readthedocs.io/en/latest/", None),
-    "psutil": ("https://psutil.readthedocs.io/en/stable/", None),
     "rad": ("https://rad.readthedocs.io/en/latest/", None),
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",
-  "semantic_version>=2.8",
+  "semantic_version>=2.10",
 ]
 license-files = ["LICENSE"]
 dynamic = ["version"]


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
The oldest deps job has been broken for awhile and the docs have been failing to build. This PR resolves both of those issues.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
