### PR TITLE
fix docs: remove distutils usage in docs configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,10 +15,7 @@ import importlib
 import os
 import sys
 import tomllib
-from distutils.version import LooseVersion
 from pathlib import Path
-
-import sphinx
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -35,16 +32,6 @@ setup_cfg = conf["project"]
 # needs_sphinx = '1.3'
 
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-
-def check_sphinx_version(expected_version):
-    sphinx_version = LooseVersion(sphinx.__version__)
-    expected_version = LooseVersion(expected_version)
-    if sphinx_version < expected_version:
-        raise RuntimeError(
-            f"At least Sphinx version {expected_version} is required to build this documentation.  Found {sphinx_version}."
-        )
-
 
 # Configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
@@ -80,10 +67,7 @@ extensions = [
 if on_rtd:
     extensions.append("sphinx.ext.mathjax")
 
-elif LooseVersion(sphinx.__version__) < LooseVersion("1.4"):
-    extensions.append("sphinx.ext.pngmath")
-else:
-    extensions.append("sphinx.ext.imgmath")
+extensions.append("sphinx.ext.imgmath")
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']


### PR DESCRIPTION
The docs builds are failing on main due to attempts to use distutils (no longer provided by setuptools).

This fixes the docs by removing the distutils usage.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
