### PR TITLE
More complex fix for static vs datamodels extensions

### DIFF
--- a/changes/639.bugfix.rst
+++ b/changes/639.bugfix.rst
@@ -1,0 +1,4 @@
+Separate the ``datamodels`` and ``static`` manifest extensions so the the ``"history"``
+section of the ASDF file records the "correct" extension in so far as the ``static``
+manifests are separate from the ``datamodels`` manifests, the extension makes
+no distinction between individual versions of the manifests.

--- a/src/roman_datamodels/_stnode/_converters.py
+++ b/src/roman_datamodels/_stnode/_converters.py
@@ -2,17 +2,28 @@
 The ASDF Converters to handle the serialization/deseialization of the STNode classes to ASDF.
 """
 
+from __future__ import annotations
+
+from typing import ClassVar, Generic, TypeVar
+
 from asdf.extension import Converter, ManifestExtension
 from astropy.time import Time
 
 from ._registry import (
+    DATAMODEL_CONVERTERS,
+    DATAMODEL_MANIFESTS,
+    DATAMODEL_PATTERNS,
     LIST_NODE_CLASSES_BY_PATTERN,
     NODE_CLASSES_BY_TAG,
-    NODE_CONVERTERS,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
+    STATIC_CONVERTERS,
+    STATIC_MANIFESTS,
+    STATIC_PATTERNS,
 )
-from ._stnode import _MANIFESTS
+from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
+
+_T = TypeVar("_T")
 
 __all__ = [
     "NODE_EXTENSIONS",
@@ -22,12 +33,14 @@ __all__ = [
 ]
 
 
-class _RomanConverter(Converter):
+class _RomanConverter(Converter, Generic[_T]):
     """
     Base class for the roman_datamodels converters.
     """
 
     lazy = True
+
+    _node_registry: ClassVar[dict[str, _T]]
 
     def __init_subclass__(cls, **kwargs) -> None:
         """
@@ -36,10 +49,28 @@ class _RomanConverter(Converter):
         super().__init_subclass__(**kwargs)
 
         if not cls.__name__.startswith("_"):
-            if cls.__name__ in NODE_CONVERTERS:
-                raise ValueError(f"Duplicate converter for {cls.__name__}")
+            if (static_name := f"static_{cls.__name__}") in STATIC_CONVERTERS:
+                raise ValueError(f"Duplicate converter for {static_name}")
 
-            NODE_CONVERTERS[cls.__name__] = cls()
+            STATIC_CONVERTERS[static_name] = cls(STATIC_PATTERNS)
+
+            if (datamodel_name := f"datamodel_{cls.__name__}") in DATAMODEL_CONVERTERS:
+                raise ValueError(f"Duplicate converter for {datamodel_name}")
+
+            DATAMODEL_CONVERTERS[datamodel_name] = cls(DATAMODEL_PATTERNS)
+
+    def __init__(self, patterns: dict[str, tagged_type]):
+        super().__init__()
+
+        self._patterns = patterns
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return tuple(pattern for pattern in self._node_registry if pattern in self._patterns)
+
+    @property
+    def types(self) -> tuple[_T, ...]:
+        return tuple(type_ for pattern, type_ in self._node_registry.items() if pattern in self._patterns)
 
     def select_tag(self, obj, tags, ctx):
         return obj.tag
@@ -50,52 +81,34 @@ class _RomanConverter(Converter):
         return obj
 
 
-class TaggedObjectNodeConverter(_RomanConverter):
+class TaggedObjectNodeConverter(_RomanConverter[type[TaggedObjectNode]]):
     """
     Converter for all subclasses of TaggedObjectNode.
     """
 
-    @property
-    def tags(self):
-        return list(OBJECT_NODE_CLASSES_BY_PATTERN.keys())
-
-    @property
-    def types(self):
-        return list(OBJECT_NODE_CLASSES_BY_PATTERN.values())
+    _node_registry = OBJECT_NODE_CLASSES_BY_PATTERN
 
     def to_yaml_tree(self, obj, tag, ctx):
         return dict(obj._data)
 
 
-class TaggedListNodeConverter(_RomanConverter):
+class TaggedListNodeConverter(_RomanConverter[type[TaggedListNode]]):
     """
     Converter for all subclasses of TaggedListNode.
     """
 
