### PR TITLE
Housekeeping Test clean ups

### DIFF
--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 OBJECT_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedObjectNode]] = {}
 LIST_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedListNode]] = {}
 SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
+NODES_BY_PATTERN: dict[str, tagged_type] = {}
 NODE_CONVERTERS: dict[str, type[_RomanConverter]] = {}
 NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
 SCHEMA_URIS_BY_TAG: dict[str, str] = {}

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -20,6 +20,7 @@ from ._registry import (
     MANIFEST_TAG_REGISTRY,
     NODE_CLASSES_BY_TAG,
     NODE_CONVERTERS,
+    NODES_BY_PATTERN,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SCHEMA_URIS_BY_TAG,
@@ -61,7 +62,6 @@ def _factory(pattern, latest_manifest, tag_def):
 
 # Main dynamic class creation loop
 #   Reads each tag entry from the manifest and creates a class for it
-_generated = {}
 for manifest in _MANIFESTS:
     _add_cls(SerializationNode._factory(manifest_uri := manifest["id"]))
 
@@ -72,9 +72,9 @@ for manifest in _MANIFESTS:
 
         # make pattern from tag
         pattern = f"{base}-*"
-        if pattern not in _generated:
-            _generated[pattern] = _factory(pattern, manifest_uri, tag_def)
-        NODE_CLASSES_BY_TAG[tag_uri] = _generated[pattern]
+        if pattern not in NODES_BY_PATTERN:
+            NODES_BY_PATTERN[pattern] = _factory(pattern, manifest_uri, tag_def)
+        NODE_CLASSES_BY_TAG[tag_uri] = NODES_BY_PATTERN[pattern]
 
         # Make serialization intermediate
         if tag_uri not in TAG_MANIFEST_REGISTRY:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,21 @@
-import asdf
 import pytest
+from asdf import get_config
 
 from roman_datamodels._stnode._registry import OBJECT_NODE_CLASSES_BY_PATTERN, SCHEMA_URIS_BY_TAG
-from roman_datamodels._stnode._stnode import _MANIFESTS as MANIFESTS
 
 
-@pytest.fixture(scope="session", params=MANIFESTS)
-def manifest(request):
-    return request.param
-
-
-@pytest.fixture(scope="session", params=list(OBJECT_NODE_CLASSES_BY_PATTERN.values()))
+@pytest.fixture(scope="module", params=list(OBJECT_NODE_CLASSES_BY_PATTERN.values()))
 def object_node(request):
     return request.param
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def object_node_default_uri(object_node):
     return SCHEMA_URIS_BY_TAG[object_node._default_tag]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def object_node_uris(object_node_default_uri):
     prefix_uri = f"{object_node_default_uri.rsplit('-', 1)[0]}-"
 
-    return [schema_uri for schema_uri in asdf.get_config().resource_manager if schema_uri.startswith(prefix_uri)]
+    return [schema_uri for schema_uri in get_config().resource_manager if schema_uri.startswith(prefix_uri)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,65 @@
 import pytest
 from asdf import get_config
 
-from roman_datamodels._stnode._registry import OBJECT_NODE_CLASSES_BY_PATTERN, SCHEMA_URIS_BY_TAG
+from roman_datamodels._stnode import TaggedListNode, TaggedObjectNode
+from roman_datamodels._stnode._registry import (
+    LIST_NODE_CLASSES_BY_PATTERN,
+    NODE_CLASSES_BY_TAG,
+    NODES_BY_PATTERN,
+    OBJECT_NODE_CLASSES_BY_PATTERN,
+    SCHEMA_URIS_BY_TAG,
+)
+from roman_datamodels._stnode._tagged import _TaggedNodeMixin
+from roman_datamodels.datamodels import (
+    MODEL_REGISTRY,
+    DataModel,
+    ForcedImageSourceCatalogModel,
+    ForcedMosaicSourceCatalogModel,
+    ImageSourceCatalogModel,
+    MosaicSourceCatalogModel,
+    MultibandSourceCatalogModel,
+)
 
 
-@pytest.fixture(scope="module", params=list(OBJECT_NODE_CLASSES_BY_PATTERN.values()))
-def object_node(request):
+@pytest.fixture(scope="module", params=NODE_CLASSES_BY_TAG)
+def tag_uri(request) -> str:
+    """Fixture to provide a tag URI for each of the RAD tags"""
     return request.param
 
 
 @pytest.fixture(scope="module")
-def object_node_default_uri(object_node):
-    return SCHEMA_URIS_BY_TAG[object_node._default_tag]
+def tagged_node_class(tag_uri: str) -> type[_TaggedNodeMixin]:
+    """Fixture to provide the node class associated with each of the RAD tags"""
+    return NODE_CLASSES_BY_TAG[tag_uri]
+
+
+@pytest.fixture(scope="module", params=NODES_BY_PATTERN.values())
+def node_class(request) -> type[_TaggedNodeMixin]:
+    """Fixture to provide all of the node classes"""
+    return request.param
+
+
+@pytest.fixture(scope="module", params=OBJECT_NODE_CLASSES_BY_PATTERN.values())
+def object_node_class(request) -> type[TaggedObjectNode]:
+    """Fixture to provide all of the object node classes"""
+    return request.param
+
+
+@pytest.fixture(scope="module", params=LIST_NODE_CLASSES_BY_PATTERN.values())
+def list_node_class(request) -> type[TaggedListNode]:
+    """Fixture to provide all of the list node classes"""
+    return request.param
+
+
+@pytest.fixture(scope="module", params=(*OBJECT_NODE_CLASSES_BY_PATTERN.values(), *LIST_NODE_CLASSES_BY_PATTERN.values()))
+def container_node_class(request) -> type[TaggedObjectNode] | type[TaggedListNode]:
+    """Fixture to provide all of the container node classes (object and list)"""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def object_node_default_uri(object_node_class):
+    return SCHEMA_URIS_BY_TAG[object_node_class._default_tag]
 
 
 @pytest.fixture(scope="module")
@@ -19,3 +67,37 @@ def object_node_uris(object_node_default_uri):
     prefix_uri = f"{object_node_default_uri.rsplit('-', 1)[0]}-"
 
     return [schema_uri for schema_uri in get_config().resource_manager if schema_uri.startswith(prefix_uri)]
+
+
+@pytest.fixture(scope="module", params=MODEL_REGISTRY)
+def data_model_node(request) -> type[TaggedObjectNode]:
+    """
+    Fixture to provide all of the model nodes associated with each of the DataModels
+    """
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def data_model(data_model_node: type[TaggedObjectNode]) -> type[DataModel]:
+    """
+    Fixture to provide all of the DataModels
+    """
+    return MODEL_REGISTRY[data_model_node]
+
+
+# TODO: Automate how to get these instead of hardcoding them here
+@pytest.fixture(
+    scope="module",
+    params=(
+        ImageSourceCatalogModel,
+        MosaicSourceCatalogModel,
+        ForcedImageSourceCatalogModel,
+        ForcedMosaicSourceCatalogModel,
+        MultibandSourceCatalogModel,
+    ),
+)
+def catalog_data_model(request) -> type[DataModel]:
+    """
+    Fixture to provide all of the DataModels with source catalogs
+    """
+    return request.param

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -2,21 +2,12 @@ import asdf
 import pytest
 
 from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG, TAG_MANIFEST_REGISTRY
+from roman_datamodels._stnode._tagged import _TaggedNodeMixin
 
 
-@pytest.fixture(scope="session", params=NODE_CLASSES_BY_TAG)
-def node_tag(request):
-    return request.param
-
-
-@pytest.fixture(scope="session")
-def node_cls(node_tag):
-    return NODE_CLASSES_BY_TAG[node_tag]
-
-
-@pytest.fixture(scope="session")
-def node_instance(node_tag, node_cls):
-    return node_cls.create_fake_data(tag=node_tag)
+@pytest.fixture(scope="module")
+def node_instance(tag_uri: str, tagged_node_class: type[_TaggedNodeMixin]) -> _TaggedNodeMixin:
+    return tagged_node_class.create_fake_data(tag=tag_uri)
 
 
 @pytest.mark.parametrize("manifest_uri", MANIFEST_TAG_REGISTRY)
@@ -37,12 +28,12 @@ def test_all_tags_in_manifest_tag_registry():
     assert len(TAG_MANIFEST_REGISTRY) == len(NODE_CLASSES_BY_TAG)
 
 
-def test_history(tmp_path, node_tag, node_instance):
+def test_history(tmp_path, tag_uri: str, node_instance: _TaggedNodeMixin):
     filename = tmp_path / "history_test.asdf"
     prefix = "asdf://stsci.edu/datamodels/roman/extensions/"
 
     # Sanity check
-    assert node_instance.tag == node_tag
+    assert node_instance.tag == tag_uri
 
     # Save asdf file
     asdf.AsdfFile(tree={"roman": node_instance}).write_to(filename)
@@ -59,9 +50,9 @@ def test_history(tmp_path, node_tag, node_instance):
 
     datamodel_uris = sorted([extension_uri.replace("extensions", "manifests") for extension_uri in extension_uris])
     # node_tag should be the list of datamodel_uris
-    assert TAG_MANIFEST_REGISTRY[node_tag] in datamodel_uris
+    assert TAG_MANIFEST_REGISTRY[tag_uri] in datamodel_uris
 
     # If a tag is in a given manifest then all of its referenced tags are also in that manifest
     #    so the earliest manifest and extension can be is the latest one for the node_tag.
     #    all other manifests must be the same or newer.
-    assert TAG_MANIFEST_REGISTRY[node_tag] == datamodel_uris[0]
+    assert TAG_MANIFEST_REGISTRY[tag_uri] == datamodel_uris[0]

--- a/tests/test_dqflags.py
+++ b/tests/test_dqflags.py
@@ -45,46 +45,50 @@ def test_pixel_uniqueness():
     assert len(dqflags.pixel) == len(dqflags.pixel.__members__)
 
 
-@pytest.mark.parametrize("flag", dqflags.pixel)
-def test_pixel_flags(flag, ramp_schema):
+@pytest.fixture(scope="module", params=dqflags.pixel)
+def pixel_flag(request):
+    """Fixture to provide each pixel flag in dqflags.pixel"""
+    return request.param
+
+
+def test_pixel_flags(pixel_flag: dqflags.pixel, ramp_schema):
     """Test that each pixel flag follows the defined rules"""
     pixel_dq_type = ramp_schema["properties"]["pixeldq"]["datatype"]
 
     # Test that the pixel flags are dqflags.pixel instances
-    assert isinstance(flag, dqflags.pixel)
+    assert isinstance(pixel_flag, dqflags.pixel)
 
     # Test that the pixel flags are of the correct dtype
-    assert flag.dtype == asdf_datatype_to_numpy_dtype(pixel_dq_type)
+    assert pixel_flag.dtype == asdf_datatype_to_numpy_dtype(pixel_dq_type)
 
     # Test that the pixel flags are ints
-    assert isinstance(flag, np.uint32)
+    assert isinstance(pixel_flag, np.uint32)
 
     # Test that the pixel flags are dict accessible
-    assert dqflags.pixel[flag.name] is flag
+    assert dqflags.pixel[pixel_flag.name] is pixel_flag
 
     # Test that the pixel flag is a power of 2
-    if flag.name == "GOOD":
+    if pixel_flag.name == "GOOD":
         # GOOD is the only non-power-of-two flag (it is 0)
-        assert flag.value == 0
+        assert pixel_flag.value == 0
     else:
-        assert _is_power_of_two(flag.value)
+        assert _is_power_of_two(pixel_flag.value)
 
 
-@pytest.mark.parametrize("flag", dqflags.pixel)
-def test_write_pixel_flags(tmp_path, flag):
+def test_write_pixel_flags(tmp_path, pixel_flag: dqflags.pixel):
     filename = tmp_path / "test_dq.asdf"
 
     ramp = rdm.RampModel.create_fake_data(shape=(2, 8, 8))
 
     # Set all pixels to the flag value
-    ramp.pixeldq[...] = flag
+    ramp.pixeldq[...] = pixel_flag
 
     # Check that we can write the model to disk (i.e. the flag validates)
     ramp.save(filename)
 
     # Check that we can read the model back in and the flag is preserved
     with rdm.open(filename) as dm:
-        assert (dm.pixeldq == flag).all()
+        assert (dm.pixeldq == pixel_flag).all()
 
 
 def test_group_uniqueness():
@@ -98,41 +102,45 @@ def test_group_uniqueness():
     assert len(dqflags.group) == len(dqflags.group.__members__)
 
 
-@pytest.mark.parametrize("flag", dqflags.group)
-def test_group_flags(flag, ramp_schema):
+@pytest.fixture(scope="module", params=dqflags.group)
+def group_flag(request):
+    """Fixture to provide each group flag in dqflags.group"""
+    return request.param
+
+
+def test_group_flags(group_flag: dqflags.group, ramp_schema):
     """Test that each group flag follows the defined rules"""
     group_dq_type = ramp_schema["properties"]["groupdq"]["datatype"]
 
     # Test that the group flags are dqflags.group instances
-    assert isinstance(flag, dqflags.group)
+    assert isinstance(group_flag, dqflags.group)
 
     # Test that the group flags are of the correct dtype
-    assert flag.dtype == asdf_datatype_to_numpy_dtype(group_dq_type)
+    assert group_flag.dtype == asdf_datatype_to_numpy_dtype(group_dq_type)
 
     # Test that the group flags are ints
-    assert isinstance(flag, np.uint8)
+    assert isinstance(group_flag, np.uint8)
 
     # Test that the group flags are dict accessible
-    assert dqflags.group[flag.name] is flag
+    assert dqflags.group[group_flag.name] is group_flag
 
     # Test that each group flag matches a pixel flag of the same name
     # except for the WFI18_TRANSIENT flag
-    if flag.name != "WFI18_TRANSIENT":
-        assert dqflags.pixel[flag.name] == flag
+    if group_flag.name != "WFI18_TRANSIENT":
+        assert dqflags.pixel[group_flag.name] == group_flag
 
 
-@pytest.mark.parametrize("flag", dqflags.group)
-def test_write_group_flags(tmp_path, flag):
+def test_write_group_flags(tmp_path, group_flag: dqflags.group):
     filename = tmp_path / "test_dq.asdf"
 
     ramp = rdm.RampModel.create_fake_data(shape=(2, 8, 8))
 
     # Set all pixels to the flag value
-    ramp.groupdq[...] = flag
+    ramp.groupdq[...] = group_flag
 
     # Check that we can write the model to disk (i.e. the flag validates)
     ramp.save(filename)
 
     # Check that we can read the model back in and the flag is preserved
     with rdm.open(filename) as dm:
-        assert (dm.groupdq == flag).all()
+        assert (dm.groupdq == group_flag).all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,9 +13,9 @@ from astropy.time import Time
 from numpy.testing import assert_array_equal
 
 from roman_datamodels import DataModel, datamodels
-from roman_datamodels._stnode import DNode, LNode, Observation, WfiImage
-from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG
-from roman_datamodels._stnode._tagged import _NO_VALUE
+from roman_datamodels._stnode import DNode, LNode, Observation, TaggedObjectNode, WfiImage
+from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY
+from roman_datamodels._stnode._tagged import _NO_VALUE, _TaggedNodeMixin
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy
 
 
@@ -53,38 +53,36 @@ def test_data_model_exists(top_level_schema: dict[str, Any], request):
     assert hasattr(datamodels, top_level_schema["datamodel_name"])
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_node_type_matches_model(model):
+def test_node_type_matches_model(data_model_node: type[TaggedObjectNode], data_model: type[DataModel]):
     """
     Test that the _node_type listed for each model is what is listed in the schema
     """
-    node_type = model._node_type
-    node = node_type.create_fake_data()
+    assert data_model._node_type is data_model_node
+    node = data_model_node.create_fake_data()
+
     schema = node.get_schema()
     name = schema["datamodel_name"]
 
-    assert model.__name__ == name
+    assert data_model.__name__ == name
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_model_schemas(model):
-    instance = model.create_fake_data()
+def test_model_schemas(data_model: type[DataModel]):
+    instance = data_model.create_fake_data()
     asdf.schema.load_schema(instance.schema_uri)
 
 
-@pytest.mark.parametrize("node, model", datamodels.MODEL_REGISTRY.items())
 @pytest.mark.parametrize("method", ["info", "search", "schema_info"])
-def test_model_asdf_operations(node, model, method):
+def test_model_asdf_operations(data_model_node: type[TaggedObjectNode], data_model: type[DataModel], method: str):
     """
     Test the decorator for asdf operations on models when an empty initial model
     which is then filled.
     """
     # Create an empty model
-    mdl = model()
-    assert isinstance(mdl._instance, node)
+    mdl = data_model()
+    assert isinstance(mdl._instance, data_model_node)
 
     # Fill the model with data, but no asdf file is present
-    mdl._instance = node.create_fake_data()
+    mdl._instance = data_model_node.create_fake_data()
     assert mdl._asdf is None
 
     # Run the method we wish to test (it should fail with warning or error
@@ -205,18 +203,8 @@ def test_node_assignment():
     assert isinstance(darkexp, DNode)
 
 
-@pytest.mark.parametrize(
-    "model_class",
-    (
-        datamodels.ImageSourceCatalogModel,
-        datamodels.MosaicSourceCatalogModel,
-        datamodels.ForcedImageSourceCatalogModel,
-        datamodels.ForcedMosaicSourceCatalogModel,
-        datamodels.MultibandSourceCatalogModel,
-    ),
-)
-def test_get_column_description(model_class):
-    model = model_class.create_fake_data()
+def test_get_column_description(catalog_data_model: type[DataModel]):
+    model = catalog_data_model.create_fake_data()
     for column in model.source_catalog.columns.values():
         column_def = model.get_column_definition(column.name)
         assert column_def is not None
@@ -357,7 +345,7 @@ def test_to_flat_dict(include_arrays):
 
 
 @pytest.mark.parametrize("model_class", (datamodels.ImageModel, datamodels.RampModel))
-def test_crds_parameters(model_class):
+def test_crds_parameters(model_class: type[DataModel]):
     # CRDS uses meta.exposure.start_time to compare to USEAFTER
     model = model_class.create_fake_data()
     # patch on a value that is valid (a simple type)
@@ -385,29 +373,24 @@ def test_model_validate_without_save():
 
 @pytest.mark.filterwarnings("ignore:ERFA function.*")
 @pytest.mark.parametrize("node_class", datamodels.MODEL_REGISTRY.keys())
-@pytest.mark.parametrize("correct, model", datamodels.MODEL_REGISTRY.items())
-def test_model_only_init_with_correct_node(node_class, correct, model):
+def test_model_only_init_with_correct_node(
+    node_class: type[TaggedObjectNode], data_model_node: type[TaggedObjectNode], data_model: type[DataModel]
+):
     """
     Datamodels should only be initializable with the correct node in the model_registry.
     This checks that it can be initialized with the correct node, and that it cannot be
     with any other node.
     """
     node = node_class.create_fake_data()
-    with nullcontext() if node_class is correct else pytest.raises(ValidationError):
-        model(node).validate()
+    with nullcontext() if node_class is data_model_node else pytest.raises(ValidationError):
+        data_model(node).validate()
 
 
 @pytest.mark.parametrize(
-    "mk_raw",
-    [
-        lambda: datamodels.ScienceRawModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.TvacModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.FpsModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.RampModel.create_fake_data(shape=(2, 8, 8)),
-    ],
+    "model_class", (datamodels.ScienceRawModel, datamodels.TvacModel, datamodels.FpsModel, datamodels.RampModel)
 )
-def test_ramp_from_science_raw(mk_raw):
-    raw = mk_raw()
+def test_ramp_from_science_raw(model_class: type[DataModel]):
+    raw = model_class.create_fake_data(shape=(2, 8, 8))
     ramp = datamodels.RampModel.from_science_raw(raw)
     for key in ramp:
         if not hasattr(raw, key):
@@ -460,17 +443,10 @@ def test_science_raw_from_tvac_raw_invalid_input():
         _ = datamodels.ScienceRawModel.from_tvac_raw(model)
 
 
-@pytest.mark.parametrize(
-    "mk_tvac",
-    [
-        lambda: datamodels.ScienceRawModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.TvacModel.create_fake_data(shape=(2, 8, 8)),
-        lambda: datamodels.FpsModel.create_fake_data(shape=(2, 8, 8)),
-    ],
-)
-def test_science_raw_from_tvac_raw(mk_tvac):
+@pytest.mark.parametrize("model_class", (datamodels.ScienceRawModel, datamodels.TvacModel, datamodels.FpsModel))
+def test_science_raw_from_tvac_raw(model_class: type[DataModel]):
     """Test conversion from expected inputs"""
-    tvac = mk_tvac()
+    tvac = model_class.create_fake_data(shape=(2, 8, 8))
     tvac.meta.statistics = {"mean_counts_per_second": 1}
 
     raw = datamodels.ScienceRawModel.from_tvac_raw(tvac)
@@ -511,8 +487,7 @@ def test_science_raw_from_tvac_raw(mk_tvac):
         assert raw.extras.tvac.meta.statistics == tvac.meta.statistics
 
 
-@pytest.mark.parametrize("model_class", datamodels.MODEL_REGISTRY.values())
-def test_datamodel_construct_like_from_like(model_class):
+def test_datamodel_construct_like_from_like(data_model: type[DataModel]):
     """
     This is a regression test for the issue reported issue #51.
 
@@ -525,13 +500,13 @@ def test_datamodel_construct_like_from_like(model_class):
     """
 
     # Create a model
-    model = model_class.create_fake_data()
+    model = data_model.create_fake_data()
 
     # Modify _iscopy as it will be reset to False by initializer if called incorrectly
     model._iscopy = "foo"
 
     # Pass model instance to model constructor
-    new_model = model_class(model)
+    new_model = data_model(model)
     assert new_model is model
     assert new_model._iscopy == "foo"  # Verify that the constructor didn't override stuff
 
@@ -584,7 +559,7 @@ def test_datamodel_save_file_date(tmp_path, monkeypatch):
         (datamodels.MosaicModel, False),
     ],
 )
