### PR TITLE
Add warnings for nodes related to no-longer supported tags

### DIFF
--- a/changes/652.feature.rst
+++ b/changes/652.feature.rst
@@ -1,0 +1,2 @@
+Add deprecation warnings for nodes that correspond to tag linages which are no
+longer part of the latest RAD datamodels manifest.

--- a/src/roman_datamodels/_stnode/_node.py
+++ b/src/roman_datamodels/_stnode/_node.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import MutableMapping, MutableSequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from asdf.lazy_nodes import AsdfDictNode, AsdfListNode
@@ -61,8 +61,8 @@ class _NodeMixin:
 
     _read_tag: str | None
 
-    def __init__(self, *args, **kwargs):
-        self._read_tag = None
+    def __init__(self, *args, read_tag: str | None = None, **kwargs):
+        self._read_tag = read_tag
 
 
 class DNode(MutableMapping, _NodeMixin):
@@ -72,8 +72,10 @@ class DNode(MutableMapping, _NodeMixin):
 
     __slots__ = ("_data", "_read_tag")
 
-    def __init__(self, node=None):
-        super().__init__(node)
+    _data: dict[str, Any]
+
+    def __init__(self, node=None, *, read_tag: str | None = None):
+        super().__init__(node, read_tag=read_tag)
 
         # Handle if we are passed different data types
         if node is None:
@@ -221,9 +223,10 @@ class LNode(MutableSequence, _NodeMixin):
     """
 
     __slots__ = ("_read_tag", "data")
+    data: list[Any]
 
-    def __init__(self, node=None):
-        super().__init__(node=node)
+    def __init__(self, node=None, *, read_tag: str | None = None):
+        super().__init__(node=node, read_tag=read_tag)
 
         if node is None:
             self.data = []

--- a/src/roman_datamodels/_stnode/_node.py
+++ b/src/roman_datamodels/_stnode/_node.py
@@ -6,6 +6,7 @@ Base node classes for all STNode classes.
 from __future__ import annotations
 
 import datetime
+import warnings
 from collections.abc import MutableMapping, MutableSequence
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +14,8 @@ import numpy as np
 from asdf.lazy_nodes import AsdfDictNode, AsdfListNode
 from asdf.tags.core import ndarray
 from astropy.time import Time
+
+from ._schema import get_latest_schema
 
 __all__ = ["DNode", "LNode"]
 
@@ -45,6 +48,9 @@ def _unwrap(value):
     return value
 
 
+_LATEST_MANIFEST = get_latest_schema("asdf://stsci.edu/datamodels/roman/manifests/datamodels")[0]
+
+
 class _NodeMixin:
     """
     Mixin class to provide the common API for all Node objects
@@ -63,6 +69,17 @@ class _NodeMixin:
 
     def __init__(self, *args, read_tag: str | None = None, **kwargs):
         self._read_tag = read_tag
