### PR TITLE
Refactor and centralize the URI handling

### DIFF
--- a/changes/662.feature.rst
+++ b/changes/662.feature.rst
@@ -1,0 +1,1 @@
+Reactor the URI handling so that all URI handling is centralized and only works via direct calls to ASDF itself to find information about URIs.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ intersphinx_mapping = {
     "astropy": ("https://docs.astropy.org/en/stable/", None),
     "asdf": ("https://asdf.readthedocs.io/en/latest/", None),
     "rad": ("https://rad.readthedocs.io/en/latest/", None),
+    "semantic_version": ("https://python-semanticversion.readthedocs.io/en/latest/", None),
 }
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/src/roman_datamodels/_stnode/__init__.py
+++ b/src/roman_datamodels/_stnode/__init__.py
@@ -11,3 +11,4 @@ from ._node import *  # noqa: F403
 from ._schema import *  # noqa: F403
 from ._stnode import *  # noqa: F403
 from ._tagged import *  # noqa: F403
+from ._uri import *  # noqa: F403

--- a/src/roman_datamodels/_stnode/_factories.py
+++ b/src/roman_datamodels/_stnode/_factories.py
@@ -10,10 +10,11 @@ from typing import TYPE_CHECKING, Any
 from astropy.time import Time
 
 from . import _mixins
-from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, class_name_from_tag_uri
+from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode
 
 if TYPE_CHECKING:
     from ._tagged import tagged_type
+    from ._uri import UriInfo
 
 __all__ = ["stnode_factory"]
 
@@ -48,14 +49,14 @@ def docstring_from_tag(tag_def: dict[str, Any]) -> str:
     return docstring + f"Class generated from tag '{tag_def['tag_uri']}'"
 
 
-def scalar_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedScalarNode]:
+def scalar_factory(tag_info: UriInfo, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedScalarNode]:
     """
     Factory to create a TaggedScalarNode class from a tag
 
     Parameters
     ----------
-    pattern: str
-        A tag pattern/wildcard
+    tag_info: UriInfo
+        A UriInfo object containing the tag_uri and pattern for the tag
 
     latest_manifest: str
         URI for the latest manifest
@@ -67,8 +68,6 @@ def scalar_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) 
     -------
     A dynamically generated TaggedScalarNode subclass
     """
-    class_name = class_name_from_tag_uri(pattern)
-
     # TaggedScalarNode subclasses are really subclasses of the type of the scalar,
     #   with the TaggedScalarNode as a mixin.  This is because the TaggedScalarNode
     #   is supposed to be the scalar, but it needs to be serializable under a specific
@@ -76,37 +75,37 @@ def scalar_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) 
     # _SCALAR_TYPE_BY_PATTERN will need to be updated as new wrappers of scalar types are added
     #   to the RAD manifest.
     # assume everything is a string if not otherwise defined
-    class_type = _SCALAR_TYPE_BY_PATTERN.get(pattern, str)
+    class_type = _SCALAR_TYPE_BY_PATTERN.get(tag_info.pattern, str)
 
     # In special cases one may need to add additional features to a tagged node class.
     #   This is done by creating a mixin class with the name <ClassName>Mixin in _mixins.py
     #   Here we mixin the mixin class if it exists.
-    if hasattr(_mixins, mixin := f"{class_name}Mixin"):
+    if hasattr(_mixins, mixin := f"{tag_info.camel_case}Mixin"):
         class_type = (class_type, getattr(_mixins, mixin), TaggedScalarNode)
     else:
         class_type = (class_type, TaggedScalarNode)
 
     return type(
-        class_name,
+        tag_info.camel_case,
         class_type,
         {
-            "_pattern": pattern,
+            "_pattern": tag_info.pattern,
             "_latest_manifest": latest_manifest,
-            "_default_tag": tag_def["tag_uri"],
+            "_default_tag": tag_info.uri,
             "__module__": "roman_datamodels._stnode",
             "__doc__": docstring_from_tag(tag_def),
         },
     )
 
 
-def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedObjectNode | TaggedListNode]:
+def node_factory(tag_info: UriInfo, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedObjectNode | TaggedListNode]:
     """
     Factory to create a TaggedObjectNode or TaggedListNode class from a tag
 
     Parameters
     ----------
-    pattern: str
-        A tag pattern/wildcard
+    tag_info: UriInfo
+        A UriInfo object containing the tag_uri and pattern for the tag
 
     latest_manifest: str
         URI for the latest manifest
@@ -118,26 +117,25 @@ def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) ->
     -------
     A dynamically generated TaggedObjectNode or TaggedListNode subclass
     """
-    class_name = class_name_from_tag_uri(pattern)
 
-    base_class_type = _NODE_TYPE_BY_PATTERN.get(pattern, TaggedObjectNode)
+    base_class_type = _NODE_TYPE_BY_PATTERN.get(tag_info.pattern, TaggedObjectNode)
 
     # In special cases one may need to add additional features to a tagged node class.
     #   This is done by creating a mixin class with the name <ClassName>Mixin in _mixins.py
     #   Here we mixin the mixin class if it exists.
     class_type: tuple[Any, tagged_type] | tuple[tagged_type]
-    if hasattr(_mixins, mixin := f"{class_name}Mixin"):
+    if hasattr(_mixins, mixin := f"{tag_info.camel_case}Mixin"):
         class_type = (getattr(_mixins, mixin), base_class_type)
     else:
         class_type = (base_class_type,)
 
     return type(
-        class_name,
+        tag_info.camel_case,
         class_type,
         {
-            "_pattern": pattern,
+            "_pattern": tag_info.pattern,
             "_latest_manifest": latest_manifest,
-            "_default_tag": tag_def["tag_uri"],
+            "_default_tag": tag_info.uri,
             "__module__": "roman_datamodels._stnode",
             "__doc__": docstring_from_tag(tag_def),
             "__slots__": (),
@@ -146,15 +144,15 @@ def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) ->
 
 
 def stnode_factory(
-    pattern: str, latest_manifest: str, tag_def: dict[str, Any]
+    tag_info: UriInfo, latest_manifest: str, tag_def: dict[str, Any]
 ) -> type[TaggedObjectNode | TaggedListNode | TaggedScalarNode]:
     """
     Construct a tagged STNode class from a tag
 
     Parameters
     ----------
-    pattern: str
-        A tag pattern/wildcard
+    tag_info: UriInfo
+        A UriInfo object containing the tag_uri and pattern for the tag
 
     latest_manifest: str
         URI for the latest manifest
@@ -169,6 +167,6 @@ def stnode_factory(
     # TaggedScalarNodes are a special case because they are not a subclass of a
     #   _node class, but rather a subclass of the type of the scalar.
     if "tagged_scalar" in tag_def["schema_uri"]:
-        return scalar_factory(pattern, latest_manifest, tag_def)
+        return scalar_factory(tag_info, latest_manifest, tag_def)
     else:
-        return node_factory(pattern, latest_manifest, tag_def)
+        return node_factory(tag_info, latest_manifest, tag_def)

--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from asdf.tags.core.ndarray import asdf_datatype_to_numpy_dtype
 
 from ._schema import Builder, _get_keyword, _get_properties
-from ._tagged import _get_schema_from_tag
+from ._uri import UriInfo
 
 # This is a workaround for MyPy to understand the Mixin classes
 if TYPE_CHECKING:
@@ -173,7 +173,7 @@ class RefFileMixin(_ObjectBase):
             defaults = deepcopy(defaults)
         else:
             defaults = {}
-        schema = _get_schema_from_tag(tag or cls._default_tag)
+        schema = UriInfo(tag or cls._default_tag).schema
         for k, v in schema["properties"].items():
             if v["type"] != "string":
                 continue
@@ -196,7 +196,7 @@ class L2CalStepMixin(_ObjectBase):
     @classmethod
     def _create_minimal(cls, defaults=None, builder=None, *, tag=None):
         defaults = defaults or {}
-        schema = _get_schema_from_tag(tag or cls._default_tag)
+        schema = UriInfo(tag or cls._default_tag).schema
         new = cls({k: defaults.get(k, "INCOMPLETE") for k in schema["properties"]})
         if tag:
             new._read_tag = tag
@@ -256,7 +256,7 @@ class ImageSourceCatalogMixin(_ObjectBase):
         aperture_radii = aperture_radii or ["00"]
         filters = filters or ["f184"]
 
-        columns_schema = dict(_get_properties(_get_schema_from_tag(tag or cls._default_tag)["properties"]["source_catalog"]))
+        columns_schema = dict(_get_properties(UriInfo(tag or cls._default_tag).schema["properties"]["source_catalog"]))
         columns = []
 
         if "columns" in columns_schema:

--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -17,7 +17,6 @@ LIST_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedListNode]] = {}
 SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
 NODE_CONVERTERS: dict[str, type[_RomanConverter]] = {}
 NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
-SCHEMA_URIS_BY_TAG: dict[str, str] = {}
 SERIALIZATION_BY_MANIFEST: dict[str, type[SerializationNode]] = {}
 MANIFEST_TAG_REGISTRY: dict[str, list[str]] = {}
 TAG_MANIFEST_REGISTRY: dict[str, str] = {}

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -6,68 +6,24 @@ from __future__ import annotations
 
 import copy
 import enum
-import functools
 import re
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 import asdf
 import asdf.schema
-from semantic_version import Version
 
-from ._registry import NODE_CLASSES_BY_TAG, SCHEMA_URIS_BY_TAG
+from ._registry import NODE_CLASSES_BY_TAG
 
 if TYPE_CHECKING:
-    from typing import Any
+    pass
 
-__all__ = ["get_latest_schema"]
+__all__ = []
 
 
 NOSTR = "?"
 NONUM = -999999
 NOBOOL = False
-
-
-@functools.cache
-def get_latest_schema(uri: str) -> tuple[str, dict[str, Any]]:
-    """
-    Get the latest version of a schema by URI (or partial URI).
-    """
-
-    if "-" in uri:
-        uri_prefix, version = uri.rsplit("-", 1)
-        latest_uri = uri
-    else:
-        uri_prefix = uri
-        version = "0.0.0"
-        latest_uri = None
-
-    uri_prefix += "-"
-    current_version = Version(version)
-    for schema_uri in asdf.get_config().resource_manager:
-        if schema_uri.startswith(uri_prefix) and (new_version := Version(schema_uri.rsplit("-", 1)[-1])) > current_version:
-            current_version = new_version
-            latest_uri = schema_uri
-
-    if latest_uri is None:
-        raise ValueError(f"No schema found for {uri}")
-
-    return latest_uri, asdf.schema.load_schema(latest_uri, resolve_references=True)
-
-
-@functools.cache
-def _get_schema_from_tag(tag):
-    """
-    Look up and load ASDF's schema corresponding to the tag_uri.
-
-    Parameters
-    ----------
-    tag : str
-        The tag_uri of the schema to load.
-    """
-    schema_uri = SCHEMA_URIS_BY_TAG[tag]
-
-    return asdf.schema.load_schema(schema_uri, resolve_references=True)
 
 
 class _MissingKeywordType:

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -20,7 +20,6 @@ from ._registry import (
     NODE_CONVERTERS,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
-    SCHEMA_URIS_BY_TAG,
     TAG_MANIFEST_REGISTRY,
 )
 from ._tagged import SerializationNode
@@ -68,7 +67,6 @@ for version in sorted(_manifest_version_uri, reverse=True):
     for tag_def in manifest["tags"]:
         tag_info = UriInfo(tag_def["tag_uri"], "asdf_tag")
 
-        SCHEMA_URIS_BY_TAG[tag_info.uri] = tag_def["schema_uri"]
         if tag_info.pattern not in _generated:
             _generated[tag_info.pattern] = _factory(tag_info, manifest_uri, tag_def)
         NODE_CLASSES_BY_TAG[tag_info.uri] = _generated[tag_info.pattern]

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -6,12 +6,10 @@ Dynamic creation of STNode classes from the RAD manifest.
     used by the user.
 """
 
-import importlib.resources
-from pathlib import Path
+from types import MappingProxyType
 
-import yaml
+from asdf import get_config
 from asdf.extension import ManifestExtension
-from rad import resources
 
 from ._converters import SerializationNodeConverter
 from ._factories import stnode_factory
@@ -26,22 +24,19 @@ from ._registry import (
     TAG_MANIFEST_REGISTRY,
 )
 from ._tagged import SerializationNode
+from ._uri import UriInfo
 
 __all__ = ["NODE_CLASSES", "NODE_EXTENSIONS"]
 
 
-# Load the manifest directly from the rad resources and not from ASDF.
-#   This is because the ASDF extensions have to be created before they can be registered
-#   and this module creates the classes used by the ASDF extension.
-_MANIFEST_DIR = Path(str(importlib.resources.files(resources) / "manifests"))
-_DATAMODEL_MANIFEST_PATHS = sorted(
-    [path for path in _MANIFEST_DIR.glob("*datamodels-*.yaml")],
-    reverse=True,
-    key=lambda v: tuple(int(i) for i in v.stem.rsplit("-")[-1].split(".")),
+MANIFEST_PREFIX = "asdf://stsci.edu/datamodels/roman/manifests/datamodels"
+_manifest_version_uri = MappingProxyType(
+    {
+        (uri_info := UriInfo(uri, "asdf_resource")).version: uri_info
+        for uri in get_config().resource_manager
+        if uri.startswith(MANIFEST_PREFIX)
+    }
 )
-DATAMODEL_MANIFESTS = [yaml.safe_load(path.read_bytes()) for path in _DATAMODEL_MANIFEST_PATHS]
-# Notice that the static manifests are first so that we defer to them
-_MANIFESTS = DATAMODEL_MANIFESTS
 
 
 def _add_cls(cls):
@@ -51,35 +46,37 @@ def _add_cls(cls):
     return cls
 
 
-def _factory(pattern, latest_manifest, tag_def):
+def _factory(tag_info, latest_manifest, tag_def):
     """
     Wrap the __all__ append and class creation in a function to avoid the linter
         getting upset
     """
-    return _add_cls(stnode_factory(pattern, latest_manifest, tag_def))
+    return _add_cls(stnode_factory(tag_info, latest_manifest, tag_def))
 
 
 # Main dynamic class creation loop
 #   Reads each tag entry from the manifest and creates a class for it
 _generated = {}
-for manifest in _MANIFESTS:
+_MANIFESTS = []
+for version in sorted(_manifest_version_uri, reverse=True):
+    manifest = _manifest_version_uri[version].schema
+    _MANIFESTS.append(manifest)
+
     _add_cls(SerializationNode._factory(manifest_uri := manifest["id"]))
 
     MANIFEST_TAG_REGISTRY[manifest_uri] = []
     for tag_def in manifest["tags"]:
-        SCHEMA_URIS_BY_TAG[(tag_uri := tag_def["tag_uri"])] = tag_def["schema_uri"]
-        base, _ = tag_uri.rsplit("-", maxsplit=1)
+        tag_info = UriInfo(tag_def["tag_uri"], "asdf_tag")
 
-        # make pattern from tag
-        pattern = f"{base}-*"
-        if pattern not in _generated:
-            _generated[pattern] = _factory(pattern, manifest_uri, tag_def)
-        NODE_CLASSES_BY_TAG[tag_uri] = _generated[pattern]
+        SCHEMA_URIS_BY_TAG[tag_info.uri] = tag_def["schema_uri"]
+        if tag_info.pattern not in _generated:
+            _generated[tag_info.pattern] = _factory(tag_info, manifest_uri, tag_def)
+        NODE_CLASSES_BY_TAG[tag_info.uri] = _generated[tag_info.pattern]
 
         # Make serialization intermediate
-        if tag_uri not in TAG_MANIFEST_REGISTRY:
-            TAG_MANIFEST_REGISTRY[tag_uri] = manifest_uri
-            MANIFEST_TAG_REGISTRY[manifest_uri].append(tag_uri)
+        if tag_info.uri not in TAG_MANIFEST_REGISTRY:
+            TAG_MANIFEST_REGISTRY[tag_info.uri] = manifest_uri
+            MANIFEST_TAG_REGISTRY[manifest_uri].append(tag_info.uri)
 
 
 # Create the ASDF extension for the STNode classes.

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 else:
     NodeMixin: TypeAlias = object
 
-__all__ = ["SerializationNode", "TaggedListNode", "TaggedObjectNode", "TaggedScalarNode"]
+__all__ = ["SerializationNode", "TaggedListNode", "TaggedObjectNode", "TaggedScalarNode", "tagged_type"]
 
 
 def name_from_tag_uri(tag_uri: str) -> str:

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Generic, TypeVar
 
+from roman_datamodels._stnode._uri import UriInfo
+
 from ._node import DNode, LNode
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
@@ -16,7 +18,7 @@ from ._registry import (
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SERIALIZATION_BY_MANIFEST,
 )
-from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, _get_schema_from_tag
+from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping
@@ -91,7 +93,7 @@ class _TaggedNodeMixin(NodeMixin):
         cls, defaults: Mapping[str, Any] | None = None, builder: Builder | None = None, *, tag: str | None = None
     ) -> Self:
         builder = builder or Builder()
-        new = cls(builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults))
+        new = cls(builder.build(UriInfo(tag or cls._default_tag).schema, defaults))
 
         if tag:
             new._read_tag = tag
