### PR TITLE
fix manifest sorting

### DIFF
--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -34,8 +34,11 @@ __all__ = ["NODE_CLASSES", "NODE_EXTENSIONS"]
 #   This is because the ASDF extensions have to be created before they can be registered
 #   and this module creates the classes used by the ASDF extension.
 _MANIFEST_DIR = Path(str(importlib.resources.files(resources) / "manifests"))
-# TODO: We should make this use semantic versioning to sort to ensure we don't get something strange
-_DATAMODEL_MANIFEST_PATHS = sorted([path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")], reverse=True)
+_DATAMODEL_MANIFEST_PATHS = sorted(
+    [path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")],
+    reverse=True,
+    key=lambda v: tuple(int(i) for i in v.stem.rsplit("-")[-1].split(".")),
+)
 DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
 # Notice that the static manifests are first so that we defer to them
 _MANIFESTS = DATAMODEL_MANIFESTS


### PR DESCRIPTION
The latest version of the manifest is 1.9.0. If the next version is 1.10.0 (and not 2.0.0) the sorting in `_stnode` will be incorrect.

This fixes the sorting.

Regression tests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/25176613583

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