+
+        if (
+            (not any(value in type(self).__name__ for value in ("Fps", "Tvac")))
+            and hasattr(self, "_latest_manifest")
+            and self._latest_manifest != _LATEST_MANIFEST
+        ):
+            warnings.warn(
+                "This node is no longer being maintained or used, support for it will drop in the future",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
 
 class DNode(MutableMapping, _NodeMixin):

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -45,9 +45,14 @@ def get_latest_schema(uri: str) -> tuple[str, dict[str, Any]]:
     uri_prefix += "-"
     current_version = Version(version)
     for schema_uri in asdf.get_config().resource_manager:
-        if schema_uri.startswith(uri_prefix) and (new_version := Version(schema_uri.rsplit("-", 1)[-1])) > current_version:
-            current_version = new_version
-            latest_uri = schema_uri
+        if schema_uri.startswith(uri_prefix):
+            version_string = schema_uri.rsplit("-", 1)[-1]
+            if version_string == "1.0":
+                version_string = "1.0.0"
+
+            if (new_version := Version(version_string)) > current_version:
+                current_version = new_version
+                latest_uri = schema_uri
 
     if latest_uri is None:
         raise ValueError(f"No schema found for {uri}")

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-from ._node import DNode, LNode
+from ._node import DNode, LNode, _NodeMixin
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
     OBJECT_NODE_CLASSES_BY_PATTERN,
@@ -259,6 +259,9 @@ class TaggedScalarNode(_TaggedNodeMixin):
     def __asdf_traverse__(self):
         return self
 
+    def __init__(self, *args, **kwargs):
+        _NodeMixin.__init__(self, *args, **kwargs)
+
     @classmethod
     def _create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
         builder = builder or Builder()
@@ -274,8 +277,10 @@ class TaggedScalarNode(_TaggedNodeMixin):
 
     @property
     def _tag(self):
-        # _tag is required by asdf to allow __asdf_traverse__
-        return getattr(self, "_read_tag", self._default_tag)
+        if hasattr(self, "_read_tag"):
+            return super()._tag
+
+        return self._default_tag
 
     def copy(self):
         return copy.copy(self)

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -187,6 +187,10 @@ class _TaggedNodeMixin(NodeMixin):
     def tag(self):
         return self._tag
 
+    @tag.setter
+    def tag(self, value: str) -> None:
+        self._read_tag = value
+
     def get_schema(self):
         """Retrieve the schema associated with this tag"""
         return _get_schema_from_tag(self.tag)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
+from contextlib import nullcontext
+
 import asdf
 import pytest
 
 from roman_datamodels._stnode._registry import OBJECT_NODE_CLASSES_BY_PATTERN, SCHEMA_URIS_BY_TAG
 from roman_datamodels._stnode._stnode import _MANIFESTS as MANIFESTS
+from roman_datamodels.datamodels import MODEL_REGISTRY, GuidewindowModel, RampFitOutputModel
 
 
 @pytest.fixture(scope="session", params=MANIFESTS)
@@ -25,3 +28,69 @@ def object_node_uris(object_node_default_uri):
     prefix_uri = f"{object_node_default_uri.rsplit('-', 1)[0]}-"
 
     return [schema_uri for schema_uri in asdf.get_config().resource_manager if schema_uri.startswith(prefix_uri)]
+
+
+@pytest.fixture(params=MODEL_REGISTRY.values())
+def model(request):
+    return request.param
+
+
+@pytest.fixture
+def node(model):
+    return model._node_type
+
+
+@pytest.fixture()
+def create_fake_data(model):
+    def _create_fake_data(*args, **kwargs):
+        with (
+            pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+            if (model is RampFitOutputModel or model is GuidewindowModel)
+            else nullcontext()
+        ):
+            return model.create_fake_data(*args, **kwargs)
+
+    return _create_fake_data
+
+
+@pytest.fixture()
+def fake_data(create_fake_data):
+    return create_fake_data()
+
+
+@pytest.fixture()
+def create_minimal(model):
+    def _create_minimal(*args, **kwargs):
+        with (
+            pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+            if (model is RampFitOutputModel or model is GuidewindowModel)
+            else nullcontext()
+        ):
+            return model.create_minimal(*args, **kwargs)
+
+    return _create_minimal
+
+
+@pytest.fixture()
+def minimal(create_minimal):
+    return create_minimal()
+
+
+@pytest.fixture()
+def node_fake_data(node, model):
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (model is RampFitOutputModel or model is GuidewindowModel)
+        else nullcontext()
+    ):
+        return node.create_fake_data()
+
+
+@pytest.fixture()
+def node_minimal(node, model):
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (model is RampFitOutputModel or model is GuidewindowModel)
+        else nullcontext()
+    ):
+        return node.create_minimal()

--- a/tests/stnode/test_mixins.py
+++ b/tests/stnode/test_mixins.py
@@ -61,6 +61,7 @@ def test_special_fake_str_mixin(type_, expected, method, defaults):
         assert obj == expected
 
 
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_ref_file_mixin():
     defaults = {"flat": "foo.asdf"}
     obj = stnode.RefFile.create_minimal(defaults)
@@ -69,6 +70,7 @@ def test_ref_file_mixin():
 
 
 @pytest.mark.parametrize("type_", (stnode.L2CalStep, stnode.L3CalStep))
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_cal_step_mixin(type_):
     defaults = {"outlier_detection": "COMPLETE"}
     obj = type_.create_minimal(defaults)