-def test_rampmodel_from_science_raw(model_class, expect_success):
+def test_rampmodel_from_science_raw(model_class: type[DataModel], expect_success: bool):
     """Test creation of RampModel from raw science/tvac"""
     model = model_class.create_fake_data(
         defaults={"meta": {"calibration_software_version": "1.2.3", "exposure": {"read_pattern": [[1], [2], [3]]}}}
@@ -601,7 +576,7 @@ def test_rampmodel_from_science_raw(model_class, expect_success):
 
 @pytest.mark.parametrize(
     "model_class",
-    [datamodels.FpsModel, datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel, datamodels.MosaicModel],
+    (datamodels.FpsModel, datamodels.RampModel, datamodels.ScienceRawModel, datamodels.TvacModel, datamodels.MosaicModel),
 )
 def test_model_assignment_access_types(model_class):
     """Test assignment and access of model keyword value via keys and dot notation"""
@@ -760,46 +735,41 @@ def test_deepcopy_after_use():
     deepcopy(m.meta)
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_minimal(model):
+def test_create_minimal(data_model: type[DataModel]):
     """Test that create_minimal produces a model instance"""
-    m = model.create_minimal()
-    assert isinstance(m, model)
+    m = data_model.create_minimal()
+    assert isinstance(m, data_model)
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_fake_data(model):
+def test_create_fake_data(data_model: type[DataModel]):
     """Test that create_fake_data produces a valid model instance"""
-    m = model.create_fake_data()
-    assert isinstance(m, model)
+    m = data_model.create_fake_data()
+    assert isinstance(m, data_model)
     assert m.validate() is None
 
 
-@pytest.mark.parametrize("tag, node_class", NODE_CLASSES_BY_TAG.items())
-def test_create_tag(tag, node_class):
+def test_create_tag(tag_uri: str, tagged_node_class: type[_TaggedNodeMixin]):
     """Test that we can create a node for every registered tag"""
 
-    node = node_class.create_minimal(tag=tag)
+    node = tagged_node_class.create_minimal(tag=tag_uri)
     if node is not _NO_VALUE:
-        assert node._read_tag == tag
+        assert node._read_tag == tag_uri
 
-    node = node_class.create_fake_data(tag=tag)
+    node = tagged_node_class.create_fake_data(tag=tag_uri)
     if node is not _NO_VALUE:
-        assert node._read_tag == tag
+        assert node._read_tag == tag_uri
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_no_hidden(model):
+def test_no_hidden(data_model: type[DataModel]):
     """Test that no hidden attributes are allowed"""
-    m = model.create_minimal()
+    m = data_model.create_minimal()
     with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
         m._foo = "bar"  # Add a hidden attribute
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_delattr(model):
+def test_delattr(data_model: type[DataModel]):
     """Test that delattr works as expected"""
-    m = model.create_minimal()
+    m = data_model.create_minimal()
 
     m.foo = "bar"
     assert hasattr(m, "foo")
@@ -808,24 +778,22 @@ def test_delattr(model):
     assert not hasattr(m, "foo")
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_slotted(model):
+def test_slotted(data_model: type[DataModel]):
     """Test that the model is slotted as expected"""
-    m = model.create_minimal()
+    m = data_model.create_minimal()
 
     with pytest.raises(AttributeError, match=r"No attribute .*"):
         # slotted object instances do not have a __dict__
         m.__dict__  # noqa: B018
 
 
-@pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
-def test_create_minimal_copies(model, tmp_path):
+def test_create_minimal_copies(data_model: type[DataModel], tmp_path):
     """Test that create_minimal does not retain references to input"""
     fn = tmp_path / "test.asdf"
-    fake = model.create_fake_data()
+    fake = data_model.create_fake_data()
     fake.save(fn)
     with datamodels.open(fn) as opened_model:
-        new_model = model.create_minimal(opened_model)
+        new_model = data_model.create_minimal(opened_model)
     del opened_model
     gc.collect(2)
     assert new_model.validate() is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,75 +1,56 @@
 import gc
 from contextlib import nullcontext
 from copy import deepcopy
+from typing import Any
 
 import asdf
 import numpy as np
 import pytest
 from asdf.exceptions import ValidationError
+from asdf.schema import load_schema
 from astropy import units as u
 from astropy.time import Time
 from numpy.testing import assert_array_equal
 
-from roman_datamodels import datamodels
-from roman_datamodels._stnode import (
-    CalLogs,
-    DNode,
-    IndividualImageMeta,
-    LNode,
-    MosaicAssociations,
-    Observation,
-    OutlierDetection,
-    Resample,
-    SkyBackground,
-    SourceCatalog,
-    WfiImage,
-    WfiWcs,
-)
-from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
+from roman_datamodels import DataModel, datamodels
+from roman_datamodels._stnode import DNode, LNode, Observation, WfiImage
+from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG
 from roman_datamodels._stnode._tagged import _NO_VALUE
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy
 
-from .conftest import MANIFESTS
 
-# Nodes for metadata schema that do not contain any archive_catalog keywords
-NODES_LACKING_ARCHIVE_CATALOG = [
-    CalLogs,
-    OutlierDetection,
-    MosaicAssociations,
-    IndividualImageMeta,
-    Resample,
-    SkyBackground,
-    SourceCatalog,
-    WfiWcs,
-]
-
-
-def datamodel_names():
-    names = []
-
-    extension_manager = asdf.AsdfFile().extension_manager
-    for manifest in MANIFESTS:
-        for tag in manifest["tags"]:
-            schema_uri = extension_manager.get_tag_definition(tag["tag_uri"]).schema_uris[0]
-            schema = asdf.schema.load_schema(schema_uri, resolve_references=True)
-
-            if not (datamodel_name := schema.get("datamodel_name")):
+def _get_top_level_schemas():
+    visited_schemas: set[str] = set()
+    for manifest_uri in MANIFEST_TAG_REGISTRY:
+        for tag_def in load_schema(manifest_uri)["tags"]:
+            if (schema_uri := tag_def["schema_uri"]) in visited_schemas:
                 continue
 
-            if datamodel_name == "AssociationsModel":
-                continue
-
-            names.append(datamodel_name)
-
-    return names
+            visited_schemas.add(schema_uri)
+            if "datamodel_name" in (schema := load_schema(schema_uri, resolve_references=True)):
+                yield schema
 
 
-@pytest.mark.parametrize("name", datamodel_names())
-def test_datamodel_exists(name):
+@pytest.fixture(scope="session", params=_get_top_level_schemas())
+def top_level_schema(request) -> dict[str, Any]:
     """
-    Confirm that a datamodel exists for every schema indicating that it is a datamodel
+    Fixture to return the top level schemas from the manifest information.
+        This returns all of the top level schemas even if they map to the same data model.
+        This is intentional in case a datamodel_name changes between schemas
     """
-    assert hasattr(datamodels, name)
+    return request.param
+
+
+def test_data_model_exists(top_level_schema: dict[str, Any], request):
+    """
+    Confirm that a DataModel exists with the correct datamodel_name for each top
+    level schema entry listed by RAD
+    """
+    name = top_level_schema["datamodel_name"]
+    # TODO: We should probably add this model back but with a warning instead
+    if name == "AssociationsModel":
+        request.applymarker(pytest.mark.xfail(reason="AssociationsModel was removed by #562"))
+    assert hasattr(datamodels, top_level_schema["datamodel_name"])
 
 
 @pytest.mark.parametrize("model", datamodels.MODEL_REGISTRY.values())
@@ -352,21 +333,18 @@ def test_datamodel_schema_info_values():
     }
 
 
