### PR TITLE
don't update meta.filename for non-local files

### DIFF
--- a/changes/648.bugfix.rst
+++ b/changes/648.bugfix.rst
@@ -1,0 +1,1 @@
+Don't attempt to update meta.filename for URLs.

--- a/src/roman_datamodels/datamodels/_utils.py
+++ b/src/roman_datamodels/datamodels/_utils.py
@@ -10,6 +10,7 @@ from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import asdf
 import numpy as np
@@ -198,6 +199,57 @@ def node_update(
             to_node["extras"] = extras_node
 
 
+def _patch_meta_filename(init, asdf_file):
+    """
+    Modify meta.filename to match init if needed.
+
+    meta.filename will not be updated if:
+        - init is not a str or Path
+        - init is a URL
+        - asdf_file does not have a meta.filename
+        - meta.filename already matches init
+
+    Parameters
+    ----------
+    init : str, ``Path`` or file-like
+        An object that can be opened by `asdf.open`
+    asdf_file : `asdf.AsdfFile`
+        Instance that may be patched if init does not match meta.filename
+
+    Returns
+    -------
+    `asdf.AsdfFile`
+    """
+    if isinstance(init, str):
+        # is init string is a url, don't patch
+        parts = urlparse(init)
+        if parts.scheme and parts.netloc:
+            return asdf_file
+        # if not, convert to Path
+        path = Path(init)
+    elif isinstance(init, Path):
+        path = init
+    else:
+        return asdf_file
+
+    tree = asdf_file.tree
+    if not isinstance((tree := tree.get("roman")), Mapping):
+        return asdf_file
+    if not isinstance((tree := tree.get("meta")), Mapping):
+        return asdf_file
+    if (filename := tree.get("filename", path.name)) == path.name:
+        return asdf_file
+
+    warnings.warn(
+        f"meta.filename: {filename} does not match filename: {path.name}, updating the filename in memory!",
+        FilenameMismatchWarning,
+        stacklevel=2,
+    )
+    asdf_file["roman"]["meta"]["filename"] = type(filename)(path.name)
+
+    return asdf_file
+
+
 def _open_asdf(init, lazy_tree=True, **kwargs):
     """
     Open init with `asdf.open`.
@@ -221,34 +273,13 @@ def _open_asdf(init, lazy_tree=True, **kwargs):
     # asdf defaults to lazy_tree=False, this overwrites it to
     # lazy_tree=True for roman_datamodels
     kwargs["lazy_tree"] = lazy_tree
-    if isinstance(init, str):
-        path = Path(init)
-    elif isinstance(init, Path):
-        path = init
-    else:
-        path = None
 
     try:
         asdf_file = asdf.open(init, **kwargs)
     except ValueError as err:
         raise TypeError("Open requires a filepath, file-like object, or Roman datamodel") from err
 
-    if (
-        path is not None
-        and "roman" in asdf_file
-        and isinstance(asdf_file["roman"], Mapping)  # Fix issue for Python 3.10
-        and "meta" in asdf_file["roman"]
-        and "filename" in asdf_file["roman"]["meta"]
-        and asdf_file["roman"]["meta"]["filename"] != path.name
-    ):
-        warnings.warn(
-            f"meta.filename: {asdf_file['roman']['meta']['filename']} does not match filename: {path.name}, updating the filename in memory!",
-            FilenameMismatchWarning,
-            stacklevel=2,
-        )
-        asdf_file["roman"]["meta"]["filename"] = type(asdf_file["roman"]["meta"]["filename"])(path.name)
-
-    return asdf_file
+    return _patch_meta_filename(init, asdf_file)
 
 
 def rdm_open(init, memmap=False, **kwargs):

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,5 +1,6 @@
 import json
 import os
+from contextlib import nullcontext
 from pathlib import Path
 
 import asdf
@@ -10,6 +11,7 @@ from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels
 from roman_datamodels._stnode import WfiImage
+from roman_datamodels.datamodels._utils import _patch_meta_filename
 from roman_datamodels.testing import assert_node_equal
 
 
@@ -290,3 +292,23 @@ def test_filename_matches_meta(tmp_path, model):
     ):
         assert model.meta.filename == open_path.name
         assert isinstance(model.meta.filename, gn_fn_type)
+
+
+@pytest.mark.parametrize(
+    "filename, original, expected",
+    [
+        ("bar.asdf", "fizz.asdf", "bar.asdf"),
+        ("foo/bar.asdf", "fizz.asdf", "bar.asdf"),
+        ("/foo/bar.asdf", "fizz.asdf", "bar.asdf"),
+        # no patching for urls
+        ("s3://foo/bar.asdf", "fizz.asdf", "fizz.asdf"),
+        ("http://foo/bar.asdf", "fizz.asdf", "fizz.asdf"),
+    ],
+)
+def test_patch_filename(filename, original, expected):
+    asdf_file = asdf.AsdfFile({"roman": WfiImage.create_fake_data()})
+    asdf_file["roman"]["meta"]["filename"] = original
+    ctx = nullcontext() if original == expected else pytest.warns(datamodels.FilenameMismatchWarning)
+    with ctx:
+        _patch_meta_filename(filename, asdf_file)
+    assert asdf_file["roman"]["meta"]["filename"] == expected


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #645

Don't update `meta.filename` if a URL is opened (`http://...`, `s3://...`, etc).

Using the example from the above linked issue the file at:
```
https://masttest.stsci.edu/search/roman/api/v0.1/retrieve_product?product_name=r0000101001001001001_0002_wfi02_f158%2Fr0000101001001001001_0002_wfi02_f158_segm.asdf
```
now opens with no warning and the expected filename:
```
r0000101001001001001_0002_wfi02_f158_segm.asdf
```

Regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/24136085070/job/70424478499

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