--- a/tests/stnode/test_mixins.py
+++ b/tests/stnode/test_mixins.py
@@ -36,7 +36,9 @@ def test_file_date(type_, method, defaults, expected):
 @pytest.mark.parametrize("method", ("create_minimal", "create_fake_data"))
 @pytest.mark.parametrize("defaults", (None, "test"))
 def test_default_str_mixin(type_, expected, method, defaults):
-    obj = getattr(type_, method)(defaults)
+    with pytest.warns(DeprecationWarning, match=r"This node is no longer.*"):
+        obj = getattr(type_, method)(defaults)
+
     assert isinstance(obj, type_)
     if defaults:
         assert obj == defaults
@@ -53,7 +55,9 @@ def test_default_str_mixin(type_, expected, method, defaults):
 )
 @pytest.mark.parametrize("defaults", (None, "test"))
 def test_special_fake_str_mixin(type_, expected, method, defaults):
-    obj = getattr(type_, method)(defaults)
+    with pytest.warns(DeprecationWarning, match=r"This node is no longer.*"):
+        obj = getattr(type_, method)(defaults)
+
     assert isinstance(obj, type_)
     if defaults:
         assert obj == defaults

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -37,6 +37,7 @@ def test_all_tags_in_manifest_tag_registry():
     assert len(TAG_MANIFEST_REGISTRY) == len(NODE_CLASSES_BY_TAG)
 
 
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_history(tmp_path, node_tag, node_instance):
     filename = tmp_path / "history_test.asdf"
     prefix = "asdf://stsci.edu/datamodels/roman/extensions/"

--- a/tests/stnode/test_schema.py
+++ b/tests/stnode/test_schema.py
@@ -123,6 +123,7 @@ def test_default_is_copied(subschema, data):
         ("asdf://stsci.edu/datamodels/roman/tags/sky_background-1.0.0", SkyBackground),
     ),
 )
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_tag(tag, expected_type):
     """Test that a schema with a tag produces the object with that tag"""
     schema = {
@@ -146,6 +147,7 @@ def test_tag(tag, expected_type):
         ("asdf://stsci.edu/datamodels/roman/tags/sky_background-1.0.0", SkyBackground),
     ),
 )
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_fake_tag(tag, expected_type):
     """Test that a schema with a tag produces the object with that tag"""
     schema = {
@@ -185,19 +187,25 @@ def _make_old_observation():
     return obj
 
 
-@pytest.mark.parametrize(
-    "tag, value",
-    (
-        # test one rad tag to not make this test dependent on NODE_CLASSES_BY_TAG
-        ("asdf://stsci.edu/datamodels/roman/tags/observation-1.1.0", Observation.create_fake_data()),
-        ("asdf://stsci.edu/datamodels/roman/tags/observation-1.1.0", {"program": 1}),
-        ("asdf://stsci.edu/datamodels/roman/tags/observation-1.1.0", _make_old_observation()),
-    ),
-)
-def test_node_builder_tagged(tag, value):
-    result = NodeBuilder().build({"tag": tag}, value)
+@pytest.fixture(params=[0, 1, 2])
+def node_builder_value(request):
+    match request.param:
+        case 0:
+            return Observation.create_fake_data()
+        case 1:
+            return {"program": 1}
+        case 2:
+            return _make_old_observation()
+        case _:
+            raise ValueError("Invalid param")
+
+
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
+def test_node_builder_tagged(node_builder_value):
+    tag = "asdf://stsci.edu/datamodels/roman/tags/observation-1.1.0"
+    result = NodeBuilder().build({"tag": tag}, node_builder_value)
     assert isinstance(result, Observation)
-    assert result is not value
+    assert result is not node_builder_value
     assert result.tag == tag
 
 
@@ -210,6 +218,7 @@ def test_node_builder_tagged(tag, value):
         ("asdf://stsci.edu/datamodels/roman/tags/cal_logs-1.1.0", {"a": 1}),
     ),
 )
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_node_builder_tag_mismatch(tag, value):
     result = NodeBuilder().build({"tag": tag}, value)
     # the tag is not picked up

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -427,8 +427,13 @@ def test_model_only_init_with_correct_node(node_class, correct, model):
         else nullcontext()
     ):
         node = node_class.create_fake_data()