-@pytest.mark.parametrize(
-    "name", (name for name in datamodel_names() if not name.startswith("Fps") and not name.startswith("Tvac"))
-)
-def test_datamodel_schema_info_existence(name):
-    # Loop over datamodels that have archive_catalog entries
-    if not name.endswith("RefModel"):
-        model_class = getattr(datamodels, name)
-        model = model_class.create_fake_data()
-        info = model.schema_info("archive_catalog")
-        for keyword in model.meta.keys():
-            # Only DNodes or LNodes need to be canvassed
-            if isinstance(model.meta[keyword], DNode | LNode):
-                # Ignore metadata schemas that lack archive_catalog entries
-                if type(model.meta[keyword]) not in NODES_LACKING_ARCHIVE_CATALOG:
-                    assert keyword in info["roman"]["meta"]
+def test_data_model_schema_info_existence(data_model: type[DataModel]):
+    """Test the archive_catalog entries in the schema info"""
+    model = data_model.create_fake_data()
+    info = model.schema_info("archive_catalog")
+    for keyword, value in model.meta.items():
+        # Bug in the TVAC/FPS schemas "ref_file" so we skip it
+        if data_model in (datamodels.TvacModel, datamodels.FpsModel) and keyword == "ref_file":
+            continue
+
+        # Only searches LNodes or DNodes
+        if isinstance(value, DNode | LNode):
+            assert keyword in info["roman"]["meta"]
 
 
 @pytest.mark.parametrize("include_arrays", (True, False))

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -10,7 +10,7 @@ from astropy.io import fits
 from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels
