### PR TITLE
add upper pin to rad (to `release/0.30.x` branch)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,10 +15,7 @@ import importlib
 import os
 import sys
 import tomllib
-from distutils.version import LooseVersion
 from pathlib import Path
-
-import sphinx
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -35,16 +32,6 @@ setup_cfg = conf["project"]
 # needs_sphinx = '1.3'
 
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-
-
-def check_sphinx_version(expected_version):
-    sphinx_version = LooseVersion(sphinx.__version__)
-    expected_version = LooseVersion(expected_version)
-    if sphinx_version < expected_version:
-        raise RuntimeError(
-            f"At least Sphinx version {expected_version} is required to build this documentation.  Found {sphinx_version}."
-        )
-
 
 # Configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
@@ -81,10 +68,7 @@ extensions = [
 if on_rtd:
     extensions.append("sphinx.ext.mathjax")
 
-elif LooseVersion(sphinx.__version__) < LooseVersion("1.4"):
-    extensions.append("sphinx.ext.pngmath")
-else:
-    extensions.append("sphinx.ext.imgmath")
+extensions.append("sphinx.ext.imgmath")
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "gwcs >=0.19.0",
   "numpy >=1.25",
   "astropy >=6.0.0",
-  "rad >=0.30.0",
+  "rad >=0.30.0, <0.31.0",
   # "rad @ git+https://github.com/spacetelescope/rad.git",
   "asdf-standard >=1.1.0",
   "pyarrow >= 10.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "asdf >=4.1.0",
   "lz4 >= 4.3.0",
   "asdf-astropy >=0.8.0",
-  "gwcs >=0.19.0",
+  "gwcs >=0.20.0",
   "numpy >=1.25",
   "astropy >=6.0.0",
   "rad >=0.30.0, <0.31.0",
@@ -26,7 +26,7 @@ license-files = ["LICENSE"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest >=9.0.0", "pytest-doctestplus >=1.2.1", "pandas >=2.2.3"]
+test = ["pytest >=9.0.0", "pytest-doctestplus >=1.3.0", "pandas >=2.2.3"]
 docs = ["sphinx", "sphinx-automodapi", "sphinx-rtd-theme", "sphinx-astropy"]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -46,11 +46,11 @@ commands_pre =
     oldestdeps: minimum_dependencies roman_datamodels --filename {env_tmp_dir}/requirements-min.txt
     oldestdeps: uv pip install -r {env_tmp_dir}/requirements-min.txt
     {list_dependencies_command}
-    romancal: git clone -n --depth=1 --filter=blob:none {[main]romancal_repo} {env_tmp_dir}/romancal/
-    romancal: git --git-dir={env_tmp_dir}/romancal/.git/ checkout HEAD {env_tmp_dir}/romancal/pyproject.toml
+    romancal: git clone -n --depth=1 --filter=blob:none {[main]romancal_repo}
+    romancal: git --git-dir={envtmpdir}/romancal/.git checkout HEAD pyproject.toml
 commands =
     pytest \
-    romancal: --config-file={env_tmp_dir}/romancal/pyproject.toml \
+    romancal: --config-file={env_tmp_dir}/pyproject.toml --pyargs romancal \
     xdist: -n auto \
     cov: --cov=roman_datamodels --cov=tests --cov-config pyproject.toml --cov-report term-missing --cov-report xml \
     {posargs}


### PR DESCRIPTION
roman_datamodels 0.30.0 does not have an upper pin for rad and the release of rad 0.31.0 causes issues for downstream roman_datamodels usage (which expects roman_datamodels will manage the rad dependency).

With a fresh environment and install of romancal 0.22.0 the following are installed:
- roman_datamodels 0.30.0
- rad 0.31.0 (this should be 0.30.0)

This causes the mosaic pipeline to fail due to inconsistent type expectations for `pixmap_stepsize` and multiband catalog step failures for requirements on `psf_match_reference_filter`
(see https://github.com/spacetelescope/romancal/issues/2290#issuecomment-4372535048 for more details)

This adds an upper pin for rad to fix the above issues and will require a patch release.

The 0.30.x branch doesn't have backports of:
- https://github.com/spacetelescope/roman_datamodels/pull/654
- https://github.com/spacetelescope/roman_datamodels/pull/636

so the oldestdeps and docs are failing.

The rcal tests won't start due to missing a backport for https://github.com/spacetelescope/roman_datamodels/pull/636

I pulled in the relevant changes to allows the docs to build and CI to run.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
