### PR TITLE
Update `tag` handling and clean up `Builder` API

### DIFF
--- a/changes/660.bugfix.rst
+++ b/changes/660.bugfix.rst
@@ -1,0 +1,2 @@
+Fix some small inconsistencies in the ``Builder``/``create_*`` API and add better
+handling of the node specific ``tag``` setting.

--- a/src/roman_datamodels/_stnode/_converters.py
+++ b/src/roman_datamodels/_stnode/_converters.py
@@ -21,7 +21,7 @@ from ._registry import (
 )
 
 if TYPE_CHECKING:
-    from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode
+    from ._tagged import SerializationNode, TaggedNode, TaggedObjectNode
 
 __all__ = [
     "TaggedListNodeConverter",
@@ -61,7 +61,7 @@ class SerializationNodeConverter(_RomanConverter):
     def to_yaml_tree(self, obj: SerializationNode, tag, ctx):
         return obj.data
 
-    def from_yaml_tree(self, node, tag, ctx) -> TaggedObjectNode | TaggedListNode | TaggedScalarNode:
+    def from_yaml_tree(self, node, tag, ctx) -> TaggedNode:
         if "file_date" in tag:
             converter = ctx.extension_manager.get_converter_for_type(Time)
             node = converter.from_yaml_tree(node, tag, ctx)

--- a/src/roman_datamodels/_stnode/_converters.py
+++ b/src/roman_datamodels/_stnode/_converters.py
@@ -66,10 +66,7 @@ class SerializationNodeConverter(_RomanConverter):
             converter = ctx.extension_manager.get_converter_for_type(Time)
             node = converter.from_yaml_tree(node, tag, ctx)
 
-        # TODO: Add method for setting read_tag with some checks
-        obj = NODE_CLASSES_BY_TAG[tag](node)
-        obj._read_tag = tag
-        return obj
+        return NODE_CLASSES_BY_TAG[tag].from_tag(node=node, tag=tag)
 
 
 class _TaggedNodeConverter(_RomanConverter):

--- a/src/roman_datamodels/_stnode/_factories.py
+++ b/src/roman_datamodels/_stnode/_factories.py
@@ -5,15 +5,12 @@ Factories for creating Tagged STNode classes from tag_uris.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from astropy.time import Time
 
 from . import _mixins
-from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, class_name_from_tag_uri
-
-if TYPE_CHECKING:
-    from ._tagged import tagged_type
+from ._tagged import TaggedListNode, TaggedNode, TaggedObjectNode, TaggedScalarNode, class_name_from_tag_uri
 
 __all__ = ["stnode_factory"]
 
@@ -125,7 +122,7 @@ def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) ->
     # In special cases one may need to add additional features to a tagged node class.
     #   This is done by creating a mixin class with the name <ClassName>Mixin in _mixins.py
     #   Here we mixin the mixin class if it exists.
-    class_type: tuple[Any, tagged_type] | tuple[tagged_type]
+    class_type: tuple[Any, type[TaggedObjectNode] | type[TaggedListNode]] | tuple[type[TaggedObjectNode] | type[TaggedListNode]]
     if hasattr(_mixins, mixin := f"{class_name}Mixin"):
         class_type = (getattr(_mixins, mixin), base_class_type)
     else:
@@ -145,9 +142,7 @@ def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) ->
     )
 
 
-def stnode_factory(
-    pattern: str, latest_manifest: str, tag_def: dict[str, Any]
-) -> type[TaggedObjectNode | TaggedListNode | TaggedScalarNode]:
+def stnode_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedNode]:
     """
     Construct a tagged STNode class from a tag
 

--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -5,8 +5,9 @@ Mixin classes for additional functionality for STNode classes
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from copy import deepcopy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar, Self, TypeAlias
 
 from asdf.tags.core.ndarray import asdf_datatype_to_numpy_dtype
 
@@ -15,8 +16,6 @@ from ._tagged import _get_schema_from_tag
 
 # This is a workaround for MyPy to understand the Mixin classes
 if TYPE_CHECKING:
-    from typing import ClassVar, TypeAlias
-
     from astropy.time import Time
 
     from ._tagged import TaggedObjectNode, TaggedScalarNode
@@ -89,20 +88,31 @@ class WfiModeMixin:
 
 class FileDateMixin(_TimeBase):
     @classmethod
-    def _create_minimal(cls, defaults=None, builder=None, *, tag=None):
-        new = cls(defaults) if defaults else cls.now()
-        if tag:
-            new._read_tag = tag
-
-        return new
+    def _create_minimal(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
+        return cls.from_tag(
+            node=(defaults if defaults else cls.now()),
+            tag=(tag or cls._default_tag),
+        )
 
     @classmethod
-    def _create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag=None):
-        new = cls(defaults) if defaults else cls("2020-01-01T00:00:00.0", format="isot", scale="utc")
-        if tag:
-            new._read_tag = tag
-
-        return new
+    def _create_fake_data(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        shape: tuple[int, ...] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
+        return cls.from_tag(
+            node=(defaults if defaults else cls("2020-01-01T00:00:00.0", format="isot", scale="utc")),
+            tag=(tag or cls._default_tag),
+        )
 
 
 class FpsFileDateMixin(FileDateMixin):
@@ -115,93 +125,127 @@ class TvacFileDateMixin(FileDateMixin):
 
 class CalibrationSoftwareNameMixin(_ScalarBase):
     @classmethod
-    def _create_minimal(cls, defaults=None, builder=None, *, tag=None):
-        new = cls(defaults) if defaults else cls("RomanCAL")
-        if tag:
-            new._read_tag = tag
-
-        return new
+    def _create_minimal(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
+        return cls.from_tag(
+            node=(defaults if defaults else "RomanCAL"),
+            tag=(tag or cls._default_tag),
+        )
 
 
 class PrdVersionMixin(_ScalarBase):
     @classmethod
-    def _create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag=None):
-        new = cls(defaults) if defaults else cls("8.8.8")
-        if tag:
-            new._read_tag = tag
-
-        return new
+    def _create_fake_data(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        shape: tuple[int, ...] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
+        return cls.from_tag(
+            node=(defaults if defaults else "8.8.8"),
+            tag=(tag or cls._default_tag),
+        )
 
 
 class SdfSoftwareVersionMixin(_ScalarBase):
     @classmethod
-    def _create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag=None):
-        new = cls(defaults) if defaults else cls("7.7.7")
-        if tag:
-            new._read_tag = tag
-
-        return new
+    def _create_fake_data(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        shape: tuple[int, ...] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
+        return cls.from_tag(
+            node=(defaults if defaults else "7.7.7"),
+            tag=(tag or cls._default_tag),
+        )
 
 
 class OriginMixin(_ScalarBase):
     @classmethod
-    def _create_minimal(cls, defaults=None, builder=None, *, tag=None):
-        new = cls(defaults) if defaults else cls("STSCI/SOC")
-        if tag:
-            new._read_tag = tag
-
-        return new
+    def _create_minimal(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
+        return cls.from_tag(
+            node=(defaults if defaults else "STSCI/SOC"),
+            tag=(tag or cls._default_tag),
+        )
 
 
 class TelescopeMixin(_ScalarBase):
     @classmethod
-    def _create_minimal(cls, defaults=None, builder=None, *, tag=None):
-        new = cls(defaults) if defaults else cls("ROMAN")
-        if tag:
-            new._read_tag = tag
-
-        return new
+    def _create_minimal(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
+        return cls.from_tag(
+            node=(defaults if defaults else "ROMAN"),
+            tag=(tag or cls._default_tag),
+        )
 
 
 class RefFileMixin(_ObjectBase):
     __slots__ = ()
 
     @classmethod
-    def _create_minimal(cls, defaults=None, builder=None, *, tag=None):
+    def _create_minimal(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
         # copy defaults as we may modify them below
-        if defaults:
-            defaults = deepcopy(defaults)
-        else:
-            defaults = {}
-        schema = _get_schema_from_tag(tag or cls._default_tag)
+        defaults = dict(deepcopy(defaults)) if defaults else {}
+        tag = tag or cls._default_tag
+
+        schema = _get_schema_from_tag(tag)
         for k, v in schema["properties"].items():
             if v["type"] != "string":
                 continue
             if k in defaults:
                 continue
             defaults[k] = "N/A"
-        if not builder:
-            builder = Builder()
-        data = builder.from_object(schema, defaults)
-        new = cls(data)
-        if tag:
-            new._read_tag = tag
 
-        return new
+        return cls.from_tag(
+            node=(builder or Builder()).from_object(schema, defaults),
+            tag=tag,
+        )
 
 
 class L2CalStepMixin(_ObjectBase):
     __slots__ = ()
 
     @classmethod
-    def _create_minimal(cls, defaults=None, builder=None, *, tag=None):
+    def _create_minimal(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self:
+        tag = tag or cls._default_tag
         defaults = defaults or {}
-        schema = _get_schema_from_tag(tag or cls._default_tag)
-        new = cls({k: defaults.get(k, "INCOMPLETE") for k in schema["properties"]})
-        if tag:
-            new._read_tag = tag
-
-        return new
+        return cls.from_tag(
+            node=({k: defaults.get(k, "INCOMPLETE") for k in _get_schema_from_tag(tag)["properties"]}),
+            tag=tag,
+        )
 
 
 class L3CalStepMixin(L2CalStepMixin):  # same as L2CalStepMixin
@@ -286,11 +330,18 @@ class ImageSourceCatalogMixin(_ObjectBase):
         return Table(columns)
 
     @classmethod
-    def _create_fake_data(cls, defaults=None, shape=None, builder=None, *, tag=None):
-        defaults = defaults or {}
+    def _create_fake_data(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        shape: tuple[int, ...] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self | None:
+        defaults = dict(defaults) if defaults else {}
         if "source_catalog" not in defaults:
             defaults["source_catalog"] = cls._create_empty_catalog(tag=tag)
-        return super()._create_fake_data(defaults, shape, builder, tag=tag)
+        return super()._create_fake_data(defaults=defaults, shape=shape, builder=builder, tag=tag)
 
 
 class ForcedImageSourceCatalogMixin(ImageSourceCatalogMixin):

--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -10,13 +10,13 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._converters import _RomanConverter
-    from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
+    from ._tagged import SerializationNode, TaggedListNode, TaggedNode, TaggedObjectNode, TaggedScalarNode
 
 OBJECT_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedObjectNode]] = {}
 LIST_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedListNode]] = {}
 SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
 NODE_CONVERTERS: dict[str, type[_RomanConverter]] = {}
-NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
+NODE_CLASSES_BY_TAG: dict[str, TaggedNode] = {}
 SCHEMA_URIS_BY_TAG: dict[str, str] = {}
 SERIALIZATION_BY_MANIFEST: dict[str, type[SerializationNode]] = {}
 MANIFEST_TAG_REGISTRY: dict[str, list[str]] = {}

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -18,7 +18,7 @@ from semantic_version import Version
 from ._registry import NODE_CLASSES_BY_TAG, SCHEMA_URIS_BY_TAG
 
 if TYPE_CHECKING:
-    from ._tagged import tagged_type
+    from ._tagged import TaggedNode
 
 __all__ = ("Builder", "FakeDataBuilder", "NoValueType", "NodeBuilder", "get_latest_schema")
 
@@ -386,7 +386,7 @@ class Builder:
     def from_null(self, schema, defaults):
         return None
 
-    def _create_tagged_node(self, cls: tagged_type, tag, defaults):
+    def _create_tagged_node(self, cls: TaggedNode, tag, defaults):
         # This method exists so that other builders can override it to control
         #    which entry point into the TaggedNode class to use in order to
         #    build it based on the builder's needs.
@@ -397,7 +397,7 @@ class Builder:
         return cls._create_minimal(defaults=defaults, builder=self, tag=tag)
 
     @final
-    def _from_tagged_node(self, cls: tagged_type, tag, defaults):
+    def _from_tagged_node(self, cls: TaggedNode, tag, defaults):
         # The _create_* returns None if it fails to create rather than _NO_VALUE
         #    the outputs of _create_* are exposed as part of the public API, so
         #    one expects something real rather than a semaphore value.
@@ -508,7 +508,7 @@ class FakeDataBuilder(Builder):
             return copy.deepcopy(defaults)
         return obj
 
-    def _create_tagged_node(self, cls: tagged_type, tag, defaults):
+    def _create_tagged_node(self, cls: TaggedNode, tag, defaults):
         return cls._create_fake_data(defaults=defaults, builder=self, tag=tag)
 
     def from_tagged(self, schema, defaults):
@@ -666,7 +666,7 @@ class NodeBuilder(Builder):
     def from_null(self, schema, defaults):
         return self._copy_default(defaults)
 
-    def _create_tagged_node(self, cls: tagged_type, tag, defaults):
+    def _create_tagged_node(self, cls: TaggedNode, tag, defaults):
         return cls._create_from_node(node=defaults, builder=self, tag=tag)
 
     def from_tagged(self, schema, defaults):

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -477,14 +477,6 @@ class FakeDataBuilder(Builder):
                 return "WFI_IMAGE|"
         return NOSTR
 
-    def from_unknown(self, schema, defaults):
-        if (value := super().from_unknown(schema, defaults)) is not _NO_VALUE:
-            return value
-        if "ndim" in schema:
-            # FIXME guidewindow is missing a tag for an array
-            return self.from_tagged(schema, defaults)
-        return _NO_VALUE
-
     def from_integer(self, schema, defaults):
         if (value := super().from_integer(schema, defaults)) is not _NO_VALUE:
             return value
@@ -520,17 +512,10 @@ class FakeDataBuilder(Builder):
         return cls._create_fake_data(defaults=defaults, builder=self, tag=tag)
 
     def from_tagged(self, schema, defaults):
-        tag = _get_keyword(schema, "tag")
-        if tag is _MISSING_KEYWORD:
-            # FIXME a guidewindow array is missing a tag
-            if _get_keyword(schema, "ndim"):
-                tag = "tag:stsci.edu:asdf/core/ndarray-1.*"
-            else:
-                return _NO_VALUE
-        if property_class := NODE_CLASSES_BY_TAG.get(tag):
-            # Pass control to the class for create_fake_data overrides
-            return self._from_tagged_node(property_class, tag, defaults)
+        if (value := super().from_tagged(schema, defaults)) is not _NO_VALUE:
+            return value
 
+        tag = _get_keyword(schema, "tag")
         if defaults is not _NO_VALUE:
             return copy.deepcopy(defaults)
         if tag == "tag:stsci.edu:asdf/time/time-1.*":

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -9,7 +9,7 @@ import enum
 import functools
 import re
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, final
 
 import asdf
 import asdf.schema
@@ -18,9 +18,9 @@ from semantic_version import Version
 from ._registry import NODE_CLASSES_BY_TAG, SCHEMA_URIS_BY_TAG
 
 if TYPE_CHECKING:
-    from typing import Any
+    from ._tagged import tagged_type
 
-__all__ = ["get_latest_schema"]
+__all__ = ("Builder", "FakeDataBuilder", "NoValueType", "NodeBuilder", "get_latest_schema")
 
 
 NOSTR = "?"
@@ -205,14 +205,14 @@ def _get_required(schema):
     return required
 
 
-class _NoValueType:
+class NoValueType:
     """Special value to indicate a builder built nothing"""
 
     def __bool__(self):
         return False
 
 
-_NO_VALUE = _NoValueType()
+_NO_VALUE = NoValueType()
 
 
 class SchemaType(enum.Enum):
@@ -386,10 +386,33 @@ class Builder:
     def from_null(self, schema, defaults):
         return None
 
+    def _create_tagged_node(self, cls: tagged_type, tag, defaults):
+        # This method exists so that other builders can override it to control
+        #    which entry point into the TaggedNode class to use in order to
+        #    build it based on the builder's needs.
+        # That is:
+        #    Builder -> _create_minimal
+        #    FakeDataBuilder -> _create_fake_data
+        #    NodeBuilder -> _create_from_node
+        return cls._create_minimal(defaults=defaults, builder=self, tag=tag)
+
+    @final
+    def _from_tagged_node(self, cls: tagged_type, tag, defaults):
+        # The _create_* returns None if it fails to create rather than _NO_VALUE
+        #    the outputs of _create_* are exposed as part of the public API, so
+        #    one expects something real rather than a semaphore value.
+        # This specifically wraps this so that we move back to the _NO_VALUE
+        #    semaphore used by the Builder API.
+        if (value := self._create_tagged_node(cls, tag, defaults)) is not None:
+            return value
+
+        return _NO_VALUE
+
     def from_tagged(self, schema, defaults):
         tag = _get_keyword(schema, "tag")
         if property_class := NODE_CLASSES_BY_TAG.get(tag):
-            return property_class._create_minimal(defaults, builder=self, tag=tag)
+            return self._from_tagged_node(property_class, tag, defaults)
+
         if defaults is not _NO_VALUE:
             return copy.deepcopy(defaults)
         return _NO_VALUE
@@ -493,6 +516,9 @@ class FakeDataBuilder(Builder):
             return copy.deepcopy(defaults)
         return obj
 
+    def _create_tagged_node(self, cls: tagged_type, tag, defaults):
+        return cls._create_fake_data(defaults=defaults, builder=self, tag=tag)
+
     def from_tagged(self, schema, defaults):
         tag = _get_keyword(schema, "tag")
         if tag is _MISSING_KEYWORD:
@@ -503,7 +529,8 @@ class FakeDataBuilder(Builder):
                 return _NO_VALUE
         if property_class := NODE_CLASSES_BY_TAG.get(tag):
             # Pass control to the class for create_fake_data overrides
-            return property_class._create_fake_data(defaults, builder=self, tag=tag)
+            return self._from_tagged_node(property_class, tag, defaults)
+
         if defaults is not _NO_VALUE:
             return copy.deepcopy(defaults)
         if tag == "tag:stsci.edu:asdf/time/time-1.*":
@@ -654,11 +681,14 @@ class NodeBuilder(Builder):
     def from_null(self, schema, defaults):
         return self._copy_default(defaults)
 
+    def _create_tagged_node(self, cls: tagged_type, tag, defaults):
+        return cls._create_from_node(node=defaults, builder=self, tag=tag)
+
     def from_tagged(self, schema, defaults):
         tag = _get_keyword(schema, "tag")
         if property_class := NODE_CLASSES_BY_TAG.get(tag):
             try:
-                return property_class._create_from_node(defaults, builder=self)
+                return self._create_tagged_node(property_class, tag, defaults)
             except ValueError:
                 # Providing an incompatible value (list to a dict expecting class)
                 # will result in a ValueError. Don't let this stop the conversion

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -7,7 +7,8 @@ Base classes for all the tagged objects defined by RAD.
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Generic, TypeVar
+from abc import ABC
+from typing import TYPE_CHECKING, Generic, TypeVar, final
 
 from ._node import DNode, LNode
 from ._registry import (
@@ -16,7 +17,7 @@ from ._registry import (
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SERIALIZATION_BY_MANIFEST,
 )
-from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, _get_schema_from_tag
+from ._schema import Builder, FakeDataBuilder, NodeBuilder, NoValueType, _get_schema_from_tag
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping
@@ -67,7 +68,7 @@ def class_name_from_tag_uri(tag_uri: str) -> str:
     return class_name
 
 
-class _TaggedNodeMixin(NodeMixin):
+class _TaggedNodeMixin(ABC, NodeMixin):
     """
     Mixin class to provide the common API for all tagged objects.
 
@@ -87,19 +88,54 @@ class _TaggedNodeMixin(NodeMixin):
     _default_tag: ClassVar[str]
 
     @classmethod
-    def _create_minimal(
-        cls, defaults: Mapping[str, Any] | None = None, builder: Builder | None = None, *, tag: str | None = None
-    ) -> Self:
-        builder = builder or Builder()
-        new = cls(builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults))
+    def from_tag(cls, *, node: Any, tag: str) -> Self:
+        """
+        Create an instance of this class from a node for a given tag.
 
-        if tag:
-            new._read_tag = tag
+        Parameters
+        ----------
+        node: Any
+            The node to create the instance from
+        tag: str
+            The tag to use when creating the instance.
+        """
+        new = cls(node)
+
+        # This is a bit hacky, but the TaggedScalar node classes don't have a
+        #    easy way to inject the tag into the __init__ method, so we set it
+        #    here like this after the fact.
+        new._read_tag = tag
 
         return new
 
+    @staticmethod
+    def _build_node(
+        *,
+        tag: str,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+    ) -> Any:
+        return (builder or Builder()).build(_get_schema_from_tag(tag), defaults)
+
     @classmethod
-    def create_minimal(cls, defaults: Mapping[str, Any] | None = None, *, tag: str | None = None) -> Self:
+    def _create_minimal(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self | None:
+        tag = tag or cls._default_tag
+        return cls.from_tag(node=cls._build_node(tag=tag, defaults=defaults, builder=builder), tag=tag)
+
+    @classmethod
+    @final
+    def create_minimal(
+        cls,
+        defaults: Mapping[str, Any] | None = None,
+        *,
+        tag: str | None = None,
+    ) -> Self | None:
         """
         Create a minimal instance of this class, only things with the attributes
         which have a default value that can be determined.
@@ -114,25 +150,34 @@ class _TaggedNodeMixin(NodeMixin):
         Returns
         -------
         Self
-            An instance of this class
+            An instance of this class, or None if creation failed
         """
-        return cls._create_minimal(defaults, tag=tag)
+        return cls._create_minimal(defaults=defaults, tag=tag)
 
     @classmethod
     def _create_fake_data(
         cls,
+        *,
         defaults: Mapping[str, Any] | None = None,
         shape: tuple[int, ...] | None = None,
         builder: Builder | None = None,
-        *,
         tag: str | None = None,
-    ) -> Self:
-        return cls._create_minimal(defaults, builder or FakeDataBuilder(shape), tag=tag)
+    ) -> Self | None:
+        return cls._create_minimal(
+            defaults=defaults,
+            builder=(builder or FakeDataBuilder(shape)),
+            tag=tag,
+        )
 
     @classmethod
+    @final
     def create_fake_data(
-        cls, defaults: Mapping[str, Any] | None = None, shape: tuple[int, ...] | None = None, *, tag: str | None = None
-    ) -> Self:
+        cls,
+        defaults: Mapping[str, Any] | None = None,
+        shape: tuple[int, ...] | None = None,
+        *,
+        tag: str | None = None,
+    ) -> Self | None:
         """
         Create an instance of this class with with all required attributes
         filled in with fake data.
@@ -148,17 +193,33 @@ class _TaggedNodeMixin(NodeMixin):
 
         Returns
         -------
-        Self
-            An instance of this class
+        Self | None
+            An instance of this class, or None if creation failed
         """
-        return cls._create_fake_data(defaults, shape, tag=tag)
+        return cls._create_fake_data(defaults=defaults, shape=shape, tag=tag)
 
     @classmethod
-    def _create_from_node(cls, node: MutableMapping[str, Any], builder: Builder | None = None, *, tag: str | None = None) -> Self:
-        return cls._create_minimal(node, builder or NodeBuilder(), tag=tag)
+    def _create_from_node(
+        cls,
+        *,
+        node: MutableMapping[str, Any],
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self | None:
+        return cls._create_minimal(
+            defaults=node,
+            builder=(builder or NodeBuilder()),
+            tag=tag,
+        )
 
     @classmethod
-    def create_from_node(cls, node: MutableMapping[str, Any], *, tag: str | None = None) -> Self:
+    @final
+    def create_from_node(
+        cls,
+        node: MutableMapping[str, Any],
+        *,
+        tag: str | None = None,
+    ) -> Self | None:
         """
         Create an instance of this class from a node (dict-like object)
 
@@ -171,10 +232,10 @@ class _TaggedNodeMixin(NodeMixin):
 
         Returns
         -------
-        Self
-            An instance of this class
+        Self | None
+            An instance of this class, or None if creation failed
         """
-        return cls._create_from_node(node, tag=tag)
+        return cls._create_from_node(node=node, tag=tag)
 
     @property
     def _tag(self):
@@ -256,17 +317,21 @@ class TaggedScalarNode(_TaggedNodeMixin):
         return self
 
     @classmethod
-    def _create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
-        builder = builder or Builder()
-        value = builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults)
-        if value is _NO_VALUE:
-            return value
+    def _create_minimal(
+        cls,
+        *,
+        defaults: Mapping[str, Any] | None = None,
+        builder: Builder | None = None,
+        tag: str | None = None,
+    ) -> Self | None:
+        tag = tag or cls._default_tag
+        if isinstance(
+            value := cls._build_node(tag=tag, defaults=defaults, builder=builder),
+            NoValueType,
+        ):
+            return None
 
-        new = cls(value)
-        if tag:
-            new._read_tag = tag
-
-        return new
+        return cls.from_tag(node=value, tag=tag)
 
     @property
     def _tag(self):

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 else:
     NodeMixin: TypeAlias = object
 
-__all__ = ["SerializationNode", "TaggedListNode", "TaggedObjectNode", "TaggedScalarNode"]
+__all__ = ("SerializationNode", "TaggedListNode", "TaggedNode", "TaggedObjectNode", "TaggedScalarNode")
 
 
 def name_from_tag_uri(tag_uri: str) -> str:
@@ -68,7 +68,7 @@ def class_name_from_tag_uri(tag_uri: str) -> str:
     return class_name
 
 
-class _TaggedNodeMixin(ABC, NodeMixin):
+class TaggedNode(ABC, NodeMixin):
     """
     Mixin class to provide the common API for all tagged objects.
 
@@ -253,7 +253,7 @@ class _TaggedNodeMixin(ABC, NodeMixin):
         return _get_schema_from_tag(self.tag)
 
 
-class TaggedObjectNode(DNode, _TaggedNodeMixin):
+class TaggedObjectNode(DNode, TaggedNode):
     """
     Base class for all tagged objects defined by RAD
         There will be one of these for any tagged object defined by RAD, which has
@@ -274,7 +274,7 @@ class TaggedObjectNode(DNode, _TaggedNodeMixin):
             OBJECT_NODE_CLASSES_BY_PATTERN[cls._pattern] = cls
 
 
-class TaggedListNode(LNode, _TaggedNodeMixin):
+class TaggedListNode(LNode, TaggedNode):
     """
     Base class for all tagged list defined by RAD
         There will be one of these for any tagged object defined by RAD, which has
@@ -295,7 +295,7 @@ class TaggedListNode(LNode, _TaggedNodeMixin):
             LIST_NODE_CLASSES_BY_PATTERN[cls._pattern] = cls
 
 
-class TaggedScalarNode(_TaggedNodeMixin):
+class TaggedScalarNode(TaggedNode):
     """
     Base class for all tagged scalars defined by RAD
         There will be one of these for any tagged object defined by RAD, which has
@@ -342,7 +342,7 @@ class TaggedScalarNode(_TaggedNodeMixin):
         return copy.copy(self)
 
 
-_T = TypeVar("_T", bound=TaggedObjectNode | TaggedListNode | TaggedScalarNode)
+_T = TypeVar("_T", bound=TaggedNode)
 
 
 class SerializationNode(Generic[_T]):
@@ -388,6 +388,3 @@ class SerializationNode(Generic[_T]):
                 "__module__": "roman_datamodels._stnode",
             },
         )
-
-
-tagged_type: TypeAlias = type[TaggedObjectNode] | type[TaggedListNode] | type[TaggedScalarNode]

--- a/tests/stnode/test_schema.py
+++ b/tests/stnode/test_schema.py
@@ -6,7 +6,7 @@ from astropy.time import Time
 from astropy.units import Quantity
 
 from roman_datamodels._stnode import Observation, SkyBackground
-from roman_datamodels._stnode._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, SchemaType, _NoValueType
+from roman_datamodels._stnode._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, NoValueType, SchemaType
 
 
 @pytest.mark.parametrize(
@@ -112,13 +112,13 @@ def test_default_is_copied(subschema, data):
     "tag, expected_type",
     (
         # non-rad tags
-        ("tag:stsci.edu:asdf/time/time-1.*", _NoValueType),
-        ("tag:stsci.edu:asdf/core/ndarray-1.*", _NoValueType),
-        ("tag:stsci.edu:gwcs/wcs-*", _NoValueType),
-        ("tag:astropy.org:astropy/table/table-1.*", _NoValueType),
-        ("tag:stsci.edu:asdf/unit/quantity-1.*", _NoValueType),
+        ("tag:stsci.edu:asdf/time/time-1.*", NoValueType),
+        ("tag:stsci.edu:asdf/core/ndarray-1.*", NoValueType),
+        ("tag:stsci.edu:gwcs/wcs-*", NoValueType),
+        ("tag:astropy.org:astropy/table/table-1.*", NoValueType),
+        ("tag:stsci.edu:asdf/unit/quantity-1.*", NoValueType),
         # unknown tag
-        ("abc", _NoValueType),
+        ("abc", NoValueType),
         # test one rad tag to not make this test dependent on NODE_CLASSES_BY_TAG
         ("asdf://stsci.edu/datamodels/roman/tags/sky_background-1.0.0", SkyBackground),
     ),
@@ -141,7 +141,7 @@ def test_tag(tag, expected_type):
         ("tag:astropy.org:astropy/table/table-1.*", Table),
         ("tag:stsci.edu:asdf/unit/quantity-1.*", Quantity),
         # unknown tag
-        ("abc", _NoValueType),
+        ("abc", NoValueType),
         # test one rad tag to not make this test dependent on NODE_CLASSES_BY_TAG
         ("asdf://stsci.edu/datamodels/roman/tags/sky_background-1.0.0", SkyBackground),
     ),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,7 +26,6 @@ from roman_datamodels._stnode import (
     WfiWcs,
 )
 from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
-from roman_datamodels._stnode._tagged import _NO_VALUE
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy
 
 from .conftest import MANIFESTS
@@ -802,11 +801,11 @@ def test_create_tag(tag, node_class):
     """Test that we can create a node for every registered tag"""
 
     node = node_class.create_minimal(tag=tag)
-    if node is not _NO_VALUE:
+    if node is not None:
         assert node._read_tag == tag
 
     node = node_class.create_fake_data(tag=tag)
-    if node is not _NO_VALUE:
+    if node is not None:
         assert node._read_tag == tag
 
 


### PR DESCRIPTION
There has been something about how stnode objects handle the setting and removal of the tags that ASDF (or users) can attach to nodes that has been bothering me for a long time, see https://github.com/spacetelescope/roman_datamodels/blob/649c8ebe1789e0ca02af6e1fb18316f84e86a4ad/src/roman_datamodels/_stnode/_converters.py#L69.

This PR attempts to resolve this by adding a constructor to the nodes that takes care of this issue. This in turn means that all the code of the form
```python
if tag:
    new._read_tag = tag

return new
```

could be rolled together. Note that while fixing this issue I noticed/found some small issues with the `Builder`/`create_*` API that could be improved. This PR resolves both the `_read_tag` and builder API stuff.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