-from roman_datamodels._stnode import WfiImage
+from roman_datamodels._stnode import TaggedObjectNode, WfiImage
 from roman_datamodels.datamodels._utils import _patch_meta_filename
 from roman_datamodels.testing import assert_node_equal
 
@@ -194,30 +194,28 @@ def test_no_memmap(tmp_path, kwargs):
         assert (model.data == data).all()
 
 
-@pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
-def test_node_round_trip(tmp_path, node_class):
+def test_node_round_trip(tmp_path, data_model_node: type[TaggedObjectNode]):
     file_path = tmp_path / "test.asdf"
 
     # Create/return a node and write it to disk, then check if the node round trips
-    node = node_class.create_fake_data()
+    node = data_model_node.create_fake_data()
     asdf.AsdfFile({"roman": node}).write_to(file_path)
     with asdf.open(file_path) as af:
         assert_node_equal(af.tree["roman"], node)
 
 
-@pytest.mark.parametrize("node_class", [node for node in datamodels.MODEL_REGISTRY])
-def test_opening_model(tmp_path, node_class):
+def test_opening_model(tmp_path, data_model_node: type[TaggedObjectNode]):
     file_path = tmp_path / "test.asdf"
 
     # Create a node and write it to disk
-    node = node_class.create_fake_data()
+    node = data_model_node.create_fake_data()
     if hasattr(node, "meta") and hasattr(node.meta, "filename"):
         node.meta.filename = type(node.meta.filename)(file_path.name)
     asdf.AsdfFile({"roman": node}).write_to(file_path)
 
     with datamodels.open(file_path) as model:
         # Check that the model is the correct type