@@ -189,7 +191,7 @@ class _TaggedNodeMixin(NodeMixin):
 
     def get_schema(self):
         """Retrieve the schema associated with this tag"""
-        return _get_schema_from_tag(self.tag)
+        return UriInfo(self.tag).schema
 
 
 class TaggedObjectNode(DNode, _TaggedNodeMixin):
@@ -258,7 +260,7 @@ class TaggedScalarNode(_TaggedNodeMixin):
     @classmethod
     def _create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
         builder = builder or Builder()
-        value = builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults)
+        value = builder.build(UriInfo(tag or cls._default_tag).schema, defaults)
         if value is _NO_VALUE:
             return value
 

--- a/src/roman_datamodels/_stnode/_uri.py
+++ b/src/roman_datamodels/_stnode/_uri.py
@@ -84,6 +84,27 @@ class UriInfo:
     in `UriInfo.uri`.
     """
 
+    pattern: str = field(init=False)
+    """
+    The generalized regex pattern for this URI:
+        ``<prefix>-*``
+    """
+
+    search_prefix: str = field(init=False)
+    """
+    The prefix for searching for related URIs in ASDF
+    """
+
+    snake_case: str = field(init=False)
+    """
+    A snake_case version of the URI prefix for use in class names and attributes.
+    """
+
+    camel_case: str = field(init=False)
+    """
+    A CamelCase version of the URI prefix for use in class names.
+    """
+
     is_tag_uri: bool = field(init=False)
     """
     If the URI is registered as a tag URI in ASDF.
@@ -102,6 +123,10 @@ class UriInfo:
         object.__setattr__(self, "uri", uri)
         object.__setattr__(self, "prefix", prefix)
         object.__setattr__(self, "version", Version(version))
+        object.__setattr__(self, "pattern", f"{prefix}-*")
+        object.__setattr__(self, "search_prefix", f"{prefix}-")
+        object.__setattr__(self, "snake_case", self._snake_case())
+        object.__setattr__(self, "camel_case", self._camel_case())
 
         match uri_type:
             case "asdf_tag":
@@ -173,6 +198,26 @@ class UriInfo:
 
         return version
 
+    def _snake_case(self) -> str:
+        """Get a snake_case representation of this URI"""
+        name = self.prefix.split("/")[-1]
+
+        # Update the name for the FPS/TVAC cases
+        if "/fps/" in self.prefix and "fps" not in name:
+            name = f"fps_{name}"
+        if "/tvac/" in self.prefix and "tvac" not in name:
+            name = f"tvac_{name}"
+
+        # Update the name for reference files
+        if "/reference_files/" in self.prefix:
+            name = f"{name}_ref"
+
+        return name
+
+    def _camel_case(self) -> str:
+        """Get a CamelCase representation of this URI"""
+        return "".join([p.capitalize() for p in self.snake_case.split("_")])
+
     @staticmethod
     @contextmanager
     def _extension_manager() -> Generator[ExtensionManager, None, None]:
@@ -206,10 +251,9 @@ class UriInfo:
                 if manager.handles_tag(uri_option):
                     return True
 
-            prefix = self._search_prefix
             # Fall back on manually searching through the tags
             for tag_def in self._tag_def_generator(manager):
-                if tag_def.tag_uri.startswith(prefix):
+                if tag_def.tag_uri.startswith(self.search_prefix):
                     return True
 
         return False
