### PR TITLE
Remove `_latest_manifest` and `_default_tag` ClassVar from stnode

### DIFF
--- a/changes/669.feature.rst
+++ b/changes/669.feature.rst
@@ -1,0 +1,2 @@
+Remove the ``_default_tag`` and ``_latest_manifest`` ClassVars from the TaggedNode classes. These
+have been replaced with dynamic (cached) lookups to the ASDF configuration itself.

--- a/changes/671.feature.rst
+++ b/changes/671.feature.rst
@@ -1,0 +1,3 @@
+Add simple tag migration function to the ``DataModel`` class. This is a dumb
+function that just makes a new model from the old with a new tag. It does not
+attempt to migrate any of the data, so routines in ``romancal`` maybe needed.

--- a/src/roman_datamodels/_stnode/_factories.py
+++ b/src/roman_datamodels/_stnode/_factories.py
@@ -88,7 +88,6 @@ def scalar_factory(pattern: str, tag_def: dict[str, Any]) -> type[TaggedScalarNo
         class_type,
         {
             "_pattern": pattern,
-            "_default_tag": tag_def["tag_uri"],
             "__module__": "roman_datamodels._stnode",
             "__doc__": docstring_from_tag(tag_def),
         },
@@ -129,7 +128,6 @@ def node_factory(pattern: str, tag_def: dict[str, Any]) -> type[TaggedObjectNode
         class_type,
         {
             "_pattern": pattern,
-            "_default_tag": tag_def["tag_uri"],
             "__module__": "roman_datamodels._stnode",
             "__doc__": docstring_from_tag(tag_def),
             "__slots__": (),

--- a/src/roman_datamodels/_stnode/_factories.py
+++ b/src/roman_datamodels/_stnode/_factories.py
@@ -48,7 +48,7 @@ def docstring_from_tag(tag_def: dict[str, Any]) -> str:
     return docstring + f"Class generated from tag '{tag_def['tag_uri']}'"
 
 
-def scalar_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedScalarNode]:
+def scalar_factory(pattern: str, tag_def: dict[str, Any]) -> type[TaggedScalarNode]:
     """
     Factory to create a TaggedScalarNode class from a tag
 
@@ -56,9 +56,6 @@ def scalar_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) 
     ----------
     pattern: str
         A tag pattern/wildcard
-
-    latest_manifest: str
-        URI for the latest manifest
 
     tag_def: dict
         A tag entry from the RAD manifest
@@ -91,7 +88,6 @@ def scalar_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) 
         class_type,
         {
             "_pattern": pattern,
-            "_latest_manifest": latest_manifest,
             "_default_tag": tag_def["tag_uri"],
             "__module__": "roman_datamodels._stnode",
             "__doc__": docstring_from_tag(tag_def),
@@ -99,7 +95,7 @@ def scalar_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) 
     )
 
 
-def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) -> type[TaggedObjectNode | TaggedListNode]:
+def node_factory(pattern: str, tag_def: dict[str, Any]) -> type[TaggedObjectNode | TaggedListNode]:
     """
     Factory to create a TaggedObjectNode or TaggedListNode class from a tag
 
@@ -107,9 +103,6 @@ def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) ->
     ----------
     pattern: str
         A tag pattern/wildcard
-
-    latest_manifest: str
-        URI for the latest manifest
 
     tag_def: dict
         A tag entry from the RAD manifest
@@ -136,7 +129,6 @@ def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) ->
         class_type,
         {
             "_pattern": pattern,
-            "_latest_manifest": latest_manifest,
             "_default_tag": tag_def["tag_uri"],
             "__module__": "roman_datamodels._stnode",
             "__doc__": docstring_from_tag(tag_def),
@@ -145,9 +137,7 @@ def node_factory(pattern: str, latest_manifest: str, tag_def: dict[str, Any]) ->
     )
 
 