-        assert isinstance(model, datamodels.MODEL_REGISTRY[node_class])
+        assert isinstance(model, datamodels.MODEL_REGISTRY[data_model_node])
 
 
 def test_read_pattern_properties():
@@ -261,16 +259,16 @@ def test_open_asn(tmp_path):
     assert isinstance(lib, romancal.datamodels.ModelLibrary)
 
 
-@pytest.mark.parametrize(
-    "model",
-    [mdl for mdl in datamodels.MODEL_REGISTRY.keys() if ("Ref" not in mdl.__name__ and "Associations" not in mdl.__name__)],
-)
-def test_filename_matches_meta(tmp_path, model):
+def test_filename_matches_meta(tmp_path, data_model_node: type[TaggedObjectNode]):
+    if "Ref" in data_model_node.__name__:
+        # These models don't have a file name
+        return
+
     save_path = tmp_path / "test_filename.asdf"
     open_path = tmp_path / "test_filename_read.asdf"
 
     # Create a node and write it to disk
-    gen_model = model.create_fake_data()
+    gen_model = data_model_node.create_fake_data()
     asdf.AsdfFile({"roman": gen_model}).write_to(save_path)
 
     # Save the filename type
@@ -288,10 +286,10 @@ def test_filename_matches_meta(tmp_path, model):
         pytest.warns(
             match="meta.filename: \\? does not match filename: test_filename_read.asdf, updating the filename in memory!"
         ),
