### PR TITLE
Make create_fake_data use provided list defaults (for example read_pattern)

### DIFF
--- a/changes/659.bugfix.rst
+++ b/changes/659.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where list defaults were ignored by ``create_fake_data``.

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -485,6 +485,13 @@ class FakeDataBuilder(Builder):
                     obj[k] = copy.deepcopy(v)
         return obj
 
+    def from_array(self, schema, defaults):
+        obj = super().from_array(schema, defaults)
+        if not obj and defaults:
+            # TODO merge defaults and obj?
+            return copy.deepcopy(defaults)
+        return obj
+
     def from_tagged(self, schema, defaults):
         tag = _get_keyword(schema, "tag")
         if tag is _MISSING_KEYWORD:

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -488,7 +488,8 @@ class FakeDataBuilder(Builder):
     def from_array(self, schema, defaults):
         obj = super().from_array(schema, defaults)
         if not obj and defaults:
-            # TODO merge defaults and obj?
+            # only use the defaults wholesale if obj is empty
+            # attempting to merge a produced obj with defaults would be overly complicated
             return copy.deepcopy(defaults)
         return obj
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -938,6 +938,20 @@ def test_create_from_model_old_tags():
     assert isinstance(converted.meta.observation, DNode)
 
 
+def test_create_nested_list_default():
+    """
+    Test that a read_pattern provided to create_fake_data is copied to the produced model.
+
+    read_pattern is used here since the nested list form is different than other metadata.
+    """
+    read_pattern = [[1], [2], [3]]
+    mdl = datamodels.ImageModel.create_fake_data(defaults={"meta": {"exposure": {"read_pattern": read_pattern}}})
+    model_value = mdl["meta"]["exposure"]["read_pattern"]
+    assert model_value is not read_pattern
+    assert not any((a is b for a, b in zip(read_pattern, model_value, strict=True)))
+    assert model_value == read_pattern
+
+
 @pytest.mark.parametrize("method", ["create_minimal", "create_fake_data"])
 class TestRomanDatamodelCreatorDefaults:
     """


### PR DESCRIPTION
While looking at https://github.com/spacetelescope/romancal/pull/2287 I noticed that providing a `read_pattern` to `create_fake_data` did not work as expected. The provided `read_pattern` was ignored and instead was always an empty list.

This PR updates the builder backing `create_fake_data` to use the provided list defaults if the schema-derived fake is empty. This mostly aligns with how object/dict creation works (where the default is used if the schema doesn't define a value). However the list creation doesn't attempt to merge the defaults with any schema-derived fake list (since this seems overly complicated and error-prone).

We have one test:
https://github.com/spacetelescope/roman_datamodels/blob/649c8ebe1789e0ca02af6e1fb18316f84e86a4ad/tests/test_models.py#L611-L618
that was silently passing but was being impacted by the bug fixed in this PR. We might want to update that test to include something like:
```python
assert ramp.meta.exposure.read_pattern == [[1], [2], [3]]
```
but given the conversation about the future of `from_science_raw` we might wait until that is resolved.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/25123011350

all pass

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
