### PR TITLE
Fully fix the extension listing in asdf file history

### DIFF
--- a/changes/640.bugfix.rst
+++ b/changes/640.bugfix.rst
@@ -1,0 +1,3 @@
+Bugfix for recording the correct extension used for a node in the history section
+of an ASDF file when writing that node to the file. This should fix the issue
+for any version of any node.

--- a/src/roman_datamodels/_stnode/_converters.py
+++ b/src/roman_datamodels/_stnode/_converters.py
@@ -2,7 +2,11 @@
 The ASDF Converters to handle the serialization/deseialization of the STNode classes to ASDF.
 """
 
-from asdf.extension import Converter, ManifestExtension
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from asdf.extension import Converter
 from astropy.time import Time
 
 from ._registry import (
@@ -11,11 +15,13 @@ from ._registry import (
     NODE_CONVERTERS,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
+    SERIALIZATION_BY_TAG,
 )
-from ._stnode import _MANIFESTS
+
+if TYPE_CHECKING:
+    from ._tagged import SerializationTaggedNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode
 
 __all__ = [
-    "NODE_EXTENSIONS",
     "TaggedListNodeConverter",
     "TaggedObjectNodeConverter",
     "TaggedScalarNodeConverter",
@@ -29,6 +35,43 @@ class _RomanConverter(Converter):
 
     lazy = True
 
+
+class SerializationTaggedNodeConverter(_RomanConverter):
+    """
+    Converter that tags are deferred to so that the correct
+    extension can be applied
+    """
+
+    def __init__(self, manifest_uri: str, tags: list[str]):
+        self._tags = tags
+        self._manifest_uri = manifest_uri
+
+    def select_tag(self, obj: SerializationTaggedNode, tags, ctx) -> str:
+        return obj.tag
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return tuple(self._tags)
+
+    @property
+    def types(self) -> tuple[type[SerializationTaggedNode], ...]:
+        return tuple(type_ for tag, type_ in SERIALIZATION_BY_TAG.items() if tag in self._tags)
+
+    def to_yaml_tree(self, obj: SerializationTaggedNode, tag, ctx):
+        return obj.data
+
+    def from_yaml_tree(self, node, tag, ctx) -> TaggedObjectNode | TaggedListNode | TaggedScalarNode:
+        if "file_date" in tag:
+            converter = ctx.extension_manager.get_converter_for_type(Time)
+            node = converter.from_yaml_tree(node, tag, ctx)
+
+        # TODO: Add method for setting read_tag with some checks
+        obj = NODE_CLASSES_BY_TAG[tag](node)
+        obj._read_tag = tag
+        return obj
+
+
+class _TaggedNodeConverter(_RomanConverter):
     def __init_subclass__(cls, **kwargs) -> None:
         """
         Automatically create the converter objects.
@@ -42,78 +85,59 @@ class _RomanConverter(Converter):
             NODE_CONVERTERS[cls.__name__] = cls()
 
     def select_tag(self, obj, tags, ctx):
-        return obj.tag
+        return None
+
+    @property
+    def tags(self) -> tuple:
+        return ()
+
+    def to_yaml_tree(self, obj, tag, ctx):
+        return SERIALIZATION_BY_TAG[tag](obj)
 
     def from_yaml_tree(self, node, tag, ctx):
-        obj = NODE_CLASSES_BY_TAG[tag](node)
-        obj._read_tag = tag
-        return obj
+        raise NotImplementedError("Converter deserialization deferred")
 
 
-class TaggedObjectNodeConverter(_RomanConverter):
+class TaggedObjectNodeConverter(_TaggedNodeConverter):
     """
     Converter for all subclasses of TaggedObjectNode.
     """
 
     @property
-    def tags(self):
-        return list(OBJECT_NODE_CLASSES_BY_PATTERN.keys())
-
-    @property
     def types(self):
-        return list(OBJECT_NODE_CLASSES_BY_PATTERN.values())
+        return tuple(OBJECT_NODE_CLASSES_BY_PATTERN.values())
 
-    def to_yaml_tree(self, obj, tag, ctx):
-        return dict(obj._data)
+    def to_yaml_tree(self, obj: TaggedObjectNode, tag, ctx):
+        return super().to_yaml_tree(dict(obj._data), obj.tag, ctx)
 
 
-class TaggedListNodeConverter(_RomanConverter):
+class TaggedListNodeConverter(_TaggedNodeConverter):
     """
     Converter for all subclasses of TaggedListNode.
     """
 
     @property
-    def tags(self):
-        return list(LIST_NODE_CLASSES_BY_PATTERN.keys())
-
-    @property
     def types(self):
-        return list(LIST_NODE_CLASSES_BY_PATTERN.values())
+        return tuple(LIST_NODE_CLASSES_BY_PATTERN.values())
 
     def to_yaml_tree(self, obj, tag, ctx):
-        return list(obj)
+        return super().to_yaml_tree(list(obj), obj.tag, ctx)
 
 
-class TaggedScalarNodeConverter(_RomanConverter):
+class TaggedScalarNodeConverter(_TaggedNodeConverter):
     """
     Converter for all subclasses of TaggedScalarNode.
     """