-def stnode_factory(
-    pattern: str, latest_manifest: str, tag_def: dict[str, Any]
-) -> type[TaggedObjectNode | TaggedListNode | TaggedScalarNode]:
+def stnode_factory(pattern: str, tag_def: dict[str, Any]) -> type[TaggedObjectNode | TaggedListNode | TaggedScalarNode]:
     """
     Construct a tagged STNode class from a tag
 
@@ -155,9 +145,6 @@ def stnode_factory(
     ----------
     pattern: str
         A tag pattern/wildcard
-
-    latest_manifest: str
-        URI for the latest manifest
 
     tag_def: dict
         A tag entry from the RAD manifest
@@ -169,6 +156,6 @@ def stnode_factory(
     # TaggedScalarNodes are a special case because they are not a subclass of a
     #   _node class, but rather a subclass of the type of the scalar.
     if "tagged_scalar" in tag_def["schema_uri"]:
-        return scalar_factory(pattern, latest_manifest, tag_def)
+        return scalar_factory(pattern, tag_def)
     else:
-        return node_factory(pattern, latest_manifest, tag_def)
+        return node_factory(pattern, tag_def)

--- a/src/roman_datamodels/_stnode/_mixins.py
+++ b/src/roman_datamodels/_stnode/_mixins.py
@@ -173,7 +173,7 @@ class RefFileMixin(_ObjectBase):
             defaults = deepcopy(defaults)
         else:
             defaults = {}
-        schema = _get_schema_from_tag(tag or cls._default_tag)
+        schema = _get_schema_from_tag(tag or cls.default_tag())
         for k, v in schema["properties"].items():
             if v["type"] != "string":
                 continue
@@ -196,7 +196,7 @@ class L2CalStepMixin(_ObjectBase):
     @classmethod
     def _create_minimal(cls, defaults=None, builder=None, *, tag=None):
         defaults = defaults or {}
-        schema = _get_schema_from_tag(tag or cls._default_tag)
+        schema = _get_schema_from_tag(tag or cls.default_tag())
         new = cls({k: defaults.get(k, "INCOMPLETE") for k in schema["properties"]})
         if tag:
             new._read_tag = tag
@@ -256,7 +256,7 @@ class ImageSourceCatalogMixin(_ObjectBase):
         aperture_radii = aperture_radii or ["00"]
         filters = filters or ["f184"]
 
-        columns_schema = dict(_get_properties(_get_schema_from_tag(tag or cls._default_tag)["properties"]["source_catalog"]))
+        columns_schema = dict(_get_properties(_get_schema_from_tag(tag or cls.default_tag())["properties"]["source_catalog"]))
         columns = []
 
         if "columns" in columns_schema:

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -51,12 +51,12 @@ def _add_cls(cls):
     return cls
 
 
-def _factory(pattern, latest_manifest, tag_def):
+def _factory(pattern, tag_def):
     """
     Wrap the __all__ append and class creation in a function to avoid the linter
         getting upset
     """
-    return _add_cls(stnode_factory(pattern, latest_manifest, tag_def))
+    return _add_cls(stnode_factory(pattern, tag_def))
 
 
 # Main dynamic class creation loop
@@ -73,7 +73,7 @@ for manifest in _MANIFESTS:
         # make pattern from tag
         pattern = f"{base}-*"
         if pattern not in _generated:
-            _generated[pattern] = _factory(pattern, manifest_uri, tag_def)
+            _generated[pattern] = _factory(pattern, tag_def)
         NODE_CLASSES_BY_TAG[tag_uri] = _generated[pattern]
 
         # Make serialization intermediate

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -17,6 +17,7 @@ from ._registry import (
     SERIALIZATION_BY_MANIFEST,
 )
 from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, _get_schema_from_tag
+from ._uri import get_default_tag
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping
@@ -83,14 +84,21 @@ class _TaggedNodeMixin(NodeMixin):
 
     _pattern: ClassVar[str]
 
-    _default_tag: ClassVar[str]
+    @classmethod
+    def default_tag(cls) -> str:
+        """Get the default tag for this class"""
+
+        if (tag := get_default_tag(cls._pattern)) is None:
+            raise RuntimeError(f"No default tag found for pattern '{cls._pattern}'")
+
+        return tag
 
     @classmethod
     def _create_minimal(
         cls, defaults: Mapping[str, Any] | None = None, builder: Builder | None = None, *, tag: str | None = None
     ) -> Self:
         builder = builder or Builder()
-        new = cls(builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults))
+        new = cls(builder.build(_get_schema_from_tag(tag or cls.default_tag()), defaults))
 
         if tag:
             new._read_tag = tag
@@ -178,7 +186,7 @@ class _TaggedNodeMixin(NodeMixin):
     @property
     def _tag(self):
         if self._read_tag is None:
-            return self._default_tag
+            return self.default_tag()
 
         return self._read_tag
 
@@ -257,7 +265,7 @@ class TaggedScalarNode(_TaggedNodeMixin):
     @classmethod
     def _create_minimal(cls, defaults=None, builder=None, *, tag: str | None = None):
         builder = builder or Builder()
-        value = builder.build(_get_schema_from_tag(tag or cls._default_tag), defaults)
+        value = builder.build(_get_schema_from_tag(tag or cls.default_tag()), defaults)
         if value is _NO_VALUE:
             return value
 
@@ -270,7 +278,7 @@ class TaggedScalarNode(_TaggedNodeMixin):
     @property
     def _tag(self):
         # _tag is required by asdf to allow __asdf_traverse__
-        return getattr(self, "_read_tag", self._default_tag)
+        return getattr(self, "_read_tag", self.default_tag())
 
     def copy(self):
         return copy.copy(self)

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -82,7 +82,6 @@ class _TaggedNodeMixin(NodeMixin):
     __slots__ = ()
 
     _pattern: ClassVar[str]
-    _latest_manifest: ClassVar[str]
 
     _default_tag: ClassVar[str]
 

--- a/src/roman_datamodels/_stnode/_uri.py
+++ b/src/roman_datamodels/_stnode/_uri.py
@@ -1,0 +1,55 @@
+from functools import cache
+
+from asdf import AsdfFile
+from asdf.extension import Extension, ExtensionManager, TagDefinition
+from asdf.util import uri_match
+from semantic_version import Version
+
+__all__ = ("get_default_tag", "get_version")
+
+
+def get_version(asdf_uri: str) -> Version:
+    """Get the version of the of the schema from the ASDF URI"""
+    # Pluck the version out of the URI if it has one, otherwise we assume it is
+    #    0.0.0
+    version = asdf_uri.rsplit("-", maxsplit=1)[-1] if "-" in asdf_uri else "0.0.0"
+
+    # Fix the issue with the first datamodel manifest being 1.0 instead of 1.0.0
+    #     which causes issues with semantic_version
+    if version == "1.0":
+        version = "1.0.0"
+
+    return Version(version)
+
+
+@cache
+def get_default_tag(pattern: str) -> str | None:
+    """
+    Get the default tag for a given pattern. This is the tag with the latest version.
+
+    Parameters
+    ----------
+    pattern: str
+        A tag pattern/wildcard
+
+    Returns
+    -------
+    The default tag URI for the given pattern
+    """
+    default_tag: str | None = None
+    default_version = Version("0.0.0")
+
+    extension: Extension
+    tag_def: TagDefinition
+    with AsdfFile() as af:
+        manager: ExtensionManager = af.extension_manager
+
+        for extension in manager.extensions:
+            for tag_def in extension.tags:
+                if uri_match(pattern, tag_def.tag_uri):
+                    version = get_version(tag_def.tag_uri)
+                    if version > default_version:
+                        default_version = version
+                        default_tag = tag_def.tag_uri
+
+    return default_tag

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -24,7 +24,8 @@ from asdf.exceptions import ValidationError
 from asdf.tags.core.ndarray import NDArrayType
 from astropy.time import Time
 
-from roman_datamodels._stnode import NODE_EXTENSIONS, DNode, TaggedObjectNode
+from roman_datamodels._stnode import DNode, TaggedObjectNode
+from roman_datamodels._stnode._registry import SCHEMA_URIS_BY_TAG
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -262,13 +263,8 @@ class DataModel(abc.ABC):
         return MODEL_REGISTRY[asdf_file.tree["roman"].__class__] == self.__class__
 
     @property
-    def _latest_manifest_uri(self):
-        return self._node_type._latest_manifest
-
-    @property
     def schema_uri(self):
-        # Determine the schema corresponding to this model's tag
-        return next(t for t in NODE_EXTENSIONS[self._latest_manifest_uri].tags if t.tag_uri == self._instance._tag).schema_uris[0]
+        return SCHEMA_URIS_BY_TAG[self._instance.tag]
 
     def close(self):
         if not (self._iscopy or self._asdf is None):

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -201,7 +201,7 @@ class DataModel(abc.ABC):
             A new version of this model with the tag updated.
         """
         # If no tag is provided, then update to the default tag.