-    @property
-    def tags(self):
-        return list(LIST_NODE_CLASSES_BY_PATTERN.keys())
-
-    @property
-    def types(self):
-        return list(LIST_NODE_CLASSES_BY_PATTERN.values())
+    _node_registry = LIST_NODE_CLASSES_BY_PATTERN
 
     def to_yaml_tree(self, obj, tag, ctx):
         return list(obj)
 
 
-class TaggedScalarNodeConverter(_RomanConverter):
+class TaggedScalarNodeConverter(_RomanConverter[type[TaggedScalarNode]]):
     """
     Converter for all subclasses of TaggedScalarNode.
     """
 
-    @property
-    def tags(self):
-        return list(SCALAR_NODE_CLASSES_BY_PATTERN.keys())
-
-    @property
-    def types(self):
-        return list(SCALAR_NODE_CLASSES_BY_PATTERN.values())
+    _node_registry = SCALAR_NODE_CLASSES_BY_PATTERN
 
     def to_yaml_tree(self, obj, tag, ctx):
         node = obj.__class__.__bases__[0](obj)
@@ -115,5 +128,12 @@ class TaggedScalarNodeConverter(_RomanConverter):
 
 # Create the ASDF extension for the STNode classes.
 NODE_EXTENSIONS = {
-    manifest["id"]: ManifestExtension.from_uri(manifest["id"], converters=NODE_CONVERTERS.values()) for manifest in _MANIFESTS
+    **{
+        manifest["id"]: ManifestExtension.from_uri(manifest["id"], converters=STATIC_CONVERTERS.values())
+        for manifest in STATIC_MANIFESTS
+    },
+    **{
+        manifest["id"]: ManifestExtension.from_uri(manifest["id"], converters=DATAMODEL_CONVERTERS.values())
+        for manifest in DATAMODEL_MANIFESTS
+    },
 }

--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -6,16 +6,32 @@ Hold all the registry information for the STNode classes.
 
 from __future__ import annotations
 
+import importlib.resources
+from pathlib import Path
 from typing import TYPE_CHECKING
+
+import yaml
+from rad import resources
 
 if TYPE_CHECKING:
     from ._converters import _RomanConverter
     from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
 
+# Load the manifest directly from the rad resources and not from ASDF.
+#   This is because the ASDF extensions have to be created before they can be registered
+#   and this module creates the classes used by the ASDF extension.
+_MANIFEST_DIR = Path(str(importlib.resources.files(resources) / "manifests"))
+# sort manifests by version (newest first)
+_STATIC_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*static-*.yaml")], reverse=True)
+STATIC_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _STATIC_MANIFEST_PATHS]
+_DATAMODEL_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")], reverse=True)
+DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
+
 OBJECT_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedObjectNode]] = {}
 LIST_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedListNode]] = {}
 SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
-NODE_CONVERTERS: dict[str, type[_RomanConverter]] = {}
+STATIC_CONVERTERS: dict[str, type[_RomanConverter]] = {}
+DATAMODEL_CONVERTERS: dict[str, type[_RomanConverter]] = {}
 NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
 SCHEMA_URIS_BY_TAG: dict[str, str] = {}
 STATIC_PATTERNS: dict[str, tagged_type] = {}

--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -18,3 +18,5 @@ SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
 NODE_CONVERTERS: dict[str, type[_RomanConverter]] = {}
 NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
 SCHEMA_URIS_BY_TAG: dict[str, str] = {}