-
-    @property
-    def tags(self):
-        return list(SCALAR_NODE_CLASSES_BY_PATTERN.keys())
 
     @property
     def types(self):
         return list(SCALAR_NODE_CLASSES_BY_PATTERN.values())
 
     def to_yaml_tree(self, obj, tag, ctx):
-        node = obj.__class__.__bases__[0](obj)
+        node = type(obj).__bases__[0](obj)
 
-        if "file_date" in tag:
+        if "file_date" in obj.tag:
             converter = ctx.extension_manager.get_converter_for_type(type(node))
             node = converter.to_yaml_tree(node, tag, ctx)
 
-        return node
-
-    def from_yaml_tree(self, node, tag, ctx):
-        if "file_date" in tag:
-            converter = ctx.extension_manager.get_converter_for_type(Time)
-            node = converter.from_yaml_tree(node, tag, ctx)
-        return super().from_yaml_tree(node, tag, ctx)
-
-
-# Create the ASDF extension for the STNode classes.
-NODE_EXTENSIONS = {
-    manifest["id"]: ManifestExtension.from_uri(manifest["id"], converters=NODE_CONVERTERS.values()) for manifest in _MANIFESTS
-}
+        return super().to_yaml_tree(node, obj.tag, ctx)

--- a/src/roman_datamodels/_stnode/_converters.py
+++ b/src/roman_datamodels/_stnode/_converters.py
@@ -11,15 +11,17 @@ from astropy.time import Time
 
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
+    MANIFEST_TAG_REGISTRY,
     NODE_CLASSES_BY_TAG,
     NODE_CONVERTERS,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
-    SERIALIZATION_BY_TAG,
+    SERIALIZATION_BY_MANIFEST,
+    TAG_MANIFEST_REGISTRY,
 )
 
 if TYPE_CHECKING:
-    from ._tagged import SerializationTaggedNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode
+    from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode
 
 __all__ = [
     "TaggedListNodeConverter",
@@ -36,28 +38,27 @@ class _RomanConverter(Converter):
     lazy = True
 
 
-class SerializationTaggedNodeConverter(_RomanConverter):
+class SerializationNodeConverter(_RomanConverter):
     """
     Converter that tags are deferred to so that the correct
     extension can be applied
     """
 
-    def __init__(self, manifest_uri: str, tags: list[str]):
-        self._tags = tags
+    def __init__(self, manifest_uri: str):
         self._manifest_uri = manifest_uri
 
-    def select_tag(self, obj: SerializationTaggedNode, tags, ctx) -> str:
+    def select_tag(self, obj: SerializationNode, tags, ctx) -> str:
         return obj.tag
 
     @property
     def tags(self) -> tuple[str, ...]:
-        return tuple(self._tags)
+        return tuple(MANIFEST_TAG_REGISTRY[self._manifest_uri])
 
     @property
-    def types(self) -> tuple[type[SerializationTaggedNode], ...]:
-        return tuple(type_ for tag, type_ in SERIALIZATION_BY_TAG.items() if tag in self._tags)
+    def types(self) -> tuple[type[SerializationNode], ...]:
+        return (SERIALIZATION_BY_MANIFEST[self._manifest_uri],)
 
-    def to_yaml_tree(self, obj: SerializationTaggedNode, tag, ctx):
+    def to_yaml_tree(self, obj: SerializationNode, tag, ctx):
         return obj.data
 
     def from_yaml_tree(self, node, tag, ctx) -> TaggedObjectNode | TaggedListNode | TaggedScalarNode:
@@ -92,7 +93,7 @@ class _TaggedNodeConverter(_RomanConverter):
         return ()
 
     def to_yaml_tree(self, obj, tag, ctx):
-        return SERIALIZATION_BY_TAG[tag](obj)
+        return SERIALIZATION_BY_MANIFEST[TAG_MANIFEST_REGISTRY[tag]](obj, tag)
 
     def from_yaml_tree(self, node, tag, ctx):
         raise NotImplementedError("Converter deserialization deferred")

--- a/src/roman_datamodels/_stnode/_factories.py
+++ b/src/roman_datamodels/_stnode/_factories.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from astropy.time import Time
 
 from . import _mixins
-from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, name_from_tag_uri
+from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, class_name_from_tag_uri
 
 if TYPE_CHECKING:
     from ._tagged import tagged_type
@@ -27,27 +27,6 @@ _SCALAR_TYPE_BY_PATTERN = {
 _NODE_TYPE_BY_PATTERN = {
     "asdf://stsci.edu/datamodels/roman/tags/cal_logs-*": TaggedListNode,
 }
-
-
-def class_name_from_tag_uri(tag_uri: str) -> str:
-    """
-    Construct the class name for the STNode class from the tag_uri
-
-    Parameters
-    ----------
-    tag_uri : str
-        The tag_uri found in the RAD manifest
-
-    Returns
-    -------
-    string name for the class
-    """
-    tag_name = name_from_tag_uri(tag_uri)
-    class_name = "".join([p.capitalize() for p in tag_name.split("_")])
-    if tag_uri.startswith("asdf://stsci.edu/datamodels/roman/tags/reference_files/"):
-        class_name += "Ref"
-
-    return class_name
 
 
 def docstring_from_tag(tag_def: dict[str, Any]) -> str:

--- a/src/roman_datamodels/_stnode/_integration.py
+++ b/src/roman_datamodels/_stnode/_integration.py
@@ -8,6 +8,8 @@ def get_extensions():
     -------
     List[`asdf.extension.Extension`]
     """
-    from ._converters import NODE_EXTENSIONS
+    # Importing from ._stnode itself so that all the dynamically created
+    #   objects are in fact created
+    from ._stnode import NODE_EXTENSIONS
 
     return list(NODE_EXTENSIONS.values())

--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -250,43 +250,46 @@ class ImageSourceCatalogMixin(_ObjectBase):
                 }
 
     @classmethod
-    def _create_empty_catalog(cls, aperture_radii=None, filters=None):
+    def _create_empty_catalog(cls, tag=None, aperture_radii=None, filters=None):
         from astropy.table import Column, Table
 
         aperture_radii = aperture_radii or ["00"]
         filters = filters or ["f184"]
 
-        table_schema = _get_schema_from_tag(cls._default_tag)["properties"]["source_catalog"]
+        columns_schema = dict(_get_properties(_get_schema_from_tag(tag or cls._default_tag)["properties"]["source_catalog"]))
         columns = []
-        for raw_col_def in dict(_get_properties(table_schema))["columns"]["allOf"]:
-            col_def = raw_col_def["not"]["items"]["not"]
-            properties = dict(_get_properties(col_def))
-            name_regex = properties["name"]["pattern"]
-            unit = _get_keyword(col_def, "unit")
-            description = _get_keyword(col_def, "description")
-            dtype = asdf_datatype_to_numpy_dtype(properties["data"]["properties"]["datatype"]["enum"][0])
 
-            name_queue = [name_regex[1:-1]]
+        if "columns" in columns_schema:
+            for raw_col_def in columns_schema["columns"]["allOf"]:
+                col_def = raw_col_def["not"]["items"]["not"]
+                properties = dict(_get_properties(col_def))
+                name_regex = properties["name"]["pattern"]
+                unit = _get_keyword(col_def, "unit")
+                description = _get_keyword(col_def, "description")
+                dtype = asdf_datatype_to_numpy_dtype(properties["data"]["properties"]["datatype"]["enum"][0])
 
-            substitutions = [
-                (r"\[0-9]\{2}", aperture_radii),
-                (r"\(.*\)", filters),
-            ]
-            while name_queue:
-                name = name_queue.pop()
-                for regex, values in substitutions:
-                    if re.search(regex, name):
-                        name_queue.extend(re.sub(regex, value, name) for value in values)
-                        break
-                else:
-                    columns.append(Column([], unit=unit, description=description, dtype=dtype, name=name))
+                name_queue = [name_regex[1:-1]]
+
+                substitutions = [
+                    (r"\[0-9]\{2}", aperture_radii),
+                    (r"\(.*\)", filters),
+                ]
+                while name_queue:
+                    name = name_queue.pop()
+                    for regex, values in substitutions:
+                        if re.search(regex, name):
+                            name_queue.extend(re.sub(regex, value, name) for value in values)
+                            break
+                    else:
+                        columns.append(Column([], unit=unit, description=description, dtype=dtype, name=name))
+
         return Table(columns)
 
     @classmethod
     def _create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag=None):
         defaults = defaults or {}
         if "source_catalog" not in defaults:
-            defaults["source_catalog"] = cls._create_empty_catalog()
+            defaults["source_catalog"] = cls._create_empty_catalog(tag=tag)
         return super()._create_fake_data(defaults, shape, builder, tag=tag)
 
 

--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._converters import _RomanConverter
-    from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
+    from ._tagged import SerializationTaggedNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
 
 OBJECT_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedObjectNode]] = {}
 LIST_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedListNode]] = {}
@@ -18,3 +18,5 @@ SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
 NODE_CONVERTERS: dict[str, type[_RomanConverter]] = {}
 NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
 SCHEMA_URIS_BY_TAG: dict[str, str] = {}
+SERIALIZATION_BY_TAG: dict[str, type[SerializationTaggedNode]] = {}
+MANIFEST_TAG_REGISTRY: dict[str, list[str]] = {}

--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._converters import _RomanConverter
-    from ._tagged import SerializationTaggedNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
+    from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
 
 OBJECT_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedObjectNode]] = {}
 LIST_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedListNode]] = {}
@@ -18,5 +18,6 @@ SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
 NODE_CONVERTERS: dict[str, type[_RomanConverter]] = {}
 NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
 SCHEMA_URIS_BY_TAG: dict[str, str] = {}
-SERIALIZATION_BY_TAG: dict[str, type[SerializationTaggedNode]] = {}
+SERIALIZATION_BY_MANIFEST: dict[str, type[SerializationNode]] = {}
 MANIFEST_TAG_REGISTRY: dict[str, list[str]] = {}
+TAG_MANIFEST_REGISTRY: dict[str, str] = {}

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -10,18 +10,24 @@ import importlib.resources
 from pathlib import Path
 
 import yaml
+from asdf.extension import ManifestExtension
 from rad import resources
 
+from ._converters import SerializationTaggedNodeConverter
 from ._factories import stnode_factory
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
+    MANIFEST_TAG_REGISTRY,
     NODE_CLASSES_BY_TAG,
+    NODE_CONVERTERS,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SCHEMA_URIS_BY_TAG,
+    SERIALIZATION_BY_TAG,
 )
+from ._tagged import SerializationTaggedNode
 
-__all__ = ["NODE_CLASSES"]
+__all__ = ["NODE_CLASSES", "NODE_EXTENSIONS"]
 
 
 # Load the manifest directly from the rad resources and not from ASDF.
@@ -35,17 +41,19 @@ DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_
 _MANIFESTS = DATAMODEL_MANIFESTS
 
 
+def _add_cls(cls):
+    class_name = cls.__name__
+    globals()[class_name] = cls  # Add to namespace of module
+    __all__.append(class_name)  # add to __all__ so it's imported with `from . import *`
+    return cls
+
+
 def _factory(pattern, latest_manifest, tag_def):
     """
     Wrap the __all__ append and class creation in a function to avoid the linter
         getting upset
     """
-    cls = stnode_factory(pattern, latest_manifest, tag_def)
-
-    class_name = cls.__name__
-    globals()[class_name] = cls  # Add to namespace of module
-    __all__.append(class_name)  # add to __all__ so it's imported with `from . import *`
-    return cls
+    return _add_cls(stnode_factory(pattern, latest_manifest, tag_def))
 
 
 # Main dynamic class creation loop
@@ -53,15 +61,31 @@ def _factory(pattern, latest_manifest, tag_def):
 _generated = {}
 for manifest in _MANIFESTS:
     manifest_uri = manifest["id"]
+    MANIFEST_TAG_REGISTRY[manifest_uri] = []
     for tag_def in manifest["tags"]:
-        SCHEMA_URIS_BY_TAG[tag_def["tag_uri"]] = tag_def["schema_uri"]
-        base, version = tag_def["tag_uri"].rsplit("-", maxsplit=1)
+        SCHEMA_URIS_BY_TAG[tag_uri := tag_def["tag_uri"]] = tag_def["schema_uri"]
+        base, _ = tag_uri.rsplit("-", maxsplit=1)
 
         # make pattern from tag
         pattern = f"{base}-*"
         if pattern not in _generated:
             _generated[pattern] = _factory(pattern, manifest_uri, tag_def)
-        NODE_CLASSES_BY_TAG[tag_def["tag_uri"]] = _generated[pattern]
+        NODE_CLASSES_BY_TAG[tag_uri] = _generated[pattern]
+
+        # Make serialization intermediate
+        if tag_uri not in SERIALIZATION_BY_TAG:
+            _add_cls(SerializationTaggedNode._factory(tag_uri))
+            MANIFEST_TAG_REGISTRY[manifest_uri].append(tag_uri)
+
+
+# Create the ASDF extension for the STNode classes.
+#    ASDF extension is setup here so that it is after the dynamic object creation
+NODE_EXTENSIONS = {
+    manifest_uri: ManifestExtension.from_uri(
+        manifest_uri, converters=(SerializationTaggedNodeConverter(manifest_uri, tags), *tuple(NODE_CONVERTERS.values()))
+    )
+    for manifest_uri, tags in MANIFEST_TAG_REGISTRY.items()
+}
 
 
 # List of node classes made available by this library.

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -13,7 +13,7 @@ import yaml
 from asdf.extension import ManifestExtension
 from rad import resources
 
-from ._converters import SerializationTaggedNodeConverter
+from ._converters import SerializationNodeConverter
 from ._factories import stnode_factory
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
@@ -23,9 +23,9 @@ from ._registry import (
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SCHEMA_URIS_BY_TAG,
-    SERIALIZATION_BY_TAG,
+    TAG_MANIFEST_REGISTRY,
 )
-from ._tagged import SerializationTaggedNode
+from ._tagged import SerializationNode
 
 __all__ = ["NODE_CLASSES", "NODE_EXTENSIONS"]
 
@@ -60,7 +60,8 @@ def _factory(pattern, latest_manifest, tag_def):
 #   Reads each tag entry from the manifest and creates a class for it
 _generated = {}
 for manifest in _MANIFESTS:
-    manifest_uri = manifest["id"]
+    _add_cls(SerializationNode._factory(manifest_uri := manifest["id"]))
+
     MANIFEST_TAG_REGISTRY[manifest_uri] = []
     for tag_def in manifest["tags"]:
         SCHEMA_URIS_BY_TAG[(tag_uri := tag_def["tag_uri"])] = tag_def["schema_uri"]
@@ -73,8 +74,8 @@ for manifest in _MANIFESTS:
         NODE_CLASSES_BY_TAG[tag_uri] = _generated[pattern]
 
         # Make serialization intermediate
-        if tag_uri not in SERIALIZATION_BY_TAG:
-            _add_cls(SerializationTaggedNode._factory(tag_uri))
+        if tag_uri not in TAG_MANIFEST_REGISTRY:
+            TAG_MANIFEST_REGISTRY[tag_uri] = manifest_uri
             MANIFEST_TAG_REGISTRY[manifest_uri].append(tag_uri)
 
 
@@ -82,9 +83,9 @@ for manifest in _MANIFESTS:
 #    ASDF extension is setup here so that it is after the dynamic object creation
 NODE_EXTENSIONS = {
     manifest_uri: ManifestExtension.from_uri(
-        manifest_uri, converters=(SerializationTaggedNodeConverter(manifest_uri, tags), *tuple(NODE_CONVERTERS.values()))
+        manifest_uri, converters=(SerializationNodeConverter(manifest_uri), *tuple(NODE_CONVERTERS.values()))
     )
-    for manifest_uri, tags in MANIFEST_TAG_REGISTRY.items()
+    for manifest_uri in MANIFEST_TAG_REGISTRY
 }
 
 

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -63,7 +63,7 @@ for manifest in _MANIFESTS:
     manifest_uri = manifest["id"]
     MANIFEST_TAG_REGISTRY[manifest_uri] = []
     for tag_def in manifest["tags"]:
-        SCHEMA_URIS_BY_TAG[tag_uri := tag_def["tag_uri"]] = tag_def["schema_uri"]
+        SCHEMA_URIS_BY_TAG[(tag_uri := tag_def["tag_uri"])] = tag_def["schema_uri"]
         base, _ = tag_uri.rsplit("-", maxsplit=1)
 
         # make pattern from tag

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -28,13 +28,11 @@ __all__ = ["NODE_CLASSES"]
 #   This is because the ASDF extensions have to be created before they can be registered
 #   and this module creates the classes used by the ASDF extension.
 _MANIFEST_DIR = Path(str(importlib.resources.files(resources) / "manifests"))
-# sort manifests by version (newest first)
-_STATIC_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*static-*.yaml")], reverse=True)
-_STATIC_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _STATIC_MANIFEST_PATHS]
+# TODO: We should make this use semantic versioning to sort to ensure we don't get something strange
 _DATAMODEL_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")], reverse=True)
-_DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
+DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
 # Notice that the static manifests are first so that we defer to them
-_MANIFESTS = _STATIC_MANIFESTS + _DATAMODEL_MANIFESTS
+_MANIFESTS = DATAMODEL_MANIFESTS
 
 
 def _factory(pattern, latest_manifest, tag_def):

--- a/src/roman_datamodels/_stnode/_stnode.pyi
+++ b/src/roman_datamodels/_stnode/_stnode.pyi
@@ -1,5 +1,7 @@
 from typing import Any
 
+from asdf.extension import ManifestExtension
+
 from ._tagged import TaggedObjectNode
 
 class AbvegaoffsetRef(TaggedObjectNode): ...
@@ -46,3 +48,4 @@ class WfiScienceRaw(TaggedObjectNode): ...
 class WfiWcs(TaggedObjectNode): ...
 
 _MANIFESTS: list[dict[str, Any]]
+NODE_EXTENSIONS: dict[str, ManifestExtension]

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -14,7 +14,7 @@ from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
-    SERIALIZATION_BY_TAG,
+    SERIALIZATION_BY_MANIFEST,
 )
 from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, _get_schema_from_tag
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 else:
     NodeMixin: TypeAlias = object
 
-__all__ = ["SerializationTaggedNode", "TaggedListNode", "TaggedObjectNode", "TaggedScalarNode"]
+__all__ = ["SerializationNode", "TaggedListNode", "TaggedObjectNode", "TaggedScalarNode"]
 
 
 def name_from_tag_uri(tag_uri: str) -> str:
@@ -280,13 +280,13 @@ class TaggedScalarNode(_TaggedNodeMixin):
 _T = TypeVar("_T", bound=TaggedObjectNode | TaggedListNode | TaggedScalarNode)
 
 
-class SerializationTaggedNode(Generic[_T]):
+class SerializationNode(Generic[_T]):
     """
     Intermediate class used to assist in serialization of Tagged objects
     so that the extension is correctly written.
     """
 
-    _tag: ClassVar[str]
+    _manifest: ClassVar[str]
 
     def __init_subclass__(cls, **kwargs) -> None:
         """
@@ -294,12 +294,13 @@ class SerializationTaggedNode(Generic[_T]):
         """
         super().__init_subclass__(**kwargs)
         if cls.__name__ != "SerializationTaggedNode":
-            if cls._tag in SERIALIZATION_BY_TAG:
-                raise RuntimeError(f"SerializationTaggedNode class for tag '{cls._tag}' has been defined twice")
-            SERIALIZATION_BY_TAG[cls._tag] = cls
+            if cls._manifest in SERIALIZATION_BY_MANIFEST:
+                raise RuntimeError(f"SerializationNode class for '{cls._manifest}' has been defined twice")
+            SERIALIZATION_BY_MANIFEST[cls._manifest] = cls
 
-    def __init__(self, data: _T):
+    def __init__(self, data: _T, tag: str):
         self._data = data
+        self._tag = tag
 
     @property
     def tag(self) -> str:
@@ -310,15 +311,16 @@ class SerializationTaggedNode(Generic[_T]):
         return self._data
 
     @classmethod
-    def _factory(cls, tag: str) -> type[SerializationTaggedNode]:
+    def _factory(cls, manifest: str) -> type[SerializationNode]:
         """Create a subclass of this for the given tag"""
-        tag_uri, version = tag.rsplit("-", maxsplit=1)
+        tag_uri, version = manifest.rsplit("-", maxsplit=1)
 
         return type(
             f"SerializationNode_{class_name_from_tag_uri(tag_uri)}__{version.replace('.', '_')}",
-            (SerializationTaggedNode,),
+            (SerializationNode,),
             {
-                "_tag": tag,
+                "_manifest": manifest,
+                "__module__": "roman_datamodels._stnode",
             },
         )
 

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -7,13 +7,14 @@ Base classes for all the tagged objects defined by RAD.
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from ._node import DNode, LNode
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
+    SERIALIZATION_BY_TAG,
 )
 from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, _get_schema_from_tag
 
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 else:
     NodeMixin: TypeAlias = object
 
-__all__ = ["TaggedListNode", "TaggedObjectNode", "TaggedScalarNode"]
+__all__ = ["SerializationTaggedNode", "TaggedListNode", "TaggedObjectNode", "TaggedScalarNode"]
 
 
 def name_from_tag_uri(tag_uri: str) -> str:
@@ -43,6 +44,27 @@ def name_from_tag_uri(tag_uri: str) -> str:
     elif "/fps/" in tag_uri and "fps" not in tag_uri_split:
         tag_uri_split = "fps_" + tag_uri.split("/")[-1].split("-")[0]
     return tag_uri_split
+
+
+def class_name_from_tag_uri(tag_uri: str) -> str:
+    """
+    Construct the class name for the STNode class from the tag_uri
+
+    Parameters
+    ----------
+    tag_uri : str
+        The tag_uri found in the RAD manifest
+
+    Returns
+    -------
+    string name for the class
+    """
+    tag_name = name_from_tag_uri(tag_uri)
+    class_name = "".join([p.capitalize() for p in tag_name.split("_")])
+    if tag_uri.startswith("asdf://stsci.edu/datamodels/roman/tags/reference_files/"):
+        class_name += "Ref"
+
+    return class_name
 
 
 class _TaggedNodeMixin(NodeMixin):
@@ -253,6 +275,52 @@ class TaggedScalarNode(_TaggedNodeMixin):
 
     def copy(self):
         return copy.copy(self)
+
+
+_T = TypeVar("_T", bound=TaggedObjectNode | TaggedListNode | TaggedScalarNode)
+
+
+class SerializationTaggedNode(Generic[_T]):
+    """
+    Intermediate class used to assist in serialization of Tagged objects
+    so that the extension is correctly written.
+    """
+
+    _tag: ClassVar[str]
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        """
+        Register any subclasses of this class in the SCALAR_NODE_CLASSES_BY_PATTERN registry.
+        """
+        super().__init_subclass__(**kwargs)
+        if cls.__name__ != "SerializationTaggedNode":
+            if cls._tag in SERIALIZATION_BY_TAG:
+                raise RuntimeError(f"SerializationTaggedNode class for tag '{cls._tag}' has been defined twice")
+            SERIALIZATION_BY_TAG[cls._tag] = cls
+
+    def __init__(self, data: _T):
+        self._data = data
+
+    @property
+    def tag(self) -> str:
+        return self._tag
+
+    @property
+    def data(self) -> _T:
+        return self._data
+
+    @classmethod
+    def _factory(cls, tag: str) -> type[SerializationTaggedNode]:
+        """Create a subclass of this for the given tag"""
+        tag_uri, version = tag.rsplit("-", maxsplit=1)
+
+        return type(
+            f"SerializationNode_{class_name_from_tag_uri(tag_uri)}__{version.replace('.', '_')}",
+            (SerializationTaggedNode,),
+            {
+                "_tag": tag,
+            },
+        )
 
 
 tagged_type: TypeAlias = type[TaggedObjectNode] | type[TaggedListNode] | type[TaggedScalarNode]

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -1,9 +1,7 @@
 import asdf
 import pytest
 
-from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG
-
-_TAG_MANIFEST_MAP = {tag_uri: manifest_uri for manifest_uri, tags in MANIFEST_TAG_REGISTRY.items() for tag_uri in tags}
+from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG, TAG_MANIFEST_REGISTRY
 
 
 @pytest.fixture(scope="session", params=NODE_CLASSES_BY_TAG)
@@ -36,7 +34,7 @@ def test_manifest_tag_registry_disjoint(manifest_uri):
 
 def test_all_tags_in_manifest_tag_registry():
     assert sum(len(tags) for tags in MANIFEST_TAG_REGISTRY.values()) == len(NODE_CLASSES_BY_TAG)
-    assert len(_TAG_MANIFEST_MAP) == len(NODE_CLASSES_BY_TAG)
+    assert len(TAG_MANIFEST_REGISTRY) == len(NODE_CLASSES_BY_TAG)
 
 
 def test_history(tmp_path, node_tag, node_instance):
@@ -61,9 +59,9 @@ def test_history(tmp_path, node_tag, node_instance):
 
     datamodel_uris = sorted([extension_uri.replace("extensions", "manifests") for extension_uri in extension_uris])
     # node_tag should be the list of datamodel_uris
-    assert _TAG_MANIFEST_MAP[node_tag] in datamodel_uris
+    assert TAG_MANIFEST_REGISTRY[node_tag] in datamodel_uris
 
     # If a tag is in a given manifest then all of its referenced tags are also in that manifest
     #    so the earliest manifest and extension can be is the latest one for the node_tag.
     #    all other manifests must be the same or newer.
-    assert _TAG_MANIFEST_MAP[node_tag] == datamodel_uris[0]
+    assert TAG_MANIFEST_REGISTRY[node_tag] == datamodel_uris[0]

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -6,27 +6,6 @@ from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY, NODE_CLASS
 _TAG_MANIFEST_MAP = {tag_uri: manifest_uri for manifest_uri, tags in MANIFEST_TAG_REGISTRY.items() for tag_uri in tags}
 
 
-XFAIL_CREATE_FAKE_DATA = (
-    "asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.5.0",
-    "asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.6.0",
-    "asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.2.0",
-    "asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.2.0",
-    "asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.3.0",
-    "asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.4.0",
-    "asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.5.0",
-    "asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.1.0",
-    "asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.1.0",
-    "asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.2.0",
-    "asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.4.0",
-    "asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.1.0",
-    "asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.3.0",
-    "asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.3.0",
-    "asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.0.0",
-    "asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.0.0",
-    "asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.0.0",
-)
-
-
 @pytest.fixture(scope="session", params=NODE_CLASSES_BY_TAG)
 def node_tag(request):
     return request.param
@@ -60,16 +39,12 @@ def test_all_tags_in_manifest_tag_registry():
     assert len(_TAG_MANIFEST_MAP) == len(NODE_CLASSES_BY_TAG)
 
 
-def test_history(tmp_path, node_tag, node_instance, request):
+def test_history(tmp_path, node_tag, node_instance):
     filename = tmp_path / "history_test.asdf"
     prefix = "asdf://stsci.edu/datamodels/roman/extensions/"
 
     # Sanity check
     assert node_instance.tag == node_tag
-
-    # These ones are broken due to a bug
-    if node_tag in XFAIL_CREATE_FAKE_DATA:
-        request.node.add_marker(pytest.mark.xfail(reason="Create_fake_data is broken for this model"))
 
     # Save asdf file
     asdf.AsdfFile(tree={"roman": node_instance}).write_to(filename)

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -1,7 +1,30 @@
 import asdf
 import pytest
 
-from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
+from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG
+
+_TAG_MANIFEST_MAP = {tag_uri: manifest_uri for manifest_uri, tags in MANIFEST_TAG_REGISTRY.items() for tag_uri in tags}
+
+
+XFAIL_CREATE_FAKE_DATA = (
+    "asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.5.0",
+    "asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.6.0",
+    "asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.2.0",
+    "asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.2.0",
+    "asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.3.0",
+    "asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.4.0",
+    "asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.5.0",
+    "asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.1.0",
+    "asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.1.0",
+    "asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.2.0",
+    "asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.4.0",
+    "asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.1.0",
+    "asdf://stsci.edu/datamodels/roman/tags/image_source_catalog-1.3.0",
+    "asdf://stsci.edu/datamodels/roman/tags/mosaic_source_catalog-1.3.0",
+    "asdf://stsci.edu/datamodels/roman/tags/multiband_source_catalog-1.0.0",
+    "asdf://stsci.edu/datamodels/roman/tags/forced_image_source_catalog-1.0.0",
+    "asdf://stsci.edu/datamodels/roman/tags/forced_mosaic_source_catalog-1.0.0",
+)
 
 
 @pytest.fixture(scope="session", params=NODE_CLASSES_BY_TAG)
@@ -15,13 +38,38 @@ def node_cls(node_tag):
 
 
 @pytest.fixture(scope="session")
-def node_instance(node_cls):
-    return node_cls.create_fake_data()
+def node_instance(node_tag, node_cls):
+    return node_cls.create_fake_data(tag=node_tag)
 
 
-def test_history(tmp_path, node_instance):
+@pytest.mark.parametrize("manifest_uri", MANIFEST_TAG_REGISTRY)
+def test_manifest_tag_registry_disjoint(manifest_uri):
+    """Test that the tags registered to each manifest are unique"""
+    for uri, tags in MANIFEST_TAG_REGISTRY.items():
+        if uri != manifest_uri:
+            assert set(tags) & set(MANIFEST_TAG_REGISTRY[manifest_uri]) == set()
+        else:
+            assert len(set(MANIFEST_TAG_REGISTRY[manifest_uri])) == len(MANIFEST_TAG_REGISTRY[manifest_uri])
+
+        for tag in tags:
+            assert tag in NODE_CLASSES_BY_TAG
+
+
+def test_all_tags_in_manifest_tag_registry():
+    assert sum(len(tags) for tags in MANIFEST_TAG_REGISTRY.values()) == len(NODE_CLASSES_BY_TAG)
+    assert len(_TAG_MANIFEST_MAP) == len(NODE_CLASSES_BY_TAG)
+
+
+def test_history(tmp_path, node_tag, node_instance, request):
     filename = tmp_path / "history_test.asdf"
-    prefix = "asdf://stsci.edu/datamodels/roman/extensions/datamodels-"
+    prefix = "asdf://stsci.edu/datamodels/roman/extensions/"
+
+    # Sanity check
+    assert node_instance.tag == node_tag
+
+    # These ones are broken due to a bug
+    if node_tag in XFAIL_CREATE_FAKE_DATA:
+        request.node.add_marker(pytest.mark.xfail(reason="Create_fake_data is broken for this model"))
 
     # Save asdf file
     asdf.AsdfFile(tree={"roman": node_instance}).write_to(filename)
@@ -33,11 +81,14 @@ def test_history(tmp_path, node_instance):
     # Find the roman extension uris
     extension_uris = [extension["extension_uri"] for extension in extensions if extension["extension_uri"].startswith(prefix)]
 
-    # There should be just one
-    assert len(extension_uris) == 1
+    for extension_uri in extension_uris:
+        assert extension_uri.startswith(f"{prefix}datamodels-")
 
-    extension_uri = extension_uris[0]
-    assert extension_uri.startswith(prefix)
+    datamodel_uris = sorted([extension_uri.replace("extensions", "manifests") for extension_uri in extension_uris])
+    # node_tag should be the list of datamodel_uris
+    assert _TAG_MANIFEST_MAP[node_tag] in datamodel_uris
 
-    datamodels_uri = extension_uri.replace("extensions", "manifests")
-    assert node_instance._latest_manifest == datamodels_uri
+    # If a tag is in a given manifest then all of its referenced tags are also in that manifest
+    #    so the earliest manifest and extension can be is the latest one for the node_tag.
+    #    all other manifests must be the same or newer.
+    assert _TAG_MANIFEST_MAP[node_tag] == datamodel_uris[0]

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -1,0 +1,43 @@
+import asdf
+import pytest
+
+from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
+
+
+@pytest.fixture(scope="session", params=NODE_CLASSES_BY_TAG)
+def node_tag(request):
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def node_cls(node_tag):
+    return NODE_CLASSES_BY_TAG[node_tag]
+
+
+@pytest.fixture(scope="session")
+def node_instance(node_cls):
+    return node_cls.create_fake_data()
+
+
+def test_history(tmp_path, node_instance):
+    filename = tmp_path / "history_test.asdf"
+    prefix = "asdf://stsci.edu/datamodels/roman/extensions/datamodels-"
+
+    # Save asdf file
+    asdf.AsdfFile(tree={"roman": node_instance}).write_to(filename)
+
+    # Read extension history
+    with asdf.open(filename) as af:
+        extensions = af.tree["history"]["extensions"]
+
+    # Find the roman extension uris
+    extension_uris = [extension["extension_uri"] for extension in extensions if extension["extension_uri"].startswith(prefix)]
+
+    # There should be just one
+    assert len(extension_uris) == 1
+
+    extension_uri = extension_uris[0]
+    assert extension_uri.startswith(prefix)
+
+    datamodels_uri = extension_uri.replace("extensions", "manifests")
+    assert node_instance._latest_manifest == datamodels_uri


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #592
Closes #637
Closes #639

<!-- describe the changes comprising this PR here -->
This PR fully addresses the issues discussed in #592, #637, #639. It does this by using the deferred converter mechanism mentioned in https://github.com/spacetelescope/roman_datamodels/pull/639#issuecomment-4134450379. 

This operates by creating an intermediate serialization object for every single tag, which can then be used to select the right extension. The actual node converters defer to the converter for this intermediate object meaning that the extension for that intermediate object is what is used. The intermediate object simply holds the serialization of the node and the converter for the intermediate object simply returns whatever information is held by that object. Deserialization works exactly as before, but is implemented in the intermediate object converter.

Note that I made the choice to assume that a tag should be associated with the latest extension claiming support for that tag. The reverse is also possible.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