@@ -223,39 +267,11 @@ class UriInfo:
                 This is determining if a URI corresponds to some resource file
                 (e.g., schema, manifest, ...) that has been registered with ASDF
         """
-        search_prefix = self._search_prefix
         for resource_uri in get_config().resource_manager:
-            if resource_uri.startswith(search_prefix):
+            if resource_uri.startswith(self.search_prefix):
                 return True
 
         return False
-
-    @property
-    def pattern(self) -> str:
-        """Return the uri pattern string for this URI"""
-        return f"{self.prefix}-*"
-
-    @property
-    def snake_case(self) -> str:
-        """Get a snake_case representation of this URI"""
-        name = self.prefix.split("/")[-1]
-
-        # Update the name for the FPS/TVAC cases
-        if "/fps/" in self.prefix and "fps" not in name:
-            name = f"fps_{name}"
-        if "/tvac/" in self.prefix and "tvac" not in name:
-            name = f"tvac_{name}"
-
-        # Update the name for reference files
-        if "/reference_files/" in self.prefix:
-            name = f"{name}_ref"
-
-        return name
-
-    @property
-    def camel_case(self) -> str:
-        """Get a CamelCase representation of this URI"""
-        return "".join([p.capitalize() for p in self.snake_case.split("_")])
 
     @property
     def is_asdf_uri(self) -> bool:
@@ -314,17 +330,10 @@ class UriInfo:
             return load_schema(self.resource_uri.exact_uri, resolve_references=True)
 
     @property
-    def _search_prefix(self) -> str:
-        """The prefix for searching for related URIs in ASDf"""
-        return f"{self.prefix}-"
-
-    @property
     def _latest_tag_uri(self) -> UriInfo:
         """
         Find the latest tag URI for this URI
         """
-        search_prefix = self._search_prefix
-
         latest_tag_uri: UriInfo = self
 
         with AsdfFile() as af:
@@ -335,7 +344,7 @@ class UriInfo:
                 tag_def: TagDefinition
                 for tag_def in extension.tags:
                     if (
-                        tag_def.tag_uri.startswith(search_prefix)
+                        tag_def.tag_uri.startswith(self.search_prefix)
                         and (new_tag_uri := UriInfo(tag_def.tag_uri, "asdf_tag")).version > latest_tag_uri.version
                     ):
                         latest_tag_uri = new_tag_uri
@@ -347,12 +356,10 @@ class UriInfo:
         """
         Find the latest resource URI for this URI
         """
-        search_prefix = self._search_prefix
-
         latest_resource_uri: UriInfo = self
         for resource_uri in get_config().resource_manager:
             if (
-                resource_uri.startswith(search_prefix)
+                resource_uri.startswith(self.search_prefix)
                 and (new_resource_uri := UriInfo(resource_uri, "asdf_resource")).version > latest_resource_uri.version
             ):
                 latest_resource_uri = new_resource_uri

--- a/src/roman_datamodels/_stnode/_uri.py
+++ b/src/roman_datamodels/_stnode/_uri.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import InitVar, dataclass, field
+from functools import cache
+from re import fullmatch
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+
+from asdf import AsdfFile, get_config
+from asdf.schema import load_schema
+from semantic_version import Version
+
+if TYPE_CHECKING:
+    from asdf.extension import Extension, ExtensionManager, TagDefinition
+
+__all__ = ("UriInfo", "get_latest_schema")
+
+
+_uri_type: TypeAlias = Literal["asdf_tag", "asdf_resource", "not_asdf"]
+
+
+# TODO: Should we upstream some of this functionality into ASDF itself?
+@dataclass(frozen=True, slots=True)
+class UriInfo:
+    """
+    A dataclass to hold the information about a URI and provide useful tools for the URI
+
+    .. note::
+
+        This class accepts uri fragments and patterns, with respect to the URI's version
+        number. If the version number is not provided or given as a wildcard, this
+        class will assume the version number parts are 0. For example:
+
+            - ``<prefix>``
+            - ``<prefix>-*``
+            - ``<prefix>-*.*``
+            - ``<prefix>-*.*.*``
+
+        will all be treated as if they were ``<prefix>-0.0.0``.
+
+    """
+
+    exact_uri: str
+    """
+    The exact URI that was provided without any of the parsing and filling of the
+        version number. This is useful for error messages and debugging.
+    """
+
+    uri_type: InitVar[_uri_type | None] = None
+    """
+    Flag to manually specify the URI flags.
+        This is so that when we directly know the the type of URI we are creating
+        (e.g., we know we have a tag or a schema URI) we can just set the flags
+        directly instead of making an ASDF query to determine the flags.
+    """
+
+    uri: str = field(init=False)
+    """
+    The full URI, (including the version), related to what was provided.
+        It will fill 0 in for each missing part of the semantic version number
+        at end of the URI:
+
+            ``<prefix>-<version>``
+    """
+
+    prefix: str = field(init=False)
+    """
+    The part of the URI before the ``-`` separator.
+        That is
+
+            ``<prefix>``
+
+        in `UriInfo.uri`.
+    """
+
+    version: Version = field(init=False)
+    """
+    The version of the URI, the part after the ``-`` parsed with `semantic_version.Version`.
+        If there is no version number, this will be 0.0.0. This is
+
+            ``<version>``
+
+    in `UriInfo.uri`.
+    """
+
+    is_tag_uri: bool = field(init=False)
+    """
+    If the URI is registered as a tag URI in ASDF.
+    """
+
+    is_resource_uri: bool = field(init=False)
+    """
+    If the URI is registered as a resource URI in ASDF.
+    """
+
+    def __post_init__(self, uri_type: _uri_type | None):
+        prefix, version = self._split_uri(self.exact_uri)
+        uri = f"{prefix}-{version}"
+
+        # Set the basic computed fields
+        object.__setattr__(self, "uri", uri)
+        object.__setattr__(self, "prefix", prefix)
+        object.__setattr__(self, "version", Version(version))
+
+        match uri_type:
+            case "asdf_tag":
+                is_tag_uri = True
+                is_resource_uri = False
+            case "asdf_resource":
+                is_tag_uri = False
+                is_resource_uri = True
+            case "not_asdf":
+                is_tag_uri = False
+                is_resource_uri = False
+            case None:
+                is_tag_uri = self._is_tag_uri()
+                is_resource_uri = self._is_resource_uri()
+            case _:
+                raise ValueError(f"Invalid uri_type '{uri_type}' given for URI '{self.exact_uri}'!")
+        object.__setattr__(self, "is_tag_uri", is_tag_uri)
+        object.__setattr__(self, "is_resource_uri", is_resource_uri)
+
+    @classmethod
+    def _split_uri(cls, uri: str) -> tuple[str, str]:
+        """
+        Helper method to split the URI into the prefix and version parts
+        """
+        # If the uri has a "-" divider, then we assume it splits into a prefix and version.
+        # Otherwise, we assume we were just given the prefix and the version is 0
+        prefix, version = uri.rsplit("-", maxsplit=1) if "-" in uri else (uri, "0")
+
+        return prefix, cls._resolve_version(version)
+
+    @staticmethod
+    def _resolve_version(version: str) -> str:
+        """
+        Helper method to resolve the version string into something that semantic_version can parse
+        """
+
+        # If "-" in passed in URI, but nothing after it, then version should be assumed to be 0
+        version = version or "0"
+
+        # If there are "*" in the version assume those are 0s
+        version = version.replace("*", "0")
+
+        # Turn version into a semantic version string by adding ".0" as needed to make it a major.minor.patch
+        # If the version is just a `<non-negative integer>`, then we assume that to be the major version
+        #   -> add period to the end
+        if fullmatch(r"^[0-9]\d*$", version):
+            version = f"{version}."
+
+        # If version is just a `<non-negative integer>.`, then we add "0" to make it a major.minor
+        #   -> add "0" to the end
+        if fullmatch(r"^[0-9]\d*\.$", version):
+            version = f"{version}0"
+
+        # If the version is just a `<non-negative integer>.<non-negative integer>`,
+        #   then we assume that to be the major.minor version
+        #   -> add period to the end
+        if fullmatch(r"^[0-9]\d*\.[0-9]\d*$", version):
+            version = f"{version}."
+
+        # If version is just a `<non-negative integer>.<non-negative integer>.`,
+        #   then we add "0" to make it a major.minor.patch
+        #   -> add "0" to the end
+        if fullmatch(r"^[0-9]\d*\.[0-9]\d*\.$", version):
+            version = f"{version}0"
+
+        # Check if the version is a semantic version
+        if not fullmatch(r"^[0-9]\d*\.[0-9]\d*\.[0-9]\d*$", version):
+            raise ValueError(f"Invalid version '{version}' in URI!")
+
+        return version
+
+    @staticmethod
+    @contextmanager
+    def _extension_manager() -> Generator[ExtensionManager, None, None]:
+        """
+        Helper to get the ASDF extension manager
+        """
+        with AsdfFile() as af:
+            yield af.extension_manager
+
+    @staticmethod
+    def _tag_def_generator(manager: ExtensionManager) -> Generator[TagDefinition, None, None]:
+        """
+        Helper generator to yield all of the ASDF tag definitions that correspond to this URI
+        """
+        extension: Extension
+        for extension in manager.extensions:
+            yield from extension.tags
+
+    def _is_tag_uri(self) -> bool:
+        """
+        Helper to determine if a URI is handled as a tag URI by ASDF
+
+            .. note::
+
+                ``alternate_uri`` option is because the first RAD manifest
+                does not have a semantic version number at the end of its URI.
+        """
+        with self._extension_manager() as manager:
+            # Short cut when we might have a full URI
+            for uri_option in (self.uri, self.exact_uri):
+                if manager.handles_tag(uri_option):
+                    return True
+
+            prefix = self._search_prefix
+            # Fall back on manually searching through the tags
+            for tag_def in self._tag_def_generator(manager):
+                if tag_def.tag_uri.startswith(prefix):
+                    return True
+
+        return False
+
+    def _is_resource_uri(self) -> bool:
+        """
+        Helper to determine if a URI is handled as a resource URI by ASDF
+
+            .. note::
+
+                This is determining if a URI corresponds to some resource file
+                (e.g., schema, manifest, ...) that has been registered with ASDF
+        """
+        search_prefix = self._search_prefix
+        for resource_uri in get_config().resource_manager:
+            if resource_uri.startswith(search_prefix):
+                return True
+
+        return False
+
+    @property
+    def pattern(self) -> str:
+        """Return the uri pattern string for this URI"""
+        return f"{self.prefix}-*"
+
+    @property
+    def snake_case(self) -> str:
+        """Get a snake_case representation of this URI"""
+        name = self.prefix.split("/")[-1]
+
+        # Update the name for the FPS/TVAC cases
+        if "/fps/" in self.prefix and "fps" not in name:
+            name = f"fps_{name}"
+        if "/tvac/" in self.prefix and "tvac" not in name:
+            name = f"tvac_{name}"
+
+        # Update the name for reference files
+        if "/reference_files/" in self.prefix:
+            name = f"{name}_ref"
+
+        return name
+
+    @property
+    def camel_case(self) -> str:
+        """Get a CamelCase representation of this URI"""
+        return "".join([p.capitalize() for p in self.snake_case.split("_")])
+
+    @property
+    def is_asdf_uri(self) -> bool:
+        """Return True if this URI is registered as either a tag or resource URI in ASDF"""
+        return self.is_tag_uri or self.is_resource_uri
+
+    @property
+    def resource_uri(self) -> UriInfo:
+        """
+        Return the resource URI for this URI, which is itself if it is a resource URI
+        """
+        if self.is_resource_uri:
+            return self
+
+        if self.is_tag_uri:
+            with self._extension_manager() as manager:
+                for uri_option in (self.uri, self.exact_uri):
+                    if manager.handles_tag(uri_option):
+                        tag_def: TagDefinition = manager.get_tag_definition(uri_option)
+
+                        # It is possible that we have multiple schemas that correspond
+                        #    to a registered ASDF tag uri, so we just take the first one
+                        return UriInfo(tag_def.schema_uris[0], "asdf_resource")
+
+                raise ValueError(f"URI '{self.uri}' is indicated as a tag URI, but ASDF does not handle it!")
+
+        raise ValueError(f"URI '{self.uri}' is not registered as either a tag or resource URI in ASDF")
+
+    @property
+    def tag_uri(self) -> UriInfo:
+        """
+        Return the tag URI for this URI, which is itself if it is a tag URI
+        """
+        if self.is_tag_uri:
+            return self
+
+        if self.is_resource_uri:
+            with self._extension_manager() as manager:
+                for tag_def in self._tag_def_generator(manager):
+                    if self.uri in tag_def.schema_uris or self.exact_uri in tag_def.schema_uris:
+                        return UriInfo(tag_def.tag_uri, "asdf_tag")
+
+                raise ValueError(f"ASDF resource URI '{self.uri}' is not associated with any tag URI in ASDF!")
+
+        raise ValueError(f"URI '{self.uri}' is not registered as either a tag or resource URI in ASDF")
+
+    @property
+    def schema(self) -> Any:
+        """
+        Return the schema URI for this URI, which is the latest version of the prefix
+        """
+        # Again this is to handle the case for the first RAD manifest
+        try:
+            return load_schema(self.resource_uri.uri, resolve_references=True)
+        except FileNotFoundError:
+            return load_schema(self.resource_uri.exact_uri, resolve_references=True)
+
+    @property
+    def _search_prefix(self) -> str:
+        """The prefix for searching for related URIs in ASDf"""
+        return f"{self.prefix}-"
+
+    @property
+    def _latest_tag_uri(self) -> UriInfo:
+        """
+        Find the latest tag URI for this URI
+        """
+        search_prefix = self._search_prefix
+
+        latest_tag_uri: UriInfo = self
+
+        with AsdfFile() as af:
+            manager: ExtensionManager = af.extension_manager
+
+            extension: Extension
+            for extension in manager.extensions:
+                tag_def: TagDefinition
+                for tag_def in extension.tags:
+                    if (
+                        tag_def.tag_uri.startswith(search_prefix)
+                        and (new_tag_uri := UriInfo(tag_def.tag_uri, "asdf_tag")).version > latest_tag_uri.version
+                    ):
+                        latest_tag_uri = new_tag_uri
+
+        return latest_tag_uri
+
+    @property
+    def _latest_resource_uri(self) -> UriInfo:
+        """
+        Find the latest resource URI for this URI
+        """
+        search_prefix = self._search_prefix
+
+        latest_resource_uri: UriInfo = self
+        for resource_uri in get_config().resource_manager:
+            if (
+                resource_uri.startswith(search_prefix)
+                and (new_resource_uri := UriInfo(resource_uri, "asdf_resource")).version > latest_resource_uri.version
+            ):
+                latest_resource_uri = new_resource_uri
+
+        return latest_resource_uri
+
+    @property
+    def latest_uri(self) -> UriInfo:
+        """
+        Return the info for the latest version of this URI
+        """
+        if self.is_tag_uri:
+            return self._latest_tag_uri
+
+        if self.is_resource_uri:
+            return self._latest_resource_uri
+
+        raise ValueError(f"URI '{self.uri}' is not registered as either a tag or resource URI in ASDF")
+
+
+# TODO: should we deprecate this function in favor of just using UriInfo directly?
+@cache
+def get_latest_schema(uri: str) -> tuple[str, Any]:
+    """
+    Get the latest version of a schema by URI (or partial URI).
+    """
+    latest = UriInfo(uri).latest_uri
+
+    return latest.resource_uri.uri, latest.schema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
+from typing import Any
+
 import asdf
 import pytest
+from asdf.schema import load_schema
 
 from roman_datamodels._stnode._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
+    MANIFEST_TAG_REGISTRY,
     NODE_CLASSES_BY_TAG,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCHEMA_URIS_BY_TAG,
@@ -17,6 +21,24 @@ def manifest(request):
     return request.param
 
 
+@pytest.fixture(scope="session", params=MANIFEST_TAG_REGISTRY)
+def manifest_uri(request):
+    """Fixture to provide all manifest URIs for testing"""
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def manifest_schema(manifest_uri: str) -> Any:
+    """Fixture to provide the schema corresponding to a given manifest URI for testing."""
+    return load_schema(manifest_uri, resolve_references=True)
+
+
+@pytest.fixture(scope="session")
+def latest_manifest_uri() -> str:
+    """Fixture to provide the latest manifest URI for testing"""
+    return MANIFESTS[0]["id"]
+
+
 @pytest.fixture(scope="module", params=NODE_CLASSES_BY_TAG)
 def tag_uri(request) -> str:
     """Fixture for providing all tag URIs to test against."""
@@ -24,9 +46,33 @@ def tag_uri(request) -> str:
 
 
 @pytest.fixture(scope="module")
+def schema_uri(tag_uri: str) -> str:
+    """Fixture to provide the schema URI corresponding to a given tag URI for testing"""
+    return SCHEMA_URIS_BY_TAG[tag_uri]
+
+
+@pytest.fixture(scope="module")
 def node_class(tag_uri: str) -> tagged_type:
     """Fixture for providing the node class corresponding to a given tag URI for testing."""
     return NODE_CLASSES_BY_TAG[tag_uri]
+
+
+@pytest.fixture(scope="module")
+def latest_tag_uri(node_class: tagged_type) -> str:
+    """Fixture for providing the latest tag URI corresponding to a given node class for testing."""
+    return node_class._default_tag
+
+
+@pytest.fixture(scope="module")
+def latest_schema_uri(latest_tag_uri: str) -> str:
+    """Fixture for providing the latest schema URI corresponding to a given tag URI for testing."""
+    return SCHEMA_URIS_BY_TAG[latest_tag_uri]
+
+
+@pytest.fixture(scope="module")
+def schema(schema_uri: str) -> Any:
+    """Fixture for providing the schema corresponding to a given schema URI for testing."""
+    return load_schema(schema_uri, resolve_references=True)
 
 
 @pytest.fixture(scope="module", params=MODEL_REGISTRY)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+from asdf import AsdfFile
 from asdf.schema import load_schema
 
 from roman_datamodels._stnode._registry import (
@@ -8,7 +9,6 @@ from roman_datamodels._stnode._registry import (
     MANIFEST_TAG_REGISTRY,
     NODE_CLASSES_BY_TAG,
     OBJECT_NODE_CLASSES_BY_PATTERN,
-    SCHEMA_URIS_BY_TAG,
 )
 from roman_datamodels._stnode._stnode import _MANIFESTS as MANIFESTS
 from roman_datamodels._stnode._tagged import TaggedListNode, TaggedObjectNode, tagged_type
@@ -47,7 +47,8 @@ def tag_uri(request) -> str:
 @pytest.fixture(scope="module")
 def schema_uri(tag_uri: str) -> str:
     """Fixture to provide the schema URI corresponding to a given tag URI for testing"""
-    return SCHEMA_URIS_BY_TAG[tag_uri]
+    with AsdfFile() as af:
+        return af.extension_manager.get_tag_definition(tag_uri).schema_uris[0]
 
 
 @pytest.fixture(scope="module")
@@ -65,7 +66,8 @@ def latest_tag_uri(node_class: tagged_type) -> str:
 @pytest.fixture(scope="module")
 def latest_schema_uri(latest_tag_uri: str) -> str:
     """Fixture for providing the latest schema URI corresponding to a given tag URI for testing."""
-    return SCHEMA_URIS_BY_TAG[latest_tag_uri]
+    with AsdfFile() as af:
+        return af.extension_manager.get_tag_definition(latest_tag_uri).schema_uris[0]
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,15 @@
 import asdf
 import pytest
 
-from roman_datamodels._stnode._registry import OBJECT_NODE_CLASSES_BY_PATTERN, SCHEMA_URIS_BY_TAG
+from roman_datamodels._stnode._registry import (
+    LIST_NODE_CLASSES_BY_PATTERN,
+    NODE_CLASSES_BY_TAG,
+    OBJECT_NODE_CLASSES_BY_PATTERN,
+    SCHEMA_URIS_BY_TAG,
+)
 from roman_datamodels._stnode._stnode import _MANIFESTS as MANIFESTS
+from roman_datamodels._stnode._tagged import TaggedListNode, TaggedObjectNode, tagged_type
+from roman_datamodels.datamodels import MODEL_REGISTRY, DataModel
 
 
 @pytest.fixture(scope="session", params=MANIFESTS)
@@ -10,18 +17,63 @@ def manifest(request):
     return request.param
 
 
-@pytest.fixture(scope="session", params=list(OBJECT_NODE_CLASSES_BY_PATTERN.values()))
-def object_node(request):
+@pytest.fixture(scope="module", params=NODE_CLASSES_BY_TAG)
+def tag_uri(request) -> str:
+    """Fixture for providing all tag URIs to test against."""
     return request.param
 
 
-@pytest.fixture(scope="session")
-def object_node_default_uri(object_node):
-    return SCHEMA_URIS_BY_TAG[object_node._default_tag]
+@pytest.fixture(scope="module")
+def node_class(tag_uri: str) -> tagged_type:
+    """Fixture for providing the node class corresponding to a given tag URI for testing."""
+    return NODE_CLASSES_BY_TAG[tag_uri]
 
 
-@pytest.fixture(scope="session")
-def object_node_uris(object_node_default_uri):
-    prefix_uri = f"{object_node_default_uri.rsplit('-', 1)[0]}-"
+@pytest.fixture(scope="module", params=MODEL_REGISTRY)
+def model_node(request) -> type[TaggedObjectNode]:
+    """Fixture for providing all of the node classes that data models wrap"""
+    return request.param
 
-    return [schema_uri for schema_uri in asdf.get_config().resource_manager if schema_uri.startswith(prefix_uri)]
+
+@pytest.fixture(scope="module", params=MODEL_REGISTRY)
+def other_model_node(request) -> type[TaggedObjectNode]:
+    """Another independent fixture for providing all of the node classes that data models wrap"""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def data_model(model_node: type[TaggedObjectNode]) -> type[DataModel]:
+    """Fixture for providing all of the data model classes for testing"""
+    return MODEL_REGISTRY[model_node]
+
+
+@pytest.fixture(scope="module", params=OBJECT_NODE_CLASSES_BY_PATTERN.values())
+def object_node_class(request) -> type[TaggedObjectNode]:
+    """Fixture for providing all of the object node classes for testing"""
+    return request.param
+
+
+@pytest.fixture(scope="module", params=LIST_NODE_CLASSES_BY_PATTERN.values())
+def list_node_class(request) -> type[TaggedListNode]:
+    """Fixture for providing all of the list node classes for testing"""
+    return request.param
+
+
+@pytest.fixture(scope="module", params=(*OBJECT_NODE_CLASSES_BY_PATTERN.values(), *LIST_NODE_CLASSES_BY_PATTERN.values()))
+def container_node_class(request) -> type[TaggedObjectNode] | type[TaggedListNode]:
+    """Fixture for providing all of the container node classes for testing"""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def object_node_default_schema_uri(object_node_class: type[TaggedObjectNode]) -> str:
+    """Fixture for providing the default schema URI for an object node class."""
+    return SCHEMA_URIS_BY_TAG[object_node_class._default_tag]
+
+
+@pytest.fixture(scope="module")
+def object_node_schema_uris(object_node_default_schema_uri: str) -> tuple[str, ...]:
+    """Fixture for providing all of the schema URIs for an object node class."""
+    prefix_uri = f"{object_node_default_schema_uri.rsplit('-', 1)[0]}-"
+
+    return tuple(schema_uri for schema_uri in asdf.get_config().resource_manager if schema_uri.startswith(prefix_uri))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import asdf
 import pytest
 from asdf.schema import load_schema
 
@@ -109,17 +108,3 @@ def list_node_class(request) -> type[TaggedListNode]:
 def container_node_class(request) -> type[TaggedObjectNode] | type[TaggedListNode]:
     """Fixture for providing all of the container node classes for testing"""
     return request.param
-
-
-@pytest.fixture(scope="module")
-def object_node_default_schema_uri(object_node_class: type[TaggedObjectNode]) -> str:
-    """Fixture for providing the default schema URI for an object node class."""
-    return SCHEMA_URIS_BY_TAG[object_node_class._default_tag]
-
-
-@pytest.fixture(scope="module")
-def object_node_schema_uris(object_node_default_schema_uri: str) -> tuple[str, ...]:
-    """Fixture for providing all of the schema URIs for an object node class."""
-    prefix_uri = f"{object_node_default_schema_uri.rsplit('-', 1)[0]}-"
-
-    return tuple(schema_uri for schema_uri in asdf.get_config().resource_manager if schema_uri.startswith(prefix_uri))

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -1,22 +1,13 @@
 import asdf
 import pytest
 
+from roman_datamodels._stnode import TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
 from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG, TAG_MANIFEST_REGISTRY
 
 
-@pytest.fixture(scope="session", params=NODE_CLASSES_BY_TAG)
-def node_tag(request):
-    return request.param
-
-
-@pytest.fixture(scope="session")
-def node_cls(node_tag):
-    return NODE_CLASSES_BY_TAG[node_tag]
-
-
-@pytest.fixture(scope="session")
-def node_instance(node_tag, node_cls):
-    return node_cls.create_fake_data(tag=node_tag)
+@pytest.fixture(scope="module")
+def node_instance(tag_uri: str, node_class: tagged_type) -> TaggedObjectNode | TaggedListNode | TaggedScalarNode:
+    return node_class.create_fake_data(tag=tag_uri)
 
 
 @pytest.mark.parametrize("manifest_uri", MANIFEST_TAG_REGISTRY)
@@ -37,12 +28,12 @@ def test_all_tags_in_manifest_tag_registry():
     assert len(TAG_MANIFEST_REGISTRY) == len(NODE_CLASSES_BY_TAG)
 
 
-def test_history(tmp_path, node_tag, node_instance):
+def test_history(tmp_path, tag_uri: str, node_instance: TaggedObjectNode | TaggedListNode | TaggedScalarNode):
     filename = tmp_path / "history_test.asdf"
     prefix = "asdf://stsci.edu/datamodels/roman/extensions/"
 
     # Sanity check
-    assert node_instance.tag == node_tag
+    assert node_instance.tag == tag_uri
 
     # Save asdf file
     asdf.AsdfFile(tree={"roman": node_instance}).write_to(filename)
@@ -59,9 +50,9 @@ def test_history(tmp_path, node_tag, node_instance):
 
     datamodel_uris = sorted([extension_uri.replace("extensions", "manifests") for extension_uri in extension_uris])
     # node_tag should be the list of datamodel_uris
-    assert TAG_MANIFEST_REGISTRY[node_tag] in datamodel_uris
+    assert TAG_MANIFEST_REGISTRY[tag_uri] in datamodel_uris
 
     # If a tag is in a given manifest then all of its referenced tags are also in that manifest
     #    so the earliest manifest and extension can be is the latest one for the node_tag.
     #    all other manifests must be the same or newer.
-    assert TAG_MANIFEST_REGISTRY[node_tag] == datamodel_uris[0]
+    assert TAG_MANIFEST_REGISTRY[tag_uri] == datamodel_uris[0]

--- a/tests/stnode/test_uri.py
+++ b/tests/stnode/test_uri.py
@@ -1,0 +1,367 @@
+from typing import Any
+
+import pytest
+from asdf.schema import load_schema
+from semantic_version import Version
+
+from roman_datamodels._stnode import UriInfo, get_latest_schema
+
+
+@pytest.fixture(
+    scope="module",
+    params=(
+        "asdf://example.com/uri/",
+        "asdf://example.com/uri/fps/",
+        "asdf://example.com/uri/tvac/",
+        "asdf://example.com/uri/reference_files/",
+    ),
+)
+def base_uri(request) -> str:
+    """Fixture to provide a base of a URI for testing"""
+    return request.param
+
+
+@pytest.fixture(scope="module", params=("example", "example_other"))
+def uri_name(request) -> str:
+    """Fixture to provide a URI name for testing"""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def prefix(base_uri: str, uri_name: str) -> str:
+    """Fixture to provide a URI prefix for testing"""
+    return f"{base_uri}{uri_name}"
+
+
+@pytest.fixture(scope="module")
+def snake_case(base_uri: str, uri_name: str) -> str:
+    """Fixture to provide a snake_case representation of the URI for testing"""
+    match base_uri:
+        case "asdf://example.com/uri/":
+            return uri_name
+        case "asdf://example.com/uri/fps/":
+            return f"fps_{uri_name}"
+        case "asdf://example.com/uri/tvac/":
+            return f"tvac_{uri_name}"
+        case "asdf://example.com/uri/reference_files/":
+            return f"{uri_name}_ref"
+        case _:
+            raise ValueError(f"Invalid base URI '{base_uri}' for testing")
+
+
+@pytest.fixture(scope="module")
+def camel_case_name(uri_name: str) -> str:
+    """Fixture to provide a CamelCase name for testing"""
+    match uri_name:
+        case "example":
+            return "Example"
+        case "example_other":
+            return "ExampleOther"
+        case _:
+            raise ValueError(f"Invalid URI name '{uri_name}' for testing")
+
+
+@pytest.fixture(scope="module")
+def camel_case(base_uri: str, camel_case_name: str) -> str:
+    """Fixture to provide a CamelCase representation of the URI for testing"""
+    match base_uri:
+        case "asdf://example.com/uri/":
+            return camel_case_name
+        case "asdf://example.com/uri/fps/":
+            return f"Fps{camel_case_name}"
+        case "asdf://example.com/uri/tvac/":
+            return f"Tvac{camel_case_name}"
+        case "asdf://example.com/uri/reference_files/":
+            return f"{camel_case_name}Ref"
+        case _:
+            raise ValueError(f"Invalid base URI '{base_uri}' for testing")
+
+
+@pytest.fixture(
+    scope="module",
+    params=(None, "", "1", "37.", "3.14", "170.27.", "14.619.4", "*", "*.", "*.*", "*.*.", "*.*.*"),
+)
+def uri_input_version(request) -> str | None:
+    """Fixture to provide a URI version for testing"""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def uri_version(uri_input_version: str | None) -> str:
+    """Fixture to provide a URI version based on the input version"""
+    match uri_input_version:
+        case None | "" | "*" | "*." | "*.*" | "*.*." | "*.*.*":
+            return "0.0.0"
+        case "1":
+            return "1.0.0"
+        case "37.":
+            return "37.0.0"
+        case "3.14":
+            return "3.14.0"
+        case "170.27.":
+            return "170.27.0"
+        case "14.619.4":
+            return "14.619.4"
+        case _:
+            raise ValueError(f"Invalid input version '{uri_input_version}' for testing")
+
+
+@pytest.fixture(scope="module")
+def input_uri(prefix: str, uri_input_version: str | None) -> str:
+    """Fixture to provide a full URI for testing"""
+    if uri_input_version is None:
+        return prefix
+
+    return f"{prefix}-{uri_input_version}"
+
+
+@pytest.fixture(scope="module")
+def uri(prefix: str, uri_version: str) -> str:
+    """Fixture to provide a full URI with version for testing"""
+    return f"{prefix}-{uri_version}"
+
+
+@pytest.fixture(scope="module")
+def version(uri_version: str) -> Version:
+    """Fixture to provide a URI version for testing"""
+    return Version(uri_version)
+
+
+@pytest.fixture(scope="module")
+def latest_schema(latest_schema_uri: str) -> Any:
+    """Fixture to provide the latest schema corresponding to a given tag URI for testing"""
+    return load_schema(latest_schema_uri, resolve_references=True)
+
+
+@pytest.fixture(scope="module")
+def latest_manifest_schema(latest_manifest_uri: str) -> Any:
+    """Fixture to provide the latest manifest schema for testing"""
+    return load_schema(latest_manifest_uri, resolve_references=True)
+
+
+@pytest.fixture(scope="module", params=(None, "", "-", "-*", "-*.", "-*.*", "-*.*.", "-*.*.*"))
+def uri_suffix(request) -> None:
+    """Fixture to provide suffixes to test that the class correctly identifies all versions of a tag URI"""
+    return request.param
+
+
+class TestBasic:
+    """Test the UriInfo helper class that does not need asdf information to be tested"""
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "uri_type, truth",
+        (
+            ("asdf_tag", (True, False, True)),
+            ("asdf_resource", (False, True, True)),
+            ("not_asdf", (False, False, False)),
+        ),
+    )
+    def test_uri_type_options(uri_type: str, truth: tuple[bool, bool, bool]):
+        """
+        Test that the `uri_type` option sets the flags correctly
+
+            truth -> (is_tag_uri, is_resource_uri, is_asdf_uri) bools
+        """
+        input_uri = "asdf://example.com/uri/test-1.0.0"
+
+        uri = UriInfo(input_uri, uri_type)
+        assert uri.is_tag_uri is truth[0]
+        assert uri.is_resource_uri is truth[1]
+        assert uri.is_asdf_uri is truth[2]
+
+        with pytest.raises(ValueError, match=r"Invalid uri_type .* given for URI.*!"):
+            UriInfo(input_uri, "invalid_uri_type")
+
+    @staticmethod
+    def test_uri(input_uri: str, uri: str):
+        """Test that the URI is correctly computed from the input URI"""
+        assert UriInfo(input_uri, "not_asdf").uri == uri
+
+    @staticmethod
+    def test_prefix(input_uri: str, prefix: str):
+        """Test that the prefix is correctly computed from the URI"""
+        assert UriInfo(input_uri, "not_asdf").prefix == prefix
+
+    @staticmethod
+    def test_version(input_uri: str, version: Version):
+        """Test that the version is correctly computed from the input URI"""
+        assert UriInfo(input_uri, "not_asdf").version == version
+
+    @staticmethod
+    @pytest.mark.parametrize("bad_version", ("a", "1.a", "1.0.a", "foo.*", "foo.bar.baz"))
+    def test_bad_version(prefix: str, bad_version: str):
+        """Test that invalid versions raise a ValueError"""
+        with pytest.raises(ValueError, match=f"Invalid version '{bad_version}' in URI!"):
+            UriInfo(f"{prefix}-{bad_version}", "not_asdf")
+
+    @staticmethod
+    def test_pattern(input_uri: str, prefix: str):
+        """Test that the pattern is correctly computed from the URI"""
+        assert UriInfo(input_uri, "not_asdf").pattern == f"{prefix}-*"
+
+    @staticmethod
+    def test_snake_case(input_uri: str, snake_case: str):
+        """Test that the snake_case representation is correctly computed from the URI"""
+        assert UriInfo(input_uri, "not_asdf").snake_case == snake_case
+
+    @staticmethod
+    def test_camel_case(input_uri: str, camel_case: str):
+        """Test that the camel_case representation is correctly computed from the URI"""
+        assert UriInfo(input_uri, "not_asdf").camel_case == camel_case
+
+
+class TestAsdf:
+    """Test the UriInfo helper class that needs asdf information to be tested"""
+
+    @staticmethod
+    def test_flags_for_not_resources(input_uri: str):
+        """
+        Test that the flags are set correctly when we don't specify the uri_type
+            and the URI is not registered with ASDF
+        """
+        uri = UriInfo(input_uri)
+        assert uri.is_tag_uri is False
+        assert uri.is_resource_uri is False
+        assert uri.is_asdf_uri is False
+
+    @staticmethod
+    def test_flags_for_tag_uri(tag_uri: str, uri_suffix: str | None):
+        """Test that the class correctly flags all the tag URIS for RAD as ASDF URIs"""
+        # Note we purposely don't specify the uri_type here to test that the class
+        #    correctly identifies the tag URIs based on the registry
+        uri = UriInfo(tag_uri)
+        if uri_suffix is not None:
+            uri = UriInfo(f"{uri.prefix}{uri_suffix}")
+
+        assert uri.is_tag_uri is True
+        assert uri.is_resource_uri is False
+        assert uri.is_asdf_uri is True
+
+    @staticmethod
+    def test_flags_for_schema_uri(schema_uri: str, uri_suffix: str | None):
+        """Test that the class correctly flags all the schema URIS for RAD as ASDF URIs"""
+        # Note we purposely don't specify the uri_type here to test that the class
+        #    correctly identifies the tag URIs based on the registry
+        uri = UriInfo(schema_uri)
+        if uri_suffix is not None:
+            uri = UriInfo(f"{uri.prefix}{uri_suffix}")
+
+        assert uri.is_tag_uri is False
+        assert uri.is_resource_uri is True
+        assert uri.is_asdf_uri is True
+
+    @staticmethod
+    def test_flags_for_manifest_uri(manifest_uri: str, uri_suffix: str | None):
+        """Test that the class correctly flags all the manifest URIS for RAD as ASDF URIs"""
+        # Note we purposely don't specify the uri_type here to test that the class
+        #    correctly identifies the tag URIs based on the registry
+        uri = UriInfo(manifest_uri)
+        if uri_suffix is not None:
+            uri = UriInfo(f"{uri.prefix}{uri_suffix}")
+
+        assert uri.is_tag_uri is False
+        assert uri.is_resource_uri is True
+        assert uri.is_asdf_uri is True
+
+    @staticmethod
+    def test_resource_uri_for_tag_uri(tag_uri: str, schema_uri: str):
+        """Test that the resource URI is correctly computed for a tag URI"""
+        assert UriInfo(tag_uri, "asdf_tag").resource_uri == UriInfo(schema_uri, "asdf_resource")
+
+    @staticmethod
+    def test_resource_uri_for_schema_uri(schema_uri: str):
+        """Test that the resource URI is correctly computed for a schema URI"""
+        assert (uri_info := UriInfo(schema_uri, "asdf_resource")).resource_uri is uri_info
+
+    @staticmethod
+    def test_resource_uri_for_manifest_uri(manifest_uri: str):
+        """Test that the resource URI is correctly computed for a manifest URI"""
+        assert (uri_info := UriInfo(manifest_uri, "asdf_resource")).resource_uri is uri_info
+
+    @staticmethod
+    def test_tag_uri_for_tag_uri(tag_uri: str):
+        """Test that the tag URI is correctly computed for a tag URI"""
+        assert (uri_info := UriInfo(tag_uri, "asdf_tag")).tag_uri is uri_info
+
+    @staticmethod
+    def test_tag_uri_for_schema_uri(tag_uri: str, schema_uri: str):
+        """Test that the tag URI is correctly computed for a schema URI"""
+        assert UriInfo(schema_uri, "asdf_resource").tag_uri == UriInfo(tag_uri, "asdf_tag")
+
+    @staticmethod
+    def test_tag_uri_for_manifest_uri(manifest_uri: str):
+        """
+        Test that the tag URI raises an error for the manifest URI since it
+        doesn't have a corresponding tag URI
+        """
+        with pytest.raises(ValueError, match=r"ASDF resource URI .* is not associated with any tag URI in ASDF!"):
+            _ = UriInfo(manifest_uri, "asdf_resource").tag_uri
+
+    @staticmethod
+    def test_schema_tag_uri(tag_uri: str, schema: Any):
+        """Test that the schema is correctly loaded from the tag URI"""
+        assert UriInfo(tag_uri, "asdf_tag").schema == schema
+
+    @staticmethod
+    def test_schema_schema_uri(schema_uri: str, schema: Any):
+        """Test that the schema is correctly loaded from the schema URI"""
+        assert UriInfo(schema_uri, "asdf_resource").schema == schema
+
+    @staticmethod
+    def test_schema_manifest_uri(manifest_uri: str, manifest_schema: Any):
+        """Test that the schema is correctly loaded from the manifest URI"""
+        assert UriInfo(manifest_uri, "asdf_resource").schema == manifest_schema
+
+    @staticmethod
+    def test_latest_uri_tag_uri(tag_uri: str, latest_tag_uri: str):
+        """Test that the latest tag URI is correctly computed from the tag URI"""
+        assert UriInfo(tag_uri, "asdf_tag").latest_uri == UriInfo(latest_tag_uri, "asdf_tag")
+
+    @staticmethod
+    def test_latest_uri_schema_uri(schema_uri: str, latest_schema_uri: str):
+        """Test that the latest tag URI is correctly computed from the schema URI"""
+        assert UriInfo(schema_uri, "asdf_resource").latest_uri == UriInfo(latest_schema_uri, "asdf_resource")
+
+    @staticmethod
+    def test_latest_uri_manifest_uri(manifest_uri: str, latest_manifest_uri: str):
+        """Test that the latest tag URI is correctly computed from the manifest URI"""
+        assert UriInfo(manifest_uri, "asdf_resource").latest_uri == UriInfo(latest_manifest_uri, "asdf_resource")
+
+    @staticmethod
+    def test_get_latest_schema_tag_uri(tag_uri: str, latest_schema_uri: str, latest_schema: Any, uri_suffix: str | None):
+        """Test that the get_latest_schema function correctly gets the latest schema for a given URI"""
+        uri_info = UriInfo(tag_uri, "asdf_tag")
+        if uri_suffix is not None:
+            uri_info = UriInfo(f"{uri_info.prefix}{uri_suffix}", "asdf_tag")
+
+        uri, schema = get_latest_schema(uri_info.uri)
+
+        assert uri == latest_schema_uri
+        assert schema == latest_schema
+
+    @staticmethod
+    def test_get_latest_schema_schema_uri(schema_uri: str, latest_schema_uri: str, latest_schema: Any, uri_suffix: str | None):
+        """Test that the get_latest_schema function correctly gets the latest schema for a given URI"""
+        uri_info = UriInfo(schema_uri, "asdf_resource")
+        if uri_suffix is not None:
+            uri_info = UriInfo(f"{uri_info.prefix}{uri_suffix}", "asdf_resource")
+
+        uri, schema = get_latest_schema(uri_info.uri)
+
+        assert uri == latest_schema_uri
+        assert schema == latest_schema
+
+    @staticmethod
+    def test_get_latest_schema_manifest_uri(
+        manifest_uri: str, latest_manifest_uri: str, latest_manifest_schema: Any, uri_suffix: str | None
+    ):
+        """Test that the get_latest_schema function correctly gets the latest schema for a given URI"""
+        uri_info = UriInfo(manifest_uri, "asdf_resource")
+        if uri_suffix is not None:
+            uri_info = UriInfo(f"{uri_info.prefix}{uri_suffix}", "asdf_resource")
+
+        uri, schema = get_latest_schema(uri_info.uri)
+
+        assert uri == latest_manifest_uri
+        assert schema == latest_manifest_schema

--- a/tests/test_dqflags.py
+++ b/tests/test_dqflags.py
@@ -45,46 +45,50 @@ def test_pixel_uniqueness():
     assert len(dqflags.pixel) == len(dqflags.pixel.__members__)
 
 
-@pytest.mark.parametrize("flag", dqflags.pixel)
-def test_pixel_flags(flag, ramp_schema):
+@pytest.fixture(scope="module", params=dqflags.pixel)
+def pixel_flag(request) -> dqflags.pixel:
+    """Fixture for providing all pixel flags for testing."""
+    return request.param
+
+
+def test_pixel_flags(pixel_flag: dqflags.pixel, ramp_schema):
     """Test that each pixel flag follows the defined rules"""
     pixel_dq_type = ramp_schema["properties"]["pixeldq"]["datatype"]
 
     # Test that the pixel flags are dqflags.pixel instances
-    assert isinstance(flag, dqflags.pixel)
+    assert isinstance(pixel_flag, dqflags.pixel)
 
     # Test that the pixel flags are of the correct dtype
-    assert flag.dtype == asdf_datatype_to_numpy_dtype(pixel_dq_type)
+    assert pixel_flag.dtype == asdf_datatype_to_numpy_dtype(pixel_dq_type)
 
     # Test that the pixel flags are ints
-    assert isinstance(flag, np.uint32)
+    assert isinstance(pixel_flag, np.uint32)
 
     # Test that the pixel flags are dict accessible
-    assert dqflags.pixel[flag.name] is flag
+    assert dqflags.pixel[pixel_flag.name] is pixel_flag
 
     # Test that the pixel flag is a power of 2
-    if flag.name == "GOOD":
+    if pixel_flag.name == "GOOD":
         # GOOD is the only non-power-of-two flag (it is 0)
-        assert flag.value == 0
+        assert pixel_flag.value == 0
     else:
-        assert _is_power_of_two(flag.value)
+        assert _is_power_of_two(pixel_flag.value)
 
 
-@pytest.mark.parametrize("flag", dqflags.pixel)
-def test_write_pixel_flags(tmp_path, flag):
+def test_write_pixel_flags(tmp_path, pixel_flag: dqflags.pixel):
     filename = tmp_path / "test_dq.asdf"
 
     ramp = rdm.RampModel.create_fake_data(shape=(2, 8, 8))
 
     # Set all pixels to the flag value
-    ramp.pixeldq[...] = flag
+    ramp.pixeldq[...] = pixel_flag
 
     # Check that we can write the model to disk (i.e. the flag validates)
     ramp.save(filename)
 
     # Check that we can read the model back in and the flag is preserved
     with rdm.open(filename) as dm:
-        assert (dm.pixeldq == flag).all()
+        assert (dm.pixeldq == pixel_flag).all()
 
 
 def test_group_uniqueness():
@@ -98,41 +102,45 @@ def test_group_uniqueness():
     assert len(dqflags.group) == len(dqflags.group.__members__)
 
 
-@pytest.mark.parametrize("flag", dqflags.group)
-def test_group_flags(flag, ramp_schema):
+@pytest.fixture(scope="module", params=dqflags.group)
+def group_flag(request) -> dqflags.group:
+    """Fixture for providing all group flags for testing."""
+    return request.param
+
+
+def test_group_flags(group_flag: dqflags.group, ramp_schema):
     """Test that each group flag follows the defined rules"""
     group_dq_type = ramp_schema["properties"]["groupdq"]["datatype"]
 
     # Test that the group flags are dqflags.group instances
-    assert isinstance(flag, dqflags.group)
+    assert isinstance(group_flag, dqflags.group)
 
     # Test that the group flags are of the correct dtype
-    assert flag.dtype == asdf_datatype_to_numpy_dtype(group_dq_type)
+    assert group_flag.dtype == asdf_datatype_to_numpy_dtype(group_dq_type)
 
     # Test that the group flags are ints
-    assert isinstance(flag, np.uint8)
+    assert isinstance(group_flag, np.uint8)
 
     # Test that the group flags are dict accessible
-    assert dqflags.group[flag.name] is flag
+    assert dqflags.group[group_flag.name] is group_flag
 
     # Test that each group flag matches a pixel flag of the same name
     # except for the WFI18_TRANSIENT flag
-    if flag.name != "WFI18_TRANSIENT":
-        assert dqflags.pixel[flag.name] == flag
+    if group_flag.name != "WFI18_TRANSIENT":
+        assert dqflags.pixel[group_flag.name] == group_flag
 
 
-@pytest.mark.parametrize("flag", dqflags.group)
-def test_write_group_flags(tmp_path, flag):
+def test_write_group_flags(tmp_path, group_flag: dqflags.group):
     filename = tmp_path / "test_dq.asdf"
 
     ramp = rdm.RampModel.create_fake_data(shape=(2, 8, 8))
 
     # Set all pixels to the flag value
-    ramp.groupdq[...] = flag
+    ramp.groupdq[...] = group_flag
 
     # Check that we can write the model to disk (i.e. the flag validates)
     ramp.save(filename)
 
     # Check that we can read the model back in and the flag is preserved
     with rdm.open(filename) as dm:
-        assert (dm.groupdq == flag).all()
+        assert (dm.groupdq == group_flag).all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,10 +22,11 @@ from roman_datamodels._stnode import (
     Resample,
     SkyBackground,
     SourceCatalog,
+    TaggedObjectNode,
     WfiImage,
     WfiWcs,
+    tagged_type,
 )
-from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
 from roman_datamodels._stnode._tagged import _NO_VALUE
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy
 
@@ -72,38 +73,39 @@ def test_datamodel_exists(name):
     assert hasattr(datamodels, name)
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_node_type_matches_model(model):
+def test_node_type_matches_model(data_model: type[datamodels.DataModel]):
     """
     Test that the _node_type listed for each model is what is listed in the schema
     """
-    node_type = model._node_type
+    node_type = data_model._node_type
     node = node_type.create_fake_data()
     schema = node.get_schema()
     name = schema["datamodel_name"]
 
-    assert model.__name__ == name
+    assert data_model.__name__ == name
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_model_schemas(model):
-    instance = model.create_fake_data()
+def test_model_schemas(data_model: type[datamodels.DataModel]):
+    instance = data_model.create_fake_data()
     asdf.schema.load_schema(instance.schema_uri)
 
 
-@pytest.mark.parametrize("node, model", datamodels.MODEL_REGISTRY.items())
 @pytest.mark.parametrize("method", ["info", "search", "schema_info"])
-def test_model_asdf_operations(node, model, method):
+def test_model_asdf_operations(
+    model_node: type[TaggedObjectNode],
+    data_model: type[datamodels.DataModel],
+    method: str,
+):
     """
     Test the decorator for asdf operations on models when an empty initial model
     which is then filled.
     """
     # Create an empty model
-    mdl = model()
-    assert isinstance(mdl._instance, node)
+    mdl = data_model()
+    assert isinstance(mdl._instance, model_node)
 
     # Fill the model with data, but no asdf file is present
-    mdl._instance = node.create_fake_data()
+    mdl._instance = model_node.create_fake_data()
     assert mdl._asdf is None
 
     # Run the method we wish to test (it should fail with warning or error
@@ -234,7 +236,7 @@ def test_node_assignment():
         datamodels.MultibandSourceCatalogModel,
     ),
 )
-def test_get_column_description(model_class):
+def test_get_column_description(model_class: type[datamodels.DataModel]):
     model = model_class.create_fake_data()
     for column in model.source_catalog.columns.values():
         column_def = model.get_column_definition(column.name)
@@ -379,7 +381,7 @@ def test_to_flat_dict(include_arrays):
 
 
 @pytest.mark.parametrize("model_class", (datamodels.ImageModel, datamodels.RampModel))
-def test_crds_parameters(model_class):
+def test_crds_parameters(model_class: type[datamodels.DataModel]):
     # CRDS uses meta.exposure.start_time to compare to USEAFTER
     model = model_class.create_fake_data()
     # patch on a value that is valid (a simple type)
@@ -406,37 +408,38 @@ def test_model_validate_without_save():
 
 
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
-@pytest.mark.parametrize("node_class", datamodels.MODEL_REGISTRY.keys())
-@pytest.mark.parametrize("correct, model", datamodels.MODEL_REGISTRY.items())
-def test_model_only_init_with_correct_node(node_class, correct, model):
+def test_model_only_init_with_correct_node(
+    other_model_node: type[TaggedObjectNode],
+    model_node: type[TaggedObjectNode],
+    data_model: type[datamodels.DataModel],
+):
     """
     Datamodels should only be initializable with the correct node in the model_registry.
     This checks that it can be initialized with the correct node, and that it cannot be
     with any other node.
     """
-    node = node_class.create_fake_data()
-    with nullcontext() if node_class is correct else pytest.raises(ValidationError):
-        model(node).validate()
+    node = other_model_node.create_fake_data()
+    with nullcontext() if other_model_node is model_node else pytest.raises(ValidationError):
+        data_model(node).validate()
 
 
 @pytest.mark.parametrize(
-    "mk_raw",
+    "model_instance",
     [
-        lambda: datamodels.ScienceRawModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.TvacModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.FpsModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.RampModel.create_fake_data(shape=(2, 8, 8)),
+        datamodels.ScienceRawModel.create_fake_data(shape=(2, 8, 8)),
+        datamodels.TvacModel.create_fake_data(shape=(2, 8, 8)),
+        datamodels.FpsModel.create_fake_data(shape=(2, 8, 8)),
+        datamodels.RampModel.create_fake_data(shape=(2, 8, 8)),
     ],
 )
-def test_ramp_from_science_raw(mk_raw):
-    raw = mk_raw()
-    ramp = datamodels.RampModel.from_science_raw(raw)
+def test_ramp_from_science_raw(model_instance: datamodels.DataModel):
+    ramp = datamodels.RampModel.from_science_raw(model_instance)
     for key in ramp:
-        if not hasattr(raw, key):
+        if not hasattr(model_instance, key):
             continue
 
         ramp_value = getattr(ramp, key)
-        raw_value = getattr(raw, key)
+        raw_value = getattr(model_instance, key)
         if isinstance(ramp_value, np.ndarray):
             assert_array_equal(ramp_value, raw_value.astype(ramp_value.dtype))
 
@@ -446,7 +449,7 @@ def test_ramp_from_science_raw(mk_raw):
             for meta_key in ramp_meta:
                 if meta_key == "model_type":
                     ramp_value[meta_key] = ramp.__class__.__name__
-                    raw_value[meta_key] = raw.__class__.__name__
+                    raw_value[meta_key] = model_instance.__class__.__name__
                     continue
                 elif meta_key == "cal_step":
                     continue
@@ -460,7 +463,7 @@ def test_ramp_from_science_raw(mk_raw):
             raise ValueError(f"Unexpected type {type(ramp_value)}, {key}")  # pragma: no cover
 
     # Check that resultantdq gets copied to groupdq
-    if hasattr(raw, "resultantdq"):
+    if hasattr(model_instance, "resultantdq"):
         assert hasattr(ramp, "groupdq")
         assert not hasattr(ramp, "resultantdq")
 
@@ -483,25 +486,24 @@ def test_science_raw_from_tvac_raw_invalid_input():
 
 
 @pytest.mark.parametrize(
-    "mk_tvac",
+    "model_instance",
     [
-        lambda: datamodels.ScienceRawModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.TvacModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.FpsModel.create_fake_data(shape=(2, 8, 8)),
+        datamodels.ScienceRawModel.create_fake_data(shape=(2, 8, 8)),
+        datamodels.TvacModel.create_fake_data(shape=(2, 8, 8)),
+        datamodels.FpsModel.create_fake_data(shape=(2, 8, 8)),
     ],
 )
-def test_science_raw_from_tvac_raw(mk_tvac):
+def test_science_raw_from_tvac_raw(model_instance: datamodels.DataModel):
     """Test conversion from expected inputs"""
-    tvac = mk_tvac()
-    tvac.meta.statistics = {"mean_counts_per_second": 1}
+    model_instance.meta.statistics = {"mean_counts_per_second": 1}
 
-    raw = datamodels.ScienceRawModel.from_tvac_raw(tvac)
+    raw = datamodels.ScienceRawModel.from_tvac_raw(model_instance)
     for key in raw:
-        if not hasattr(tvac, key):
+        if not hasattr(model_instance, key):
             continue
 
         raw_value = getattr(raw, key)
-        tvac_value = getattr(tvac, key)
+        tvac_value = getattr(model_instance, key)
         if isinstance(raw_value, np.ndarray):
             assert_array_equal(raw_value, tvac_value.astype(raw_value.dtype))
 
@@ -511,7 +513,7 @@ def test_science_raw_from_tvac_raw(mk_tvac):
             for meta_key in raw_meta:
                 if meta_key == "model_type":
                     raw_value[meta_key] = raw.__class__.__name__
-                    tvac_value[meta_key] = tvac.__class__.__name__
+                    tvac_value[meta_key] = model_instance.__class__.__name__
                     continue
                 elif meta_key == "cal_step":
                     continue
@@ -525,16 +527,15 @@ def test_science_raw_from_tvac_raw(mk_tvac):
             raise ValueError(f"Unexpected type {type(raw_value)}, {key}")  # pragma: no cover
 
     # If tvac/fps, check that statistics are handled properly
-    if isinstance(tvac, datamodels.TvacModel | datamodels.FpsModel):
+    if isinstance(model_instance, datamodels.TvacModel | datamodels.FpsModel):
         assert hasattr(raw, "extras")
         assert hasattr(raw.extras, "tvac")
         assert hasattr(raw.extras.tvac, "meta")
         assert hasattr(raw.extras.tvac.meta, "statistics")
-        assert raw.extras.tvac.meta.statistics == tvac.meta.statistics
+        assert raw.extras.tvac.meta.statistics == model_instance.meta.statistics
 
 
-@pytest.mark.parametrize("model_class", datamodels.MODEL_REGISTRY.values())
-def test_datamodel_construct_like_from_like(model_class):
+def test_datamodel_construct_like_from_like(data_model: type[datamodels.DataModel]):
     """
     This is a regression test for the issue reported issue #51.
 
