### PR TITLE
Remove the LNode class

### DIFF
--- a/changes/658.removal.rst
+++ b/changes/658.removal.rst
@@ -1,0 +1,1 @@
+Remove the ``LNode`` class and refactor its functionality into the ``TaggedListNode`` class.

--- a/docs/roman_datamodels/datamodels/stnode.rst
+++ b/docs/roman_datamodels/datamodels/stnode.rst
@@ -2,28 +2,36 @@ Stnode Functionality
 ====================
 
 As seen throughout :ref:`using-datamodels`, "node" objects are used to actually
-handle and store the data for a datamodel. Indeed, if one opens an ASDF file
+handle and store the data for a data model. Indeed, if one opens an ASDF file
 with a roman datamodel directly with `asdf.open` instead of
 `roman_datamodels.datamodels.open`, the resulting object stored under the
-``roman`` attribute will be a specialized `~roman_datamodels._stnode.DNode` object rather
-than a `~roman_datamodels.datamodels.DataModel` object. Thus the stnode, "node"
-objects form the data storage and manipulation backbone of the roman datamodels.
+``roman`` attribute will be a specialized `~roman_datamodels._stnode.DNode` object
+rather than a `~roman_datamodels.datamodels.DataModel` object. Thus the stnode,
+"node" objects form the data storage and manipulation backbone of the roman data
+models.
 
 
-Node Types
-**********
+Node Structure
+**************
 
-There are two main container node types `~roman_datamodels._stnode.DNode` and
-`~roman_datamodels._stnode.LNode` which correspond to "dictionary" and
-"list"-like data structures, respectively.
+Stnode organizes the in the form of a tree structure. Where the
+`roman_datamodels._stnode.DNode` "Node" objects act as keyword-value containers,
+which branch to either other `~roman_datamodels._stnode.DNode` objects or to
+the actual "leaf" data values (e.g. strings, numbers, arrays, etc.). These
+`~roman_datamodels._stnode.DNode` objects are the core of stnode. Everything else
+in stnode is built on top of these objects.
 
-Currently, these two objects are implemented so that they follow the
-dictionary or list interface; meaning that, they can be accessed via the ``[]``
-operator (``node["keyword"]`` or ``node[0]``). However, for the case of the
-`~roman_datamodels._stnode.DNode` objects, keys can also be used to directly
-access the data attributes of the object via the Python ``.`` operator
-(``node.keyword``). This is so that the `~roman_datamodels._stnode.DNode`
-objects "look" like they are nice Python derived types.
+The `roman_datamodels._stnode.DNode` object itself is effectively a wrapper around
+a python dictionary, which enriches the way one can interact with the data stored
+within the node, and how RDM can handle the entire data-tree structure for things
+like validation, serialization, etc. To end users, `~roman_datamodels._stnode.DNode`
+implements the entire ``MutableMapping`` protocol interface, so users can interact
+with it exactly as if they were interacting with any normal python dictionary.
+So things like ``node["keyword"]``, ``node.keys()``, ``node.values()``, etc. all
+work as one would expect with a normal python dictionary. For end users, the interface
+has been enriched so that one can use the ``.`` operator to access the data attributes,
+e.g. ``node.keyword`` works the same as ``node["keyword"]``. This is done to make
+the stnode objects feel more "Pythonic" and act as though they were Python classes.
 
 
 Dynamic Node Construction
@@ -35,16 +43,13 @@ to a corresponding schema name, will be created and registered by
 get this treatment are the "tagged" schemas defined within the ``datamodels-*``
 manifest in the RAD package. Any "un-tagged" schemas in RAD will not have a
 corresponding stnode object. Instead, the information they contain will be
-stored in a `~roman_datamodels._stnode.DNode` or `~roman_datamodels._stnode.LNode`
-object, depending on the schema in question.
+stored in a `~roman_datamodels._stnode.DNode` object or standard python list.
 
-The specific stnode objects will be subclasses of the
-`~roman_datamodels._stnode.TaggedObjectNode` or
-`~roman_datamodels._stnode.TaggedListNode` classes. These classes are extensions
-of the `~roman_datamodels._stnode.DNode` and `~roman_datamodels._stnode.LNode`
-classes which have extensions to handle looking up the schema information.
-In particular, they will track the ``tag`` information
-contained within the manifest from RAD.
+These dynamically created "node" classes are subclasses of the
+`~roman_datamodels._stnode.DNode` and contain additional functionally to handle
+tagging information for ASDF functionally and referencing information stored within
+the corresponding RAD schema. Most importantly, these "tagged-nodes" will keep
+track of the ``tag`` information about the data.
 
 These "tagged-nodes" are then turned into specific stnode objects via the
 factories in `roman_datamodels._stnode._factories`. The way these factories work