-        datamodels.open(open_path) as model,
+        datamodels.open(open_path) as mdl,
     ):
-        assert model.meta.filename == open_path.name
-        assert isinstance(model.meta.filename, gn_fn_type)
+        assert mdl.meta.filename == open_path.name
+        assert isinstance(mdl.meta.filename, gn_fn_type)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -4,17 +4,11 @@ import pyarrow.parquet as pq
 import pytest
 from asdf.exceptions import ValidationError
 
-from roman_datamodels import datamodels
-
-CATALOG_CLASSES = (
-    datamodels.ImageSourceCatalogModel,
-    datamodels.MosaicSourceCatalogModel,
-)
+from roman_datamodels import DataModel
 
 
-@pytest.mark.parametrize("catalog_class", CATALOG_CLASSES)
-def test_source_catalog(catalog_class, tmp_path):
-    sc_dm = catalog_class.create_fake_data()
+def test_source_catalog(catalog_data_model: type[DataModel], tmp_path):
+    sc_dm = catalog_data_model.create_fake_data()
     name_a, name_b = sc_dm.source_catalog.colnames[:2]
 
     sc_dm.source_catalog[name_a].description = "a description"
@@ -48,9 +42,8 @@ def test_source_catalog(catalog_class, tmp_path):
         assert f.read(4) == b"PAR1"
 
 