@@ -547,13 +548,13 @@ def test_datamodel_construct_like_from_like(model_class):
     """
 
     # Create a model
-    model = model_class.create_fake_data()
+    model = data_model.create_fake_data()
 
     # Modify _iscopy as it will be reset to False by initializer if called incorrectly
     model._iscopy = "foo"
 
     # Pass model instance to model constructor
-    new_model = model_class(model)
+    new_model = data_model(model)
     assert new_model is model
     assert new_model._iscopy == "foo"  # Verify that the constructor didn't override stuff
 
@@ -606,7 +607,7 @@ def test_datamodel_save_file_date(tmp_path, monkeypatch):
         (datamodels.MosaicModel, False),
     ],
 )
-def test_rampmodel_from_science_raw(model_class, expect_success):
+def test_rampmodel_from_science_raw(model_class: type[datamodels.DataModel], expect_success: bool):
     """Test creation of RampModel from raw science/tvac"""
     model = model_class.create_fake_data(
         defaults={"meta": {"calibration_software_version": "1.2.3", "exposure": {"read_pattern": [[1], [2], [3]]}}}
@@ -625,7 +626,7 @@ def test_rampmodel_from_science_raw(model_class, expect_success):
     "model_class",
     [datamodels.FpsModel, datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel, datamodels.MosaicModel],
 )
-def test_model_assignment_access_types(model_class):
+def test_model_assignment_access_types(model_class: type[datamodels.DataModel]):
     """Test assignment and access of model keyword value via keys and dot notation"""
     # Test creation
     model = model_class.create_fake_data(
@@ -782,46 +783,41 @@ def test_deepcopy_after_use():
     deepcopy(m.meta)
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_minimal(model):
+def test_create_minimal(data_model: type[datamodels.DataModel]):
     """Test that create_minimal produces a model instance"""
-    m = model.create_minimal()
-    assert isinstance(m, model)
+    m = data_model.create_minimal()
+    assert isinstance(m, data_model)
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_fake_data(model):
+def test_create_fake_data(data_model: type[datamodels.DataModel]):
     """Test that create_fake_data produces a valid model instance"""
-    m = model.create_fake_data()
-    assert isinstance(m, model)
+    m = data_model.create_fake_data()
+    assert isinstance(m, data_model)
     assert m.validate() is None
 
 
-@pytest.mark.parametrize("tag, node_class", NODE_CLASSES_BY_TAG.items())
-def test_create_tag(tag, node_class):
+def test_create_tag(tag_uri: str, node_class: tagged_type):
     """Test that we can create a node for every registered tag"""
 
-    node = node_class.create_minimal(tag=tag)
+    node = node_class.create_minimal(tag=tag_uri)
     if node is not _NO_VALUE:
-        assert node._read_tag == tag
+        assert node._read_tag == tag_uri
 
-    node = node_class.create_fake_data(tag=tag)
+    node = node_class.create_fake_data(tag=tag_uri)
     if node is not _NO_VALUE:
-        assert node._read_tag == tag
+        assert node._read_tag == tag_uri
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_no_hidden(model):
+def test_no_hidden(data_model: type[datamodels.DataModel]):
     """Test that no hidden attributes are allowed"""
-    m = model.create_minimal()
+    m = data_model.create_minimal()
     with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
         m._foo = "bar"  # Add a hidden attribute
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_delattr(model):
+def test_delattr(data_model: type[datamodels.DataModel]):
     """Test that delattr works as expected"""
-    m = model.create_minimal()
+    m = data_model.create_minimal()
 
     m.foo = "bar"
     assert hasattr(m, "foo")
@@ -830,24 +826,22 @@ def test_delattr(model):
     assert not hasattr(m, "foo")
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_slotted(model):
+def test_slotted(data_model: type[datamodels.DataModel]):
     """Test that the model is slotted as expected"""
-    m = model.create_minimal()
+    m = data_model.create_minimal()
 
     with pytest.raises(AttributeError, match=r"No attribute .*"):
         # slotted object instances do not have a __dict__
         m.__dict__  # noqa: B018
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_minimal_copies(model, tmp_path):
+def test_create_minimal_copies(data_model: type[datamodels.DataModel], tmp_path):
     """Test that create_minimal does not retain references to input"""
     fn = tmp_path / "test.asdf"
-    fake = model.create_fake_data()
+    fake = data_model.create_fake_data()
     fake.save(fn)
     with datamodels.open(fn) as opened_model:
-        new_model = model.create_minimal(opened_model)
+        new_model = data_model.create_minimal(opened_model)
     del opened_model
     gc.collect(2)
     assert new_model.validate() is None

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -10,7 +10,7 @@ from astropy.io import fits
 from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels
-from roman_datamodels._stnode import WfiImage
+from roman_datamodels._stnode import TaggedObjectNode, WfiImage, tagged_type
 from roman_datamodels.datamodels._utils import _patch_meta_filename
 from roman_datamodels.testing import assert_node_equal
 
@@ -194,30 +194,29 @@ def test_no_memmap(tmp_path, kwargs):
         assert (model.data == data).all()
 
 
-@pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
-def test_node_round_trip(tmp_path, node_class):
+def test_node_round_trip(tmp_path, tag_uri: str, node_class: tagged_type):
     file_path = tmp_path / "test.asdf"
 
     # Create/return a node and write it to disk, then check if the node round trips
-    node = node_class.create_fake_data()
+    node = node_class.create_fake_data(tag=tag_uri)
     asdf.AsdfFile({"roman": node}).write_to(file_path)
     with asdf.open(file_path) as af:
         assert_node_equal(af.tree["roman"], node)
+        assert af.tree["roman"]._read_tag == tag_uri
 
 
-@pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
-def test_opening_model(tmp_path, node_class):
+def test_opening_model(tmp_path, model_node: type[TaggedObjectNode]):
     file_path = tmp_path / "test.asdf"
 
     # Create a node and write it to disk
-    node = node_class.create_fake_data()
+    node = model_node.create_fake_data()
     if hasattr(node, "meta") and hasattr(node.meta, "filename"):
         node.meta.filename = type(node.meta.filename)(file_path.name)
     asdf.AsdfFile({"roman": node}).write_to(file_path)
 
     with datamodels.open(file_path) as model:
         # Check that the model is the correct type
-        assert isinstance(model, datamodels.MODEL_REGISTRY[node_class])
+        assert isinstance(model, datamodels.MODEL_REGISTRY[model_node])
 
 
 def test_read_pattern_properties():
@@ -261,16 +260,16 @@ def test_open_asn(tmp_path):
     assert isinstance(lib, romancal.datamodels.ModelLibrary)
 
 
-@pytest.mark.parametrize(
-    "model",
-    [mdl for mdl in datamodels.MODEL_REGISTRY.keys() if ("Ref" not in mdl.__name__ and "Associations" not in mdl.__name__)],
-)
-def test_filename_matches_meta(tmp_path, model):
+def test_filename_matches_meta(tmp_path, model_node: type[TaggedObjectNode]):
+    # These models do not have meta.filename
+    if "Ref" in model_node.__name__ or "Associations" in model_node.__name__:
+        return
+
     save_path = tmp_path / "test_filename.asdf"
     open_path = tmp_path / "test_filename_read.asdf"
 
     # Create a node and write it to disk
-    gen_model = model.create_fake_data()
+    gen_model = model_node.create_fake_data()
     asdf.AsdfFile({"roman": gen_model}).write_to(save_path)
 
     # Save the filename type

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -12,7 +12,7 @@ from .conftest import MANIFESTS
 
 @pytest.mark.parametrize("tag_def", [tag_def for manifest in MANIFESTS for tag_def in manifest["tags"]])
 def test_tag_has_node_class(tag_def):
-    class_name = stnode._factories.class_name_from_tag_uri(tag_def["tag_uri"])
+    class_name = stnode.UriInfo(tag_def["tag_uri"]).camel_case
     node_class = getattr(stnode, class_name)
 
     assert asdf.util.uri_match(node_class._pattern, tag_def["tag_uri"])
@@ -194,20 +194,6 @@ def test_node_representation():
             "optical_element": mdl.meta.instrument.optical_element,
         }
     )
-
-
-def test_get_latest_schema(
-    object_node_class: type[stnode.TaggedObjectNode],
-    object_node_default_schema_uri: str,
-    object_node_schema_uris: tuple[str, ...],
-):
-    assert len(object_node_schema_uris) > 0, "This test requires at lest one URI available."
-
-    for uri in [object_node_default_schema_uri.rsplit("-", 1)[0], *object_node_schema_uris]:
-        latest_uri, schema = stnode.get_latest_schema(uri)
-        assert latest_uri == object_node_default_schema_uri
-
-        assert stnode._schema._get_schema_from_tag(object_node_class._default_tag) == schema
 
 
 @pytest.mark.parametrize(

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -25,15 +25,13 @@ def test_tag_has_node_class(tag_def):
         assert asdf.versioning.Version(default_tag_version) > asdf.versioning.Version(tag_def_version)
 
 
-@pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
-def test_node_classes_available_via_stnode(node_class):
+def test_node_classes_available_via_stnode(node_class: stnode.tagged_type):
     assert issubclass(node_class, stnode.TaggedObjectNode | stnode.TaggedListNode | stnode.TaggedScalarNode)
     assert node_class.__module__ == stnode.__name__
     assert hasattr(stnode, node_class.__name__)
 
 
-@pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
-def test_copy(node_class):
+def test_copy(node_class: stnode.tagged_type):
     """Demonstrate nodes can copy themselves, but don't always deepcopy."""
     node = node_class.create_fake_data()
     node_copy = node.copy()
