### PR TITLE
remove deprecated stnode

### DIFF
--- a/changes/646.removal.rst
+++ b/changes/646.removal.rst
@@ -1,0 +1,1 @@
+Remove deprecated ``roman_datamodels.stnode``.

--- a/docs/roman_datamodels/datamodels/developer_api.rst
+++ b/docs/roman_datamodels/datamodels/developer_api.rst
@@ -5,5 +5,3 @@ Developer API
 .. automodapi:: roman_datamodels.datamodels
 
 .. automodapi:: roman_datamodels._stnode
-
-.. automodapi:: roman_datamodels.table_definitions

--- a/src/roman_datamodels/stnode.py
+++ b/src/roman_datamodels/stnode.py
@@ -1,9 +1,0 @@
-import warnings
-
-from ._stnode import *  # noqa: F403
-
-warnings.warn(
-    "roman_datamodels.stnode as public API has been deprecated. Please use use the DataModel directly",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/src/roman_datamodels/table_definitions.py
+++ b/src/roman_datamodels/table_definitions.py
@@ -1,8 +1,0 @@
-# Pleaceholder for future tables, ex:
-#
-# DQ_DEF_DTYPE = np.dtype([
-#     ("BIT", np.int32),
-#     ("VALUE", np.uint32),
-#     ("NAME", "S40"),
-#     ("DESCRIPTION", "S80")
-# ])


### PR DESCRIPTION
Remove the deprecated public `roman_datamodels.stnode` submodule.

Also remove the empty files:
  - roman_datamodels.table_definitions
  - roman_datamodels.conftest

Regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/24042095958

Test PR for romanisim (just changes dependency to this PR): https://github.com/spacetelescope/romanisim/pull/345

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