--- a/src/roman_datamodels/_stnode/_node.py
+++ b/src/roman_datamodels/_stnode/_node.py
@@ -6,7 +6,7 @@ Base node classes for all STNode classes.
 from __future__ import annotations
 
 import datetime
-from collections.abc import MutableMapping, MutableSequence
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -14,35 +14,7 @@ from asdf.lazy_nodes import AsdfDictNode, AsdfListNode
 from asdf.tags.core import ndarray
 from astropy.time import Time
 
-__all__ = ["DNode", "LNode"]
-
-
-def _wrap(value):
-    """
-    Convert dict to DNode and list to LNode
-    """
-    # Return objects as node classes, if applicable
-    if isinstance(value, dict | AsdfDictNode):
-        return DNode(value)
-
-    if isinstance(value, list | AsdfListNode):
-        return LNode(value)
-
-    return value
-
-
-def _unwrap(value):
-    """
-    Convert DNode to dict and LNode to list
-    """
-    # use "type(...) is" so that we don't unwrap subclasses
-    if type(value) is DNode:
-        return value._data
-
-    if type(value) is LNode:
-        return value.data
-
-    return value
+__all__ = ("DNode",)
 
 
 class _NodeMixin:
@@ -96,7 +68,7 @@ class DNode(MutableMapping, _NodeMixin):
         # If the key is in the schema, then we can return the value
         if key in self._data:
             # Return objects as node classes, if applicable
-            return _wrap(self._data[key])
+            return DNode(value) if isinstance(value := self._data[key], dict | AsdfDictNode) else value
 
         # Raise the correct error for the attribute not being found
         raise AttributeError(f"No such attribute ({key}) found in node: {type(self)}")
@@ -109,7 +81,7 @@ class DNode(MutableMapping, _NodeMixin):
         # Private keys should just be in the normal __dict__
         if key[0] != "_":
             # Finally set the value
-            self._data[key] = _unwrap(value)
+            self._data[key] = value._data if type(value) is DNode else value
         else:
             if key in DNode.__slots__:
                 DNode.__dict__[key].__set__(self, value)
@@ -132,7 +104,7 @@ class DNode(MutableMapping, _NodeMixin):
             if isinstance(tree, DNode | dict | AsdfDictNode):
                 for key, val in tree.items():
                     yield from recurse(val, [*path, key])
-            elif isinstance(tree, LNode | list | tuple | AsdfListNode):
+            elif isinstance(tree, list | tuple | AsdfListNode):
                 for i, val in enumerate(tree):
                     yield from recurse(val, [*path, i])
             elif tree is not None:
@@ -212,64 +184,4 @@ class DNode(MutableMapping, _NodeMixin):
         instance._read_tag = self._read_tag
         instance._data = self._data.copy()
 
-        return instance
-
-
-class LNode(MutableSequence, _NodeMixin):
-    """
-    Base class describing all "array" (list-like) data nodes for STNode classes.
-    """
-
-    __slots__ = ("_read_tag", "data")
-
-    def __init__(self, node=None):
-        super().__init__(node=node)
-
-        if node is None:
-            self.data = []
-        elif isinstance(node, list | AsdfListNode):
-            self.data = node
-        elif isinstance(node, self.__class__):
-            self.data = node.data
-        else:
-            raise ValueError("Initializer only accepts lists")
-
-    def __getitem__(self, index):
-        return _wrap(self.data[index])
-
-    def __setitem__(self, index, value):
-        self.data[index] = _unwrap(value)
-
-    def __delitem__(self, index):
-        del self.data[index]
-
-    def __len__(self):
-        return len(self.data)
-
-    def insert(self, index, value):
-        self.data.insert(index, value)
-
-    def __asdf_traverse__(self):
-        return list(self)
-
-    def __setattr__(self, key, value):
-        if key in LNode.__slots__:
-            LNode.__dict__[key].__set__(self, value)
-        else:
-            raise AttributeError(f"Cannot set attribute {key}, only allowed are {LNode.__slots__}")
-
-    def __eq__(self, other):
-        if isinstance(other, LNode):
-            return self.data == other.data
-        elif isinstance(other, list | AsdfListNode):
-            return self.data == other
-        else:
-            return False
-
-    def copy(self):
-        """Handle copying of the node"""
-        instance = self.__class__.__new__(self.__class__)
-
-        instance.data = self.data.copy()
-        instance._read_tag = self._read_tag
         return instance

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -7,9 +7,12 @@ Base classes for all the tagged objects defined by RAD.
 from __future__ import annotations
 
 import copy