@@ -48,9 +46,8 @@ def test_copy(node_class):
         assert_node_is_copy(node, node_copy, deepcopy=True)
 
 
-@pytest.mark.parametrize("model_class", datamodels.MODEL_REGISTRY.values())
-def test_deepcopy_model(model_class):
-    model = model_class.create_fake_data(shape=(8, 8, 8))
+def test_deepcopy_model(data_model: type[datamodels.DataModel]):
+    model = data_model.create_fake_data(shape=(8, 8, 8))
     model_copy = model.copy()
 
     # There is no assert equal for models, but the data inside is what we care about.
@@ -86,8 +83,7 @@ def test_wfi_mode():
     assert isinstance(node, stnode._mixins.WfiModeMixin)
 
 
-@pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
-def test_serialization(node_class, tmp_path):
+def test_serialization(node_class: stnode.tagged_type, tmp_path):
     file_path = tmp_path / "test.asdf"
 
     node = node_class.create_fake_data()
@@ -99,17 +95,15 @@ def test_serialization(node_class, tmp_path):
         assert_node_equal(af["node"], node)
 
 
-@pytest.mark.parametrize("node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedObjectNode)])
-def test_no_hidden(node_class):
-    node = node_class.create_fake_data()
+def test_no_hidden(object_node_class: type[stnode.TaggedObjectNode]):
+    node = object_node_class.create_fake_data()
     with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
         node._foo = "bar"  # Add a hidden attribute
 
 
-@pytest.mark.parametrize("node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedListNode)])
-def test_list_node_no_new_attributes(node_class):
+def test_list_node_no_new_attributes(list_node_class):
     """Test that no new attributes can be added to a list node."""
-    node = node_class.create_fake_data()
+    node = list_node_class.create_fake_data()
     with pytest.raises(AttributeError, match=r"Cannot set attribute .*, only allowed are .*"):
         node.foo = "bar"
 
@@ -117,14 +111,11 @@ def test_list_node_no_new_attributes(node_class):
         node._foo = "bar"
 
 
-@pytest.mark.parametrize(
-    "node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedObjectNode | stnode.TaggedListNode)]
-)
-def test_slotted(node_class):
+def test_slotted(container_node_class: type[stnode.TaggedObjectNode] | type[stnode.TaggedListNode]):
     """
     Test that slotted nodes do not allow new attributes to be added.
     """
-    node = node_class.create_fake_data()
+    node = container_node_class.create_fake_data()
     with pytest.raises(AttributeError, match=r".* attribute .*__dict__.*"):
         # Attempt to access __dict__ directly, slotted classes do not have __dict__
         node.__dict__  # noqa: B018
@@ -205,14 +196,18 @@ def test_node_representation():
     )
 
 
-def test_get_latest_schema(object_node, object_node_default_uri, object_node_uris):
-    assert len(object_node_uris) > 0, "This test requires at lest one URI available."
+def test_get_latest_schema(
+    object_node_class: type[stnode.TaggedObjectNode],
+    object_node_default_schema_uri: str,
+    object_node_schema_uris: tuple[str, ...],
+):
+    assert len(object_node_schema_uris) > 0, "This test requires at lest one URI available."
 
-    for uri in [object_node_default_uri.rsplit("-", 1)[0], *object_node_uris]:
+    for uri in [object_node_default_schema_uri.rsplit("-", 1)[0], *object_node_schema_uris]:
         latest_uri, schema = stnode.get_latest_schema(uri)
-        assert latest_uri == object_node_default_uri
+        assert latest_uri == object_node_default_schema_uri
 
-        assert stnode._schema._get_schema_from_tag(object_node._default_tag) == schema
+        assert stnode._schema._get_schema_from_tag(object_node_class._default_tag) == schema
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR refactors the way stnode handle's the different types of URIs and places this all in the same place, and adds additional features for users to work with URIs if they wish to. This refactor moves all logic into querying ASDF directly.

Additionally, this

- Updates the tests to use fixtures instead of individual parameterizations 
- Updates the _stnode._stnode in a way that ensures that the manifests are always processed in reverse order AND removes the implicit dependency of RDM on `pyyaml` (which it gets via ASDF). 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