-@pytest.mark.parametrize("catalog_class", CATALOG_CLASSES)
-def test_to_parquet_validates(catalog_class, tmp_path):
-    sc_dm = catalog_class.create_fake_data()
+def test_to_parquet_validates(catalog_data_model: type[DataModel], tmp_path):
+    sc_dm = catalog_data_model.create_fake_data()
     fn = tmp_path / "foo.parquet"
     sc_dm.meta = {}
     with pytest.raises(ValidationError):

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -1,27 +1,43 @@
 from contextlib import nullcontext
+from typing import Any
 
 import asdf
 import pytest
+from asdf.schema import load_schema
 
 from roman_datamodels import _stnode as stnode
 from roman_datamodels import datamodels
+from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy, wraps_hashable
 
-from .conftest import MANIFESTS
+
+@pytest.fixture(
+    scope="session",
+    params=(tag_def for manifest_uri in MANIFEST_TAG_REGISTRY for tag_def in load_schema(manifest_uri)["tags"]),
+)
+def raw_tag_def(request) -> dict[str, Any]:
+    """
+    Fixture to return the raw tag definitions from the raw manifest information.
+
+    Note that this will have repeated items as it returns every single definition
+        from every single manifest, but this is intentional to make sure we hit
+        everything in the tests that use this fixture.
+    """
+    return request.param
 
 
-@pytest.mark.parametrize("tag_def", [tag_def for manifest in MANIFESTS for tag_def in manifest["tags"]])
-def test_tag_has_node_class(tag_def):
-    class_name = stnode._factories.class_name_from_tag_uri(tag_def["tag_uri"])
+def test_tag_has_node_class(raw_tag_def: dict[str, Any]):
+
+    class_name = stnode._tagged.class_name_from_tag_uri(raw_tag_def["tag_uri"])
     node_class = getattr(stnode, class_name)
 
-    assert asdf.util.uri_match(node_class._pattern, tag_def["tag_uri"])
-    if node_class._default_tag == tag_def["tag_uri"]:
-        assert tag_def["description"] in node_class.__doc__
-        assert tag_def["tag_uri"] in node_class.__doc__
+    assert asdf.util.uri_match(node_class._pattern, raw_tag_def["tag_uri"])
+    if node_class._default_tag == raw_tag_def["tag_uri"]:
+        assert raw_tag_def["description"] in node_class.__doc__
+        assert raw_tag_def["tag_uri"] in node_class.__doc__
     else:
         default_tag_version = node_class._default_tag.rsplit("-", maxsplit=1)[1]