+from collections import UserList
 from typing import TYPE_CHECKING, Generic, TypeVar
 
-from ._node import DNode, LNode
+from asdf.lazy_nodes import AsdfListNode
+
+from ._node import DNode
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
     OBJECT_NODE_CLASSES_BY_PATTERN,
@@ -213,14 +216,14 @@ class TaggedObjectNode(DNode, _TaggedNodeMixin):
             OBJECT_NODE_CLASSES_BY_PATTERN[cls._pattern] = cls
 
 
-class TaggedListNode(LNode, _TaggedNodeMixin):
+class TaggedListNode(UserList, _TaggedNodeMixin):
     """
     Base class for all tagged list defined by RAD
         There will be one of these for any tagged object defined by RAD, which has
         base type: array.
     """
 
-    __slots__ = ()
+    __slots__ = ("_read_tag",)
 
     def __init_subclass__(cls, **kwargs) -> None:
         """
@@ -232,6 +235,48 @@ class TaggedListNode(LNode, _TaggedNodeMixin):
             if cls._pattern in LIST_NODE_CLASSES_BY_PATTERN:
                 raise RuntimeError(f"TaggedListNode class for tag '{cls._pattern}' has been defined twice")
             LIST_NODE_CLASSES_BY_PATTERN[cls._pattern] = cls
+
+    def __init__(self, node=None):
+        self._read_tag = None
+
+        if node is None:
+            data = []
+        elif isinstance(node, list | AsdfListNode):
+            data = node
+        elif isinstance(node, self.__class__):
+            data = node.data
+        else:
+            raise ValueError("Initializer only accepts lists")
+
+        super().__init__(data)
+
+    def __asdf_traverse__(self):
+        return list(self)
+
+    def __setattr__(self, key, value):
+        if key in {"_read_tag", "data"}:
+            object.__setattr__(self, key, value)
+        else:
+            raise AttributeError(f"Cannot set attribute {key}, only allowed are ('_read_tag', 'data')")
+
+    def __getattribute__(self, key):
+        if key == "__dict__":
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '__dict__'")
+        return super().__getattribute__(key)
+
+    def __eq__(self, other):
+        if isinstance(other, TaggedListNode):
+            return self.data == other.data
+        if isinstance(other, list | AsdfListNode):
+            return self.data == other
+        return False
+
+    def copy(self):
+        """Handle copying of the node"""
+        instance = self.__class__.__new__(self.__class__)
+        instance.data = self.data.copy()
+        instance._read_tag = self._read_tag
+        return instance
 
 
 class TaggedScalarNode(_TaggedNodeMixin):

--- a/src/roman_datamodels/datamodels/_utils.py
+++ b/src/roman_datamodels/datamodels/_utils.py
@@ -21,7 +21,7 @@ from roman_datamodels._stnode import TaggedScalarNode
 from ._core import MODEL_REGISTRY, DataModel
 
 if TYPE_CHECKING:
-    from roman_datamodels._stnode import DNode, LNode
+    from roman_datamodels._stnode import DNode, TaggedListNode
 
 
 __all__ = ["FilenameMismatchWarning", "node_update", "rdm_open", "temporary_update_filedate", "temporary_update_filename"]
@@ -96,8 +96,8 @@ def temporary_update_filedate(datamodel: DataModel, file_date: time.Time) -> Gen
 
 
 def node_update(
-    to_node: DNode | LNode | TaggedScalarNode,
-    from_node: DNode | LNode | TaggedScalarNode | DataModel,
+    to_node: DNode | TaggedListNode | TaggedScalarNode,
+    from_node: DNode | TaggedListNode | TaggedScalarNode | DataModel,
     extras: list[str] | tuple[str, ...] | None = None,
     extras_key: str | None = None,
     ignore: list[str] | tuple[str, ...] | None = None,
@@ -122,10 +122,10 @@ def node_update(
 
     Parameters
     ----------
-    to_node : DNode, LNode or TaggedScalarNode
+    to_node : DNode, TaggedListNode or TaggedScalarNode
         Node to receive the contents.
 
-    from_node : DNode, LNode, TaggedScalarNode or DataModel
+    from_node : DNode, TaggedListNode, TaggedScalarNode or DataModel
         Node to copy from
 
     extras : list[str], tuple[str, ...] or None
@@ -173,7 +173,7 @@ def node_update(
                         new_extras[key] = returned_extras
                 else:
                     if isinstance(to_node[key], list):
-                        value = getattr(from_node, key).data
+                        value = list(getattr(from_node, key))
                     elif isinstance(to_node[key], np.ndarray):
                         value = getattr(from_node, key).astype(to_node[key].dtype)
                         value = getattr(value, "value", value)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,13 +15,13 @@ from roman_datamodels._stnode import (
     CalLogs,
     DNode,
     IndividualImageMeta,
-    LNode,
     MosaicAssociations,
     Observation,
     OutlierDetection,
     Resample,
     SkyBackground,
     SourceCatalog,
+    TaggedListNode,
     WfiImage,
     WfiWcs,
 )
@@ -213,10 +213,10 @@ def test_node_assignment():
     wfi_image.meta.exposure = exposure
     assert isinstance(wfi_image.meta.exposure, DNode)
 
-    # The following tests that supplying a LNode passes validation.
+    # The following tests that supplying list-like values passes validation.
     rampmodel = datamodels.RampModel.create_fake_data()
     rampmodel.meta.exposure.read_pattern = [1, 2, 3]
-    assert isinstance(rampmodel.meta.exposure.read_pattern[1:], LNode)
+    assert isinstance(rampmodel.meta.exposure.read_pattern[1:], list)
 
     # Test that supplying a DNode passes validation
     darkmodel = datamodels.DarkRefModel.create_fake_data()
@@ -362,8 +362,8 @@ def test_datamodel_schema_info_existence(name):
         model = model_class.create_fake_data()
         info = model.schema_info("archive_catalog")
         for keyword in model.meta.keys():
-            # Only DNodes or LNodes need to be canvassed
-            if isinstance(model.meta[keyword], DNode | LNode):
+            # Only DNodes or TaggedListNodes need to be canvassed
+            if isinstance(model.meta[keyword], DNode | TaggedListNode):
                 # Ignore metadata schemas that lack archive_catalog entries
                 if type(model.meta[keyword]) not in NODES_LACKING_ARCHIVE_CATALOG:
                     assert keyword in info["roman"]["meta"]

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -222,10 +222,6 @@ def test_get_latest_schema(object_node, object_node_default_uri, object_node_uri
         ("__setattr__", stnode.DNode({}), stnode.DNode, dict),
         ("__setitem__", {}, stnode.DNode, dict),
         ("__setitem__", stnode.DNode({}), stnode.DNode, stnode.DNode),
-        ("__setattr__", [], stnode.LNode, list),
-        ("__setattr__", stnode.LNode([]), stnode.LNode, list),
-        ("__setitem__", [], stnode.LNode, list),
-        ("__setitem__", stnode.LNode([]), stnode.LNode, stnode.LNode),
     ],
 )
 def test_dnode_unwrapping(set_method, value, getattr_type, getitem_type):
@@ -237,24 +233,5 @@ def test_dnode_unwrapping(set_method, value, getattr_type, getitem_type):
     getattr(node, set_method)(key, value)
     assert type(getattr(node, key)) is getattr_type
     assert type(node[key]) is getitem_type
-    if set_method == "__setattr__":
+    if set_method == "__setattr__" and getattr_type is stnode.DNode:
         assert getattr(node, key) is not value
-
-
-@pytest.mark.parametrize(
-    "value, return_type",
-    [
-        ({}, stnode.DNode),
-        (stnode.DNode({}), stnode.DNode),
-        ([], stnode.LNode),
-        (stnode.LNode([]), stnode.LNode),
-    ],
-)
-def test_lnode_unwrapping(value, return_type):
-    """
-    Test LNode wraps and unwraps for set/getitem
-    """
-    node = stnode.LNode([0])
-    node[0] = value
-    assert type(node[0]) is return_type
-    assert node[0] is not value


### PR DESCRIPTION
The LNode added significant complexity and was only really used by the legacy support TaggedListNode, which only handled a single legacy object.

This PR  removes LNode as a distinct object and moves the minimal implementation to support TaggedListNode's functionality directly into that object. This is part of an effort to reduce the complexities of the internal stnode subpackage

This will help when we remove dynamic node creation suggested in #655.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
