### PR TITLE
Add api to assist in migrating  a datamodel to a different tag.

### DIFF
--- a/changes/671.feature.rst
+++ b/changes/671.feature.rst
@@ -1,0 +1,3 @@
+Add simple tag migration function to the ``DataModel`` class. This is a dumb
+function that just makes a new model from the old with a new tag. It does not
+attempt to migrate any of the data, so routines in ``romancal`` maybe needed.

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -163,7 +163,7 @@ class DataModel(abc.ABC):
     __slots__ = ("_asdf", "_files_to_close", "_instance", "_iscopy", "_shape")
 
     @classmethod
-    def create_from_model(cls, model: DataModel | DNode) -> Self:
+    def create_from_model(cls, model: DataModel | DNode, *, tag: str | None = None) -> Self:
         """
         Create a new DataModel from an existing model.
         """
@@ -171,7 +171,41 @@ class DataModel(abc.ABC):
             node = model._instance
         else:
             node = model
-        return cls(cls._node_type.create_from_node(node))
+        return cls(cls._node_type.create_from_node(node, tag=tag))
+
+    def migrate_tag(self, tag: str | None = None) -> Self:
+        """
+        Return a new version of this model with the tag updated.
+
+        .. note::
+
+            This may not fully update your model to the new tag, it only moves
+            the information into the new tree. So it maybe missing information
+            or have information of the wrong type. If you want a more complete
+            migration to the new tag, use
+
+                ``romancal.datamodels.migration.update_model_version``
+
+            instead. This function begins with the result of this function and
+            then apply migration steps that require the full pipeline to determine.
+
+        Parameters
+        ----------
+        tag: str or None
+            If provided, specifically update to this tag not the default (latest) one.
+
+        Returns
+        -------
+        DataModel
+            A new version of this model with the tag updated.
+        """
+        # If no tag is provided, then update to the default tag.
+        tag = tag or self._node_type._default_tag
+
+        if self.tag == tag:
+            return self
+
+        return type(self).create_from_model(self, tag=tag)
 
     def __init__(self, init=None, **kwargs):
         if isinstance(init, self.__class__):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,7 +26,7 @@ from roman_datamodels._stnode import (
     WfiWcs,
 )
 from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
-from roman_datamodels._stnode._tagged import _NO_VALUE
+from roman_datamodels._stnode._tagged import _NO_VALUE, TaggedObjectNode
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy
 
 from .conftest import MANIFESTS
@@ -795,6 +795,35 @@ def test_create_fake_data(model):
     m = model.create_fake_data()
     assert isinstance(m, model)
     assert m.validate() is None
+
+
+@pytest.mark.parametrize("node_class, model", datamodels.MODEL_REGISTRY.items())
+def test_migrate_tag(node_class: type[TaggedObjectNode], model: type[datamodels.DataModel]):
+    """Test that we can migrate the tag to a new version"""
+
+    # Find all the tags that are mapped to the datamodel's node class
+    model_tags = set(tag_uri for tag_uri, node in NODE_CLASSES_BY_TAG.items() if node is node_class)
+
+    for current_tag in model_tags:
+        # Create a model with the current tag
+        current = model.create_fake_data(tag=current_tag)
+        assert current.tag == current_tag
+
+        for new_tag in model_tags:
+            new = current.migrate_tag(new_tag)
+
+            # The tag has been updated
+            assert new.tag == new_tag
+
+            # The tags match then we should get the same object back
+            if new_tag == current_tag:
+                assert new is current
+            else:
+                assert new is not current
+
+        # Check the default is to migrage to the default tag
+        new = current.migrate_tag()
+        assert new.tag == node_class._default_tag
 
 
 @pytest.mark.parametrize("tag, node_class", NODE_CLASSES_BY_TAG.items())


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR moves part of the code in https://github.com/spacetelescope/romancal/blob/13de40cd1d95fbb7047fec375cd7ad2c05223b42/romancal/datamodels/migration.py#L13 so that `romancal` isn't using the private RDM API that #669 is removing.

Namely it moves:
https://github.com/spacetelescope/romancal/blob/13de40cd1d95fbb7047fec375cd7ad2c05223b42/romancal/datamodels/migration.py#L31-L34
into a DataModel method that we can make sure not to break.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