-        tag_def_version = tag_def["tag_uri"].rsplit("-", maxsplit=1)[1]
+        tag_def_version = raw_tag_def["tag_uri"].rsplit("-", maxsplit=1)[1]
         assert asdf.versioning.Version(default_tag_version) > asdf.versioning.Version(tag_def_version)
 
 

--- a/tests/test_stnode.py
+++ b/tests/test_stnode.py
@@ -5,9 +5,10 @@ import asdf
 import pytest
 from asdf.schema import load_schema
 
+from roman_datamodels import DataModel, datamodels
 from roman_datamodels import _stnode as stnode
-from roman_datamodels import datamodels
 from roman_datamodels._stnode._registry import MANIFEST_TAG_REGISTRY
+from roman_datamodels._stnode._tagged import _TaggedNodeMixin
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy, wraps_hashable
 
 
@@ -41,15 +42,13 @@ def test_tag_has_node_class(raw_tag_def: dict[str, Any]):
         assert asdf.versioning.Version(default_tag_version) > asdf.versioning.Version(tag_def_version)
 
 
-@pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
-def test_node_classes_available_via_stnode(node_class):
+def test_node_classes_available_via_stnode(node_class: type[_TaggedNodeMixin]):
     assert issubclass(node_class, stnode.TaggedObjectNode | stnode.TaggedListNode | stnode.TaggedScalarNode)
     assert node_class.__module__ == stnode.__name__
     assert hasattr(stnode, node_class.__name__)
 
 
-@pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
-def test_copy(node_class):
+def test_copy(node_class: type[_TaggedNodeMixin]):
     """Demonstrate nodes can copy themselves, but don't always deepcopy."""
     node = node_class.create_fake_data()
     node_copy = node.copy()
@@ -64,9 +63,8 @@ def test_copy(node_class):
         assert_node_is_copy(node, node_copy, deepcopy=True)
 
 
-@pytest.mark.parametrize("model_class", datamodels.MODEL_REGISTRY.values())
-def test_deepcopy_model(model_class):
-    model = model_class.create_fake_data(shape=(8, 8, 8))
+def test_deepcopy_model(data_model: type[DataModel]):
+    model = data_model.create_fake_data(shape=(8, 8, 8))
     model_copy = model.copy()
 
     # There is no assert equal for models, but the data inside is what we care about.
@@ -102,8 +100,7 @@ def test_wfi_mode():
     assert isinstance(node, stnode._mixins.WfiModeMixin)
 
 
-@pytest.mark.parametrize("node_class", stnode.NODE_CLASSES)
-def test_serialization(node_class, tmp_path):
+def test_serialization(node_class: type[_TaggedNodeMixin], tmp_path):
     file_path = tmp_path / "test.asdf"
 
     node = node_class.create_fake_data()
@@ -115,17 +112,15 @@ def test_serialization(node_class, tmp_path):
         assert_node_equal(af["node"], node)
 
 
-@pytest.mark.parametrize("node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedObjectNode)])
-def test_no_hidden(node_class):
-    node = node_class.create_fake_data()
+def test_no_hidden(object_node_class: type[stnode.TaggedObjectNode]):
+    node = object_node_class.create_fake_data()
     with pytest.raises(AttributeError, match=r"Cannot set private attribute.*"):
         node._foo = "bar"  # Add a hidden attribute
 
 
-@pytest.mark.parametrize("node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedListNode)])
-def test_list_node_no_new_attributes(node_class):
+def test_list_node_no_new_attributes(list_node_class: type[stnode.TaggedListNode]):
     """Test that no new attributes can be added to a list node."""
-    node = node_class.create_fake_data()
+    node = list_node_class.create_fake_data()
     with pytest.raises(AttributeError, match=r"Cannot set attribute .*, only allowed are .*"):
         node.foo = "bar"
 
@@ -133,14 +128,11 @@ def test_list_node_no_new_attributes(node_class):
         node._foo = "bar"
 
 
-@pytest.mark.parametrize(
-    "node_class", [cls for cls in stnode.NODE_CLASSES if issubclass(cls, stnode.TaggedObjectNode | stnode.TaggedListNode)]
-)
-def test_slotted(node_class):
+def test_slotted(container_node_class: type[stnode.TaggedObjectNode] | type[stnode.TaggedListNode]):
     """
     Test that slotted nodes do not allow new attributes to be added.
     """
-    node = node_class.create_fake_data()
+    node = container_node_class.create_fake_data()
     with pytest.raises(AttributeError, match=r".* attribute .*__dict__.*"):
         # Attempt to access __dict__ directly, slotted classes do not have __dict__
         node.__dict__  # noqa: B018
@@ -221,14 +213,16 @@ def test_node_representation():
     )
 
 
-def test_get_latest_schema(object_node, object_node_default_uri, object_node_uris):
+def test_get_latest_schema(
+    object_node_class: type[stnode.TaggedObjectNode], object_node_default_uri: str, object_node_uris: list[str]
+):
     assert len(object_node_uris) > 0, "This test requires at lest one URI available."
 
     for uri in [object_node_default_uri.rsplit("-", 1)[0], *object_node_uris]:
         latest_uri, schema = stnode.get_latest_schema(uri)
         assert latest_uri == object_node_default_uri
 
-        assert stnode._schema._get_schema_from_tag(object_node._default_tag) == schema
+        assert stnode._schema._get_schema_from_tag(object_node_class._default_tag) == schema
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is a good start in cleaning up the tests in preparation for  #668. It simply moves most of the parameterizations to ones over a fixtures so that when we start removing dynamic nodes and cleaning up registries it is much easier to reasonably manage the tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