-        tag = tag or self._node_type._default_tag
+        tag = tag or self._node_type.default_tag()
 
         if self.tag == tag:
             return self

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -163,7 +163,7 @@ class DataModel(abc.ABC):
     __slots__ = ("_asdf", "_files_to_close", "_instance", "_iscopy", "_shape")
 
     @classmethod
-    def create_from_model(cls, model: DataModel | DNode) -> Self:
+    def create_from_model(cls, model: DataModel | DNode, *, tag: str | None = None) -> Self:
         """
         Create a new DataModel from an existing model.
         """
@@ -171,7 +171,41 @@ class DataModel(abc.ABC):
             node = model._instance
         else:
             node = model
-        return cls(cls._node_type.create_from_node(node))
+        return cls(cls._node_type.create_from_node(node, tag=tag))
+
+    def migrate_tag(self, tag: str | None = None) -> Self:
+        """
+        Return a new version of this model with the tag updated.
+
+        .. note::
+
+            This may not fully update your model to the new tag, it only moves
+            the information into the new tree. So it maybe missing information
+            or have information of the wrong type. If you want a more complete
+            migration to the new tag, use
+
+                ``romancal.datamodels.migration.update_model_version``
+
+            instead. This function begins with the result of this function and
+            then apply migration steps that require the full pipeline to determine.
+
+        Parameters
+        ----------
+        tag: str or None
+            If provided, specifically update to this tag not the default (latest) one.
+
+        Returns
+        -------
+        DataModel
+            A new version of this model with the tag updated.
+        """
+        # If no tag is provided, then update to the default tag.
+        tag = tag or self._node_type._default_tag
+
+        if self.tag == tag:
+            return self
+
+        return type(self).create_from_model(self, tag=tag)
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, self.__class__):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def object_node(request):
 
 @pytest.fixture(scope="session")
 def object_node_default_uri(object_node):
