### PR TITLE
Update `RampModel.from_science_raw` to not create fake data

### DIFF
--- a/changes/653.bugfix.rst
+++ b/changes/653.bugfix.rst
@@ -1,0 +1,1 @@
+Update ``RampModel.from_science_raw`` to not create fake data.

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -390,6 +390,11 @@ class RampModel(_RomanDataModel):
         # Create base ramp node with dummy values (for validation)
         ramp_model = cls.create_minimal()
 
+        # make cal_step
+        ramp_model.meta.cal_step = {}
+        for step_name in ramp_model.schema_info("required")["roman"]["meta"]["cal_step"]["required"].info:
+            ramp_model.meta.cal_step[step_name] = "INCOMPLETE"
+
         shape = model.data.shape
         ramp_model.pixeldq = np.zeros(shape[1:], dtype=np.uint32)
         ramp_model.groupdq = np.zeros(shape, dtype=np.uint8)

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -388,7 +388,7 @@ class RampModel(_RomanDataModel):
             raise ValueError(f"Input must be one of {ALLOWED_MODELS}")
 
         # Create base ramp node with dummy values (for validation)
-        ramp_model = cls.create_fake_data()
+        ramp_model = cls.create_minimal()
 
         shape = model.data.shape
         ramp_model.pixeldq = np.zeros(shape[1:], dtype=np.uint32)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -465,6 +465,16 @@ def test_ramp_from_science_raw(mk_raw):
         assert not hasattr(ramp, "resultantdq")
 
 
+def test_science_raw_missing_required():
+    """Test that from_science_raw does not fill in required but missing values"""
+    raw = datamodels.ScienceRawModel.create_fake_data()
+    del raw.meta.exposure._data["hga_move"]
+    ramp = datamodels.RampModel.from_science_raw(raw)
+    assert "hga_move" not in raw.meta.exposure
+    with pytest.raises(ValidationError, match="hga_move"):
+        ramp.validate()
+
+
 def test_science_raw_from_tvac_raw_invalid_input():
     """Test for invalid input"""
     model = datamodels.RampModel.create_fake_data()


### PR DESCRIPTION
Closes #651

Switch `RampModel.from_science_raw` back to using non-fake-data-creating methods. Add a test that confirms that `from_science_raw` correctly fails if required data is missing from the input.

Will require some romancal changes since fixing this bug means `hga_move` is no longer being made up during `from_science_raw`. Since the romancal `hga_move` migration doesn't handle `ScienceRawModel` instances regtests will fail for elp runs on old data.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/24564013413/job/71825994292
show expected errors that will require romancal changes.

docs failures are unrelated: https://github.com/spacetelescope/roman_datamodels/pull/654

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