-    with nullcontext() if node_class is correct else pytest.raises(ValidationError):
-        model(node).validate()
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (node_class is Guidewindow and correct is Guidewindow)
+        else nullcontext()
+    ):
+        with nullcontext() if node_class is correct else pytest.raises(ValidationError):
+            model(node).validate()
 
 
 @pytest.mark.parametrize(
@@ -561,7 +566,13 @@ def test_datamodel_construct_like_from_like(fake_data, model):
     fake_data._iscopy = "foo"
 
     # Pass model instance to model constructor
-    new_model = model(fake_data)
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (model is datamodels.GuidewindowModel)
+        else nullcontext()
+    ):
+        new_model = model(fake_data)
+
     assert new_model is fake_data
     assert new_model._iscopy == "foo"  # Verify that the constructor didn't override stuff
 
@@ -840,7 +851,12 @@ def test_slotted(minimal):
 def test_create_minimal_copies(fake_data, model, tmp_path):
     """Test that create_minimal does not retain references to input"""
     fn = tmp_path / "test.asdf"
-    fake_data.save(fn)
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (model is datamodels.GuidewindowModel)
+        else nullcontext()
+    ):
+        fake_data.save(fn)
     with (
         pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
         if (model is datamodels.RampFitOutputModel or model is datamodels.GuidewindowModel)
@@ -934,7 +950,9 @@ def test_create_from_model_old_tags():
     assert old_model._instance._read_tag == old_model_tag
     assert old_model.meta.observation._read_tag == old_observation_tag
 
-    converted = datamodels.ImageModel.create_from_model(old_model)
+    with pytest.warns(DeprecationWarning, match=r"This node is no longer.*"):
+        converted = datamodels.ImageModel.create_from_model(old_model)
+
     assert converted.tag == new_model_tag
     # New models should not have a tagged observation node
     assert not isinstance(converted.meta.observation, Observation)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,11 +14,13 @@ from roman_datamodels import datamodels
 from roman_datamodels._stnode import (
     CalLogs,
     DNode,
+    Guidewindow,
     IndividualImageMeta,
     LNode,
     MosaicAssociations,
     Observation,
     OutlierDetection,
+    RampFitOutput,
     Resample,
     SkyBackground,
     SourceCatalog,
@@ -72,38 +74,37 @@ def test_datamodel_exists(name):
     assert hasattr(datamodels, name)
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_node_type_matches_model(model):
+def test_node_type_matches_model(model, node_fake_data):
     """
     Test that the _node_type listed for each model is what is listed in the schema
     """
-    node_type = model._node_type
-    node = node_type.create_fake_data()
-    schema = node.get_schema()
+    schema = node_fake_data.get_schema()
     name = schema["datamodel_name"]
 
     assert model.__name__ == name
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_model_schemas(model):
-    instance = model.create_fake_data()
-    asdf.schema.load_schema(instance.schema_uri)
+def test_model_schemas(fake_data):
+    asdf.schema.load_schema(fake_data.schema_uri)
 
 
-@pytest.mark.parametrize("node, model", datamodels.MODEL_REGISTRY.items())
 @pytest.mark.parametrize("method", ["info", "search", "schema_info"])
-def test_model_asdf_operations(node, model, method):
+def test_model_asdf_operations(node, node_fake_data, model, method):
     """
     Test the decorator for asdf operations on models when an empty initial model
     which is then filled.
     """
     # Create an empty model
-    mdl = model()
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (model is datamodels.RampFitOutputModel or model is datamodels.GuidewindowModel)
+        else nullcontext()
+    ):
+        mdl = model()
     assert isinstance(mdl._instance, node)
 
     # Fill the model with data, but no asdf file is present
-    mdl._instance = node.create_fake_data()
+    mdl._instance = node_fake_data
     assert mdl._asdf is None
 
     # Run the method we wish to test (it should fail with warning or error
@@ -359,7 +360,13 @@ def test_datamodel_schema_info_existence(name):
     # Loop over datamodels that have archive_catalog entries
     if not name.endswith("RefModel"):
         model_class = getattr(datamodels, name)
-        model = model_class.create_fake_data()
+        with (
+            pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+            if (model_class is datamodels.RampFitOutputModel or model_class is datamodels.GuidewindowModel)
+            else nullcontext()
+        ):
+            model = model_class.create_fake_data()
+
         info = model.schema_info("archive_catalog")
         for keyword in model.meta.keys():
             # Only DNodes or LNodes need to be canvassed
@@ -414,7 +421,12 @@ def test_model_only_init_with_correct_node(node_class, correct, model):
     This checks that it can be initialized with the correct node, and that it cannot be
     with any other node.
     """
-    node = node_class.create_fake_data()
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (node_class is RampFitOutput or node_class is Guidewindow)
+        else nullcontext()
+    ):
+        node = node_class.create_fake_data()
     with nullcontext() if node_class is correct else pytest.raises(ValidationError):
         model(node).validate()
 
@@ -533,8 +545,7 @@ def test_science_raw_from_tvac_raw(mk_tvac):
         assert raw.extras.tvac.meta.statistics == tvac.meta.statistics
 
 
-@pytest.mark.parametrize("model_class", datamodels.MODEL_REGISTRY.values())
-def test_datamodel_construct_like_from_like(model_class):
+def test_datamodel_construct_like_from_like(fake_data, model):
     """
     This is a regression test for the issue reported issue #51.
 
@@ -546,15 +557,12 @@ def test_datamodel_construct_like_from_like(model_class):
     that was passed to the constructor. i.e. it should not return a copy of the instance.
     """
 
-    # Create a model
-    model = model_class.create_fake_data()
-
     # Modify _iscopy as it will be reset to False by initializer if called incorrectly
-    model._iscopy = "foo"
+    fake_data._iscopy = "foo"
 
     # Pass model instance to model constructor
-    new_model = model_class(model)
-    assert new_model is model
+    new_model = model(fake_data)
+    assert new_model is fake_data
     assert new_model._iscopy == "foo"  # Verify that the constructor didn't override stuff
 
 
@@ -782,21 +790,18 @@ def test_deepcopy_after_use():
     deepcopy(m.meta)
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_minimal(model):
+def test_create_minimal(model, minimal):
     """Test that create_minimal produces a model instance"""
-    m = model.create_minimal()
-    assert isinstance(m, model)
+    assert isinstance(minimal, model)
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_fake_data(model):
+def test_create_fake_data(model, fake_data):
     """Test that create_fake_data produces a valid model instance"""
-    m = model.create_fake_data()
-    assert isinstance(m, model)
-    assert m.validate() is None
+    assert isinstance(fake_data, model)
+    assert fake_data.validate() is None
 
 
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 @pytest.mark.parametrize("tag, node_class", NODE_CLASSES_BY_TAG.items())
 def test_create_tag(tag, node_class):
     """Test that we can create a node for every registered tag"""
@@ -810,44 +815,40 @@ def test_create_tag(tag, node_class):
         assert node._read_tag == tag
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_no_hidden(model):
+def test_no_hidden(minimal):
     """Test that no hidden attributes are allowed"""
-    m = model.create_minimal()
     with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
-        m._foo = "bar"  # Add a hidden attribute
+        minimal._foo = "bar"  # Add a hidden attribute
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_delattr(model):
+def test_delattr(minimal):
     """Test that delattr works as expected"""
-    m = model.create_minimal()
+    minimal.foo = "bar"
+    assert hasattr(minimal, "foo")
 
-    m.foo = "bar"
-    assert hasattr(m, "foo")
-
-    del m.foo
-    assert not hasattr(m, "foo")
+    del minimal.foo
+    assert not hasattr(minimal, "foo")
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_slotted(model):
+def test_slotted(minimal):
     """Test that the model is slotted as expected"""
-    m = model.create_minimal()
-
     with pytest.raises(AttributeError, match=r"No attribute .*"):
         # slotted object instances do not have a __dict__
-        m.__dict__  # noqa: B018
+        minimal.__dict__  # noqa: B018
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_minimal_copies(model, tmp_path):
+def test_create_minimal_copies(fake_data, model, tmp_path):
     """Test that create_minimal does not retain references to input"""
     fn = tmp_path / "test.asdf"
-    fake = model.create_fake_data()
-    fake.save(fn)
-    with datamodels.open(fn) as opened_model:
-        new_model = model.create_minimal(opened_model)
+    fake_data.save(fn)
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (model is datamodels.RampFitOutputModel or model is datamodels.GuidewindowModel)
+        else nullcontext()
+    ):
+        with datamodels.open(fn) as opened_model:
+            new_model = model.create_minimal(opened_model)
+
     del opened_model
     gc.collect(2)
     assert new_model.validate() is None
@@ -927,7 +928,9 @@ def test_create_from_model_old_tags():
     assert old_model_tag != new_model_tag
     assert old_observation_tag != new_observation_tag
 
-    old_model = datamodels.ImageModel.create_fake_data(tag=old_model_tag)
+    with pytest.warns(DeprecationWarning, match=r"This node is no longer.*"):
+        old_model = datamodels.ImageModel.create_fake_data(tag=old_model_tag)
+
     assert old_model._instance._read_tag == old_model_tag
     assert old_model.meta.observation._read_tag == old_observation_tag
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -10,7 +10,7 @@ from astropy.io import fits
 from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels
-from roman_datamodels._stnode import WfiImage
+from roman_datamodels._stnode import Guidewindow, RampFitOutput, WfiImage
 from roman_datamodels.datamodels._utils import _patch_meta_filename
 from roman_datamodels.testing import assert_node_equal
 
@@ -199,9 +199,21 @@ def test_node_round_trip(tmp_path, node_class):
     file_path = tmp_path / "test.asdf"
 
     # Create/return a node and write it to disk, then check if the node round trips
-    node = node_class.create_fake_data()
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (node_class is RampFitOutput or node_class is Guidewindow)
+        else nullcontext()
+    ):
+        node = node_class.create_fake_data()
     asdf.AsdfFile({"roman": node}).write_to(file_path)
-    with asdf.open(file_path) as af:
+    with (
+        (
+            pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+            if (node_class is RampFitOutput or node_class is Guidewindow)
+            else nullcontext()
+        ),
+        asdf.open(file_path) as af,
+    ):
         assert_node_equal(af.tree["roman"], node)
 
 
@@ -210,12 +222,27 @@ def test_opening_model(tmp_path, node_class):
     file_path = tmp_path / "test.asdf"
 
     # Create a node and write it to disk
-    node = node_class.create_fake_data()
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (node_class is RampFitOutput or node_class is Guidewindow)
+        else nullcontext()
+    ):
+        node = node_class.create_fake_data()
     if hasattr(node, "meta") and hasattr(node.meta, "filename"):
-        node.meta.filename = type(node.meta.filename)(file_path.name)
+        with (
+            pytest.warns(DeprecationWarning, match=r"This node is no longer.*") if (node_class is Guidewindow) else nullcontext()
+        ):
+            node.meta.filename = type(node.meta.filename)(file_path.name)
     asdf.AsdfFile({"roman": node}).write_to(file_path)
 
-    with datamodels.open(file_path) as model:
+    with (
+        (
+            pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+            if (node_class is RampFitOutput or node_class is Guidewindow)
+            else nullcontext()
+        ),
+        datamodels.open(file_path) as model,
+    ):
         # Check that the model is the correct type
         assert isinstance(model, datamodels.MODEL_REGISTRY[node_class])
 
@@ -270,7 +297,13 @@ def test_filename_matches_meta(tmp_path, model):
     open_path = tmp_path / "test_filename_read.asdf"
 
     # Create a node and write it to disk
-    gen_model = model.create_fake_data()
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (model is RampFitOutput or model is Guidewindow)
+        else nullcontext()
+    ):
+        gen_model = model.create_fake_data()
+
     asdf.AsdfFile({"roman": gen_model}).write_to(save_path)
 
     # Save the filename type
@@ -280,11 +313,23 @@ def test_filename_matches_meta(tmp_path, model):
     os.rename(save_path, open_path)
 
     # Prove filename is different from meta.filename without using datamodels.open
-    with asdf.open(open_path) as af:
+    with (
+        (
+            pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+            if (model is RampFitOutput or model is Guidewindow)
+            else nullcontext()
+        ),
+        asdf.open(open_path) as af,
+    ):
         assert af["roman"]["meta"]["filename"] != open_path.name
 
     # Show datamodels.open will update the filename in memory
     with (
+        (
+            pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+            if (model is RampFitOutput or model is Guidewindow)
+            else nullcontext()
+        ),
         pytest.warns(
             match="meta.filename: \\? does not match filename: test_filename_read.asdf, updating the filename in memory!"
         ),

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -33,6 +33,7 @@ def test_node_classes_available_via_stnode(node_class):
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_copy(node_class):
     """Demonstrate nodes can copy themselves, but don't always deepcopy."""
     node = node_class.create_fake_data()
@@ -48,17 +49,21 @@ def test_copy(node_class):
         assert_node_is_copy(node, node_copy, deepcopy=True)
 
 
-@pytest.mark.parametrize("model_class", datamodels.MODEL_REGISTRY.values())
-def test_deepcopy_model(model_class):
-    model = model_class.create_fake_data(shape=(8, 8, 8))
-    model_copy = model.copy()
+def test_deepcopy_model(model, fake_data):
+    with (
+        pytest.warns(DeprecationWarning, match=r"This node is no longer.*")
+        if (model is datamodels.RampFitOutputModel or model is datamodels.GuidewindowModel)
+        else nullcontext()
+    ):
+        model_copy = fake_data.copy()
 
     # There is no assert equal for models, but the data inside is what we care about.
     # this is stored under the _instance attribute. We can assert those instances are
     # deep copies of each other.
-    assert_node_is_copy(model._instance, model_copy._instance, deepcopy=True)
+    assert_node_is_copy(fake_data._instance, model_copy._instance, deepcopy=True)
 
 
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_wfi_mode():
     """
     The WfiMode class includes special properties that map optical_element
@@ -87,6 +92,7 @@ def test_wfi_mode():
 
 
 @pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_serialization(node_class, tmp_path):
     file_path = tmp_path / "test.asdf"
 
@@ -100,6 +106,7 @@ def test_serialization(node_class, tmp_path):
 
 
 @pytest.mark.parametrize("node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedObjectNode)])
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_no_hidden(node_class):
     node = node_class.create_fake_data()
     with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
@@ -107,6 +114,7 @@ def test_no_hidden(node_class):
 
 
 @pytest.mark.parametrize("node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedListNode)])
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_list_node_no_new_attributes(node_class):
     """Test that no new attributes can be added to a list node."""
     node = node_class.create_fake_data()
@@ -120,6 +128,7 @@ def test_list_node_no_new_attributes(node_class):
 @pytest.mark.parametrize(
     "node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedObjectNode | stnode.TaggedListNode)]
 )
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_slotted(node_class):
     """
     Test that slotted nodes do not allow new attributes to be added.
@@ -130,6 +139,7 @@ def test_slotted(node_class):
         node.__dict__  # noqa: B018
 
 
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_info(capsys):
     node = stnode.WfiMode({"optical_element": "GRISM", "detector": "WFI18", "name": "WFI"})
     tree = dict(wfimode=node)
@@ -140,6 +150,7 @@ def test_info(capsys):
     assert "GRISM" in captured.out
 
 
+@pytest.mark.filterwarnings("ignore:This node is no longer.*:DeprecationWarning")
 def test_schema_info():
     node = stnode.WfiMode({"optical_element": "GRISM", "detector": "WFI18", "name": "WFI"})
     tree = dict(wfimode=node)


### PR DESCRIPTION
This PR adds warnings for when a user attempts to work with a tag which is no longer used in the current datamodels manifest.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