-    return SCHEMA_URIS_BY_TAG[object_node._default_tag]
+    return SCHEMA_URIS_BY_TAG[object_node.default_tag()]
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,7 +26,7 @@ from roman_datamodels._stnode import (
     WfiWcs,
 )
 from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
-from roman_datamodels._stnode._tagged import _NO_VALUE
+from roman_datamodels._stnode._tagged import _NO_VALUE, TaggedObjectNode
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy
 
 from .conftest import MANIFESTS
@@ -795,6 +795,35 @@ def test_create_fake_data(model):
     m = model.create_fake_data()
     assert isinstance(m, model)
     assert m.validate() is None
+
+
+@pytest.mark.parametrize("node_class, model", datamodels.MODEL_REGISTRY.items())
+def test_migrate_tag(node_class: type[TaggedObjectNode], model: type[datamodels.DataModel]):
+    """Test that we can migrate the tag to a new version"""
+
+    # Find all the tags that are mapped to the datamodel's node class
+    model_tags = set(tag_uri for tag_uri, node in NODE_CLASSES_BY_TAG.items() if node is node_class)
+
+    for current_tag in model_tags:
+        # Create a model with the current tag
+        current = model.create_fake_data(tag=current_tag)
+        assert current.tag == current_tag
+
+        for new_tag in model_tags:
+            new = current.migrate_tag(new_tag)
+
+            # The tag has been updated
+            assert new.tag == new_tag
+
+            # The tags match then we should get the same object back
+            if new_tag == current_tag:
+                assert new is current
+            else:
+                assert new is not current
+
+        # Check the default is to migrage to the default tag
+        new = current.migrate_tag()
+        assert new.tag == node_class._default_tag
 
 
 @pytest.mark.parametrize("tag, node_class", NODE_CLASSES_BY_TAG.items())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -823,7 +823,7 @@ def test_migrate_tag(node_class: type[TaggedObjectNode], model: type[datamodels.
 
         # Check the default is to migrage to the default tag
         new = current.migrate_tag()
-        assert new.tag == node_class._default_tag
+        assert new.tag == node_class.default_tag()
 
 
 @pytest.mark.parametrize("tag, node_class", NODE_CLASSES_BY_TAG.items())
@@ -949,8 +949,8 @@ def test_create_from_model_old_tags():
     """
     old_model_tag = "asdf://stsci.edu/datamodels/roman/tags/wfi_image-1.2.0"
     old_observation_tag = "asdf://stsci.edu/datamodels/roman/tags/observation-1.0.0"
-    new_model_tag = WfiImage._default_tag
-    new_observation_tag = Observation._default_tag
+    new_model_tag = WfiImage.default_tag()
+    new_observation_tag = Observation.default_tag()
 
     # check tags aren't defaults (which is required for this test)
     assert old_model_tag != new_model_tag

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -16,11 +16,11 @@ def test_tag_has_node_class(tag_def):
     node_class = getattr(stnode, class_name)
 
     assert asdf.util.uri_match(node_class._pattern, tag_def["tag_uri"])
-    if node_class._default_tag == tag_def["tag_uri"]:
+    if node_class.default_tag() == tag_def["tag_uri"]:
         assert tag_def["description"] in node_class.__doc__
         assert tag_def["tag_uri"] in node_class.__doc__
     else:
-        default_tag_version = node_class._default_tag.rsplit("-", maxsplit=1)[1]
+        default_tag_version = node_class.default_tag().rsplit("-", maxsplit=1)[1]
         tag_def_version = tag_def["tag_uri"].rsplit("-", maxsplit=1)[1]
         assert asdf.versioning.Version(default_tag_version) > asdf.versioning.Version(tag_def_version)
 
@@ -212,7 +212,7 @@ def test_get_latest_schema(object_node, object_node_default_uri, object_node_uri
         latest_uri, schema = stnode.get_latest_schema(uri)
         assert latest_uri == object_node_default_uri
 
-        assert stnode._schema._get_schema_from_tag(object_node._default_tag) == schema
+        assert stnode._schema._get_schema_from_tag(object_node.default_tag()) == schema
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR removes the `_latest_manifest` and `_default_tag` class variables from stnode and replaces them with lookups based on the `_pattern` class variable. This is part of an effort to reduce the object complexity in stnode.

Note that this PR depends on #671

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