+STATIC_PATTERNS: dict[str, tagged_type] = {}
+DATAMODEL_PATTERNS: dict[str, tagged_type] = {}

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -6,36 +6,22 @@ Dynamic creation of STNode classes from the RAD manifest.
     used by the user.
 """
 
-import importlib.resources
-from pathlib import Path
-
-import yaml
-from rad import resources
-
 from ._factories import stnode_factory
 from ._registry import (
+    DATAMODEL_MANIFESTS,
     DATAMODEL_PATTERNS,
     LIST_NODE_CLASSES_BY_PATTERN,
     NODE_CLASSES_BY_TAG,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SCHEMA_URIS_BY_TAG,
+    STATIC_MANIFESTS,
     STATIC_PATTERNS,
 )
 
-__all__ = ["NODE_CLASSES"]
+__all__ = ["DATAMODEL_MANIFESTS", "NODE_CLASSES", "STATIC_MANIFESTS"]
 
 
-# Load the manifest directly from the rad resources and not from ASDF.
-#   This is because the ASDF extensions have to be created before they can be registered
-#   and this module creates the classes used by the ASDF extension.
-_MANIFEST_DIR = Path(str(importlib.resources.files(resources) / "manifests"))
-# sort manifests by version (newest first)
-_STATIC_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*static-*.yaml")], reverse=True)
-STATIC_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _STATIC_MANIFEST_PATHS]
-_DATAMODEL_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")], reverse=True)
-DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
-# Notice that the static manifests are first so that we defer to them
 _MANIFESTS = STATIC_MANIFESTS + DATAMODEL_MANIFESTS
 
 

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -14,11 +14,13 @@ from rad import resources
 
 from ._factories import stnode_factory
 from ._registry import (
+    DATAMODEL_PATTERNS,
     LIST_NODE_CLASSES_BY_PATTERN,
     NODE_CLASSES_BY_TAG,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SCHEMA_URIS_BY_TAG,
+    STATIC_PATTERNS,
 )
 
 __all__ = ["NODE_CLASSES"]
@@ -30,11 +32,11 @@ __all__ = ["NODE_CLASSES"]
 _MANIFEST_DIR = Path(str(importlib.resources.files(resources) / "manifests"))
 # sort manifests by version (newest first)
 _STATIC_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*static-*.yaml")], reverse=True)
-_STATIC_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _STATIC_MANIFEST_PATHS]
+STATIC_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _STATIC_MANIFEST_PATHS]
 _DATAMODEL_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")], reverse=True)
-_DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
+DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
 # Notice that the static manifests are first so that we defer to them
-_MANIFESTS = _STATIC_MANIFESTS + _DATAMODEL_MANIFESTS
+_MANIFESTS = STATIC_MANIFESTS + DATAMODEL_MANIFESTS
 
 
 def _factory(pattern, latest_manifest, tag_def):
@@ -53,17 +55,32 @@ def _factory(pattern, latest_manifest, tag_def):
 # Main dynamic class creation loop
 #   Reads each tag entry from the manifest and creates a class for it
 _generated = {}
-for manifest in _MANIFESTS:
+
+
+def _process_manifest(manifest):
     manifest_uri = manifest["id"]
+    nodes_by_pattern = {}
     for tag_def in manifest["tags"]:
         SCHEMA_URIS_BY_TAG[tag_def["tag_uri"]] = tag_def["schema_uri"]
-        base, version = tag_def["tag_uri"].rsplit("-", maxsplit=1)
+        base, _ = tag_def["tag_uri"].rsplit("-", maxsplit=1)
 
         # make pattern from tag
         pattern = f"{base}-*"
         if pattern not in _generated:
             _generated[pattern] = _factory(pattern, manifest_uri, tag_def)
+            nodes_by_pattern[pattern] = _generated[pattern]
+
         NODE_CLASSES_BY_TAG[tag_def["tag_uri"]] = _generated[pattern]
+
+    return nodes_by_pattern
+
+
+for manifest in STATIC_MANIFESTS:
+    STATIC_PATTERNS.update(_process_manifest(manifest))
+
+
+for manifest in DATAMODEL_MANIFESTS:
+    DATAMODEL_PATTERNS.update(_process_manifest(manifest))
 
 
 # List of node classes made available by this library.

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -63,7 +63,7 @@ def test_node_uris(node_tag, node_cls, request):
         raise ValueError(f"{node_cls._pattern} for {type(node_cls)} is not in a manifest")
 
 
-def test_history(tmp_path, node_instance):
+def test_history(tmp_path, node_tag, node_instance, request):
     filename = tmp_path / "history_test.asdf"
     prefix = "asdf://stsci.edu/datamodels/roman/extensions/"
 
@@ -91,3 +91,10 @@ def test_history(tmp_path, node_instance):
 
     datamodels_uri = extension_uri.replace("extensions", "manifests")
     assert datamodels_uri.startswith(prefix.replace("extensions", "manifests"))
+
+    # Place the xfail mark here because any failure above will result in a test fail
+    #    rather than an xfail. The RAD bug expresses itself here
+    if node_tag in _X_FAIL_TAGS:
+        request.node.add_marker(pytest.mark.xfail(reason=f"RAD has a manifest bug for {node_tag}"))
+
+    assert datamodels_uri == node_instance._latest_manifest

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -1,0 +1,93 @@
+import asdf
+import pytest
+
+from roman_datamodels._stnode._registry import DATAMODEL_PATTERNS, NODE_CLASSES_BY_TAG, STATIC_PATTERNS
+from roman_datamodels._stnode._stnode import DATAMODEL_MANIFESTS, STATIC_MANIFESTS
+
+_LATEST_STATIC = STATIC_MANIFESTS[0]
+_LATEST_STATIC_URIS = set(tag_def["tag_uri"] for tag_def in _LATEST_STATIC["tags"])
+_LATEST_DATAMODEL = DATAMODEL_MANIFESTS[0]
+_LATEST_DATAMODEL_URIS = set(tag_def["tag_uri"] for tag_def in _LATEST_DATAMODEL["tags"])
+
+
+# RAD has a bug in its manifests making it so that some tags are not accounted for
+_X_FAIL_TAGS = {
+    "asdf://stsci.edu/datamodels/roman/tags/l3_cal_step-1.0.0",
+    "asdf://stsci.edu/datamodels/roman/tags/l3_cal_step-1.1.0",
+    "asdf://stsci.edu/datamodels/roman/tags/resample-1.0.0",
+    "asdf://stsci.edu/datamodels/roman/tags/individual_image_meta-1.0.0",
+    "asdf://stsci.edu/datamodels/roman/tags/mosaic_associations-1.0.0",
+    "asdf://stsci.edu/datamodels/roman/tags/mosaic_wcsinfo-1.0.0",
+}
+
+# from ..conftest import MANIFESTS
+
+
+@pytest.fixture(scope="session", params=NODE_CLASSES_BY_TAG)
+def node_tag(request):
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def node_cls(node_tag):
+    return NODE_CLASSES_BY_TAG[node_tag]
+
+
+@pytest.fixture(scope="session")
+def node_instance(node_cls):
+    return node_cls.create_fake_data()
+
+
+def test_static_datamodel_pattern_disjoint():
+    """Test that the static and datamodel manifests are disjoint"""
+    assert len(STATIC_PATTERNS) > 0
+    assert len(DATAMODEL_PATTERNS) > 0
+
+    assert set(STATIC_PATTERNS.keys()) & set(DATAMODEL_PATTERNS.keys()) == set()
+
+
+def test_node_uris(node_tag, node_cls, request):
+    """Test the _default_tag and _latest_manifest uris to make sure they are correct"""
+    if node_tag in _X_FAIL_TAGS:
+        request.node.add_marker(pytest.mark.xfail(reason=f"RAD has a manifest bug for {node_tag}"))
+
+    if node_cls._pattern in STATIC_PATTERNS:
+        assert node_cls._default_tag in _LATEST_STATIC_URIS
+        assert node_cls._latest_manifest == _LATEST_STATIC["id"]
+
+    elif node_cls._pattern in DATAMODEL_PATTERNS:
+        assert node_cls._default_tag in _LATEST_DATAMODEL_URIS
+        assert node_cls._latest_manifest == _LATEST_DATAMODEL["id"]
+
+    else:
+        raise ValueError(f"{node_cls._pattern} for {type(node_cls)} is not in a manifest")
+
+
+def test_history(tmp_path, node_instance):
+    filename = tmp_path / "history_test.asdf"
+    prefix = "asdf://stsci.edu/datamodels/roman/extensions/"
+
+    # Save asdf file
+    asdf.AsdfFile(tree={"roman": node_instance}).write_to(filename)
+
+    # Read extension history
+    with asdf.open(filename) as af:
+        extensions = af.tree["history"]["extensions"]
+
+    # Find the roman extension uris
+    extension_uris = [extension["extension_uri"] for extension in extensions if extension["extension_uri"].startswith(prefix)]
+
+    # There should be just one
+    assert len(extension_uris) == 1
+
+    # Generate the prefix for the extension
+    if node_instance._pattern in STATIC_PATTERNS:
+        prefix += "static-"
+    else:
+        prefix += "datamodels-"
+
+    extension_uri = extension_uris[0]
+    assert extension_uri.startswith(prefix)
+
+    datamodels_uri = extension_uri.replace("extensions", "manifests")
+    assert datamodels_uri.startswith(prefix.replace("extensions", "manifests"))


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR solves the exact problem that @braingram is getting at in https://github.com/spacetelescope/roman_datamodels/pull/637#pullrequestreview-4007900821 but it does not solve the more general issue I point out https://github.com/spacetelescope/roman_datamodels/issues/592#issuecomment-4127953421. It does this by creating additional converters that are only targeted at the latest datamodels and latest static manifests respectively.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
