### PR TITLE
Clean up ASDF converters

### DIFF
--- a/changes/672.feature.rst
+++ b/changes/672.feature.rst
@@ -1,0 +1,2 @@
+Cleanup and centralize all of the ASDF extension/serialization objects in order
+to reduce the number of objects that RDM needs in order to support ASDF.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -421,4 +421,5 @@ epub_exclude_files = ["search.html"]
 nitpicky = True
 nitpick_ignore = [
     ("py:class", "_io.FileIO"),
+    ("py:class", "SerializationContext"),
 ]

--- a/src/roman_datamodels/_stnode/__init__.py
+++ b/src/roman_datamodels/_stnode/__init__.py
@@ -6,6 +6,7 @@ The STNode classes and supporting objects generated dynamically at import time
 from __future__ import annotations
 
 from ._converters import *  # noqa: F403
+from ._manifest import *  # noqa: F403
 from ._mixins import *  # noqa: F403
 from ._node import *  # noqa: F403
 from ._schema import *  # noqa: F403

--- a/src/roman_datamodels/_stnode/_converters.py
+++ b/src/roman_datamodels/_stnode/_converters.py
@@ -7,14 +7,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from asdf.extension import Converter, SerializationContext
-from astropy.time import Time
-
-from ._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG, SERIALIZATION_BY_MANIFEST
 
 if TYPE_CHECKING:
-    from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode, _TaggedNodeMixin
+    from ._manifest import ManifestNode
+    from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, _TaggedNodeMixin
 
-__all__ = ("SerializationNodeConverter", "TaggedNodeConverter")
+__all__ = ("ManifestNodeConverter", "TaggedNodeConverter")
 
 
 class _RomanConverter(Converter):
@@ -25,30 +23,38 @@ class _RomanConverter(Converter):
     lazy = True
 
 
-class SerializationNodeConverter(_RomanConverter):
+class ManifestNodeConverter(_RomanConverter):
     """
     Converter that tags are deferred to so that the correct
-    extension can be applied
+        extension can recorded in the ASDF file's history section.
     """
 
-    def __init__(self, manifest_uri: str):
-        self._manifest_uri = manifest_uri
+    def __init__(self, node_cls: type[ManifestNode]):
+        self._node_cls = node_cls
 
-    def select_tag(self, obj: SerializationNode, tags, ctx) -> str:
+    def select_tag(self, obj: ManifestNode, tags: tuple[str, ...], ctx: SerializationContext) -> str:
         return obj.tag
 
     @property
     def tags(self) -> tuple[str, ...]:
-        return tuple(MANIFEST_TAG_REGISTRY[self._manifest_uri])
+        from ._registry import MANIFEST_TAG_REGISTRY
+
+        return tuple(MANIFEST_TAG_REGISTRY[self._node_cls.manifest_uri])
 
     @property
-    def types(self) -> tuple[type[SerializationNode], ...]:
-        return (SERIALIZATION_BY_MANIFEST[self._manifest_uri],)
+    def types(self) -> tuple[type[ManifestNode], ...]:
+        return (self._node_cls,)
 
-    def to_yaml_tree(self, obj: SerializationNode, tag, ctx):
+    def to_yaml_tree(self, obj: ManifestNode, tag: str, ctx: SerializationContext) -> Any:
         return obj.data
 
-    def from_yaml_tree(self, node, tag, ctx) -> TaggedObjectNode | TaggedListNode | TaggedScalarNode:
+    def from_yaml_tree(
+        self, node: dict[str, Any], tag: str, ctx: SerializationContext
+    ) -> TaggedObjectNode | TaggedListNode | TaggedScalarNode:
+        from astropy.time import Time
+
+        from ._registry import NODE_CLASSES_BY_TAG
+
         if "file_date" in tag:
             converter = ctx.extension_manager.get_converter_for_type(Time)
             node = converter.from_yaml_tree(node, tag, ctx)
@@ -89,7 +95,7 @@ class TaggedNodeConverter(_RomanConverter):
 
         return tuple(NODE_CLASSES)
 
-    def to_yaml_tree(self, obj: _TaggedNodeMixin, tag: str, ctx: SerializationContext) -> SerializationNode:
+    def to_yaml_tree(self, obj: _TaggedNodeMixin, tag: str, ctx: SerializationContext) -> ManifestNode:
         return obj.to_asdf_tree(ctx)
 
     def from_yaml_tree(self, node: dict[str, Any], tag: str, ctx: SerializationContext):

--- a/src/roman_datamodels/_stnode/_converters.py
+++ b/src/roman_datamodels/_stnode/_converters.py
@@ -4,30 +4,17 @@ The ASDF Converters to handle the serialization/deseialization of the STNode cla
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from asdf.extension import Converter
+from asdf.extension import Converter, SerializationContext
 from astropy.time import Time
 
-from ._registry import (
-    LIST_NODE_CLASSES_BY_PATTERN,
-    MANIFEST_TAG_REGISTRY,
-    NODE_CLASSES_BY_TAG,
-    NODE_CONVERTERS,
-    OBJECT_NODE_CLASSES_BY_PATTERN,
-    SCALAR_NODE_CLASSES_BY_PATTERN,
-    SERIALIZATION_BY_MANIFEST,
-    TAG_MANIFEST_REGISTRY,
-)
+from ._registry import MANIFEST_TAG_REGISTRY, NODE_CLASSES_BY_TAG, SERIALIZATION_BY_MANIFEST
 
 if TYPE_CHECKING:
-    from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode
+    from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode, _TaggedNodeMixin
 
-__all__ = [
-    "TaggedListNodeConverter",
-    "TaggedObjectNodeConverter",
-    "TaggedScalarNodeConverter",
-]
+__all__ = ("SerializationNodeConverter", "TaggedNodeConverter")
 
 
 class _RomanConverter(Converter):
@@ -72,73 +59,38 @@ class SerializationNodeConverter(_RomanConverter):
         return obj
 
 
-class _TaggedNodeConverter(_RomanConverter):
-    def __init_subclass__(cls, **kwargs) -> None:
-        """
-        Automatically create the converter objects.
-        """
-        super().__init_subclass__(**kwargs)
+class TaggedNodeConverter(_RomanConverter):
+    """
+    The converter which handles all Tagged Nodes
+        This converter will defer final ASDF serialization to the ManifestNodeConverter
+        so that the extensions recorded in the ASDF file's history section are property
+        attributed to the correct manifest.
+    """
 
-        if not cls.__name__.startswith("_"):
-            if cls.__name__ in NODE_CONVERTERS:
-                raise ValueError(f"Duplicate converter for {cls.__name__}")
+    _instance: ClassVar[TaggedNodeConverter | None] = None
 
-            NODE_CONVERTERS[cls.__name__] = cls()
+    # Make a singleton
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls, *args, **kwargs)
 
-    def select_tag(self, obj, tags, ctx):
+        return cls._instance
+
+    def select_tag(self, obj: _TaggedNodeMixin, tags: tuple[str, ...], ctx: SerializationContext) -> None:
         return None
 
     @property
     def tags(self) -> tuple:
         return ()
 
-    def to_yaml_tree(self, obj, tag, ctx):
-        return SERIALIZATION_BY_MANIFEST[TAG_MANIFEST_REGISTRY[tag]](obj, tag)
+    @property
+    def types(self) -> tuple[type[_TaggedNodeMixin], ...]:
+        from ._stnode import NODE_CLASSES
 
-    def from_yaml_tree(self, node, tag, ctx):
+        return tuple(NODE_CLASSES)
+
+    def to_yaml_tree(self, obj: _TaggedNodeMixin, tag: str, ctx: SerializationContext) -> SerializationNode:
+        return obj.to_asdf_tree(ctx)
+
+    def from_yaml_tree(self, node: dict[str, Any], tag: str, ctx: SerializationContext):
         raise NotImplementedError("Converter deserialization deferred")
-
-
-class TaggedObjectNodeConverter(_TaggedNodeConverter):
-    """
-    Converter for all subclasses of TaggedObjectNode.
-    """
-
-    @property
-    def types(self):
-        return tuple(OBJECT_NODE_CLASSES_BY_PATTERN.values())
-
-    def to_yaml_tree(self, obj: TaggedObjectNode, tag, ctx):
-        return super().to_yaml_tree(dict(obj._data), obj.tag, ctx)
-
-
-class TaggedListNodeConverter(_TaggedNodeConverter):
-    """
-    Converter for all subclasses of TaggedListNode.
-    """
-
-    @property
-    def types(self):
-        return tuple(LIST_NODE_CLASSES_BY_PATTERN.values())
-
-    def to_yaml_tree(self, obj, tag, ctx):
-        return super().to_yaml_tree(list(obj), obj.tag, ctx)
-
-
-class TaggedScalarNodeConverter(_TaggedNodeConverter):
-    """
-    Converter for all subclasses of TaggedScalarNode.
-    """
-
-    @property
-    def types(self):
-        return list(SCALAR_NODE_CLASSES_BY_PATTERN.values())
-
-    def to_yaml_tree(self, obj, tag, ctx):
-        node = type(obj).__bases__[0](obj)
-
-        if "file_date" in obj.tag:
-            converter = ctx.extension_manager.get_converter_for_type(type(node))
-            node = converter.to_yaml_tree(node, tag, ctx)
-
-        return super().to_yaml_tree(node, obj.tag, ctx)

--- a/src/roman_datamodels/_stnode/_manifest.py
+++ b/src/roman_datamodels/_stnode/_manifest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, ClassVar, Self
+
+from asdf.extension import ManifestExtension
+
+from ._converters import ManifestNodeConverter, TaggedNodeConverter
+
+__all__ = ("ManifestNode",)
+
+
+class ManifestNode:
+    """
+    Intermediate "Node" class that is used to assist in ASDF serialization of TaggedNode(s)
+        so that the extensions recorded in the ASDF file's history section are properly
+        attributed to the correct manifest.
+    """
+
+    __slots__ = ("_data", "_tag")
+    manifest_uri: ClassVar[str]
+    extension: ClassVar[ManifestExtension]
+
+    # TODO: Fix the Any hint here
+    def __init__(self, data: Any, tag: str):
+        self._data = data
+        self._tag = tag
+
+    @property
+    def data(self) -> Any:
+        return self._data
+
+    @property
+    def tag(self) -> str:
+        return self._tag
+
+    @classmethod
+    def _with_asdf_extension(cls) -> type[Self]:
+        """
+        Return ManifestNode with the appropriate ASDF extension added for the manifest
+        """
+
+        if not hasattr(cls, "extension"):
+            cls.extension = ManifestExtension.from_uri(
+                cls.manifest_uri,
+                converters=(ManifestNodeConverter(cls), TaggedNodeConverter()),
+            )
+
+        return cls
+
+    @staticmethod
+    def factory(uri: str) -> type[ManifestNode]:
+        """
+        Factory method to create a ManifestNode subclass with the given manifest URI.
+        """
+
+        # We can just create a local subclass of ManifestNode instead of with
+        #    type() since we don't actually care about the name of the class
+        class _ManifestNode(ManifestNode):
+            __slots__ = ()
+            manifest_uri: ClassVar[str] = uri
+
+        return _ManifestNode._with_asdf_extension()

--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -9,15 +9,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ._converters import _RomanConverter
     from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
 
 OBJECT_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedObjectNode]] = {}
 LIST_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedListNode]] = {}
 SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
-NODE_CONVERTERS: dict[str, type[_RomanConverter]] = {}
 NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
 SCHEMA_URIS_BY_TAG: dict[str, str] = {}
 SERIALIZATION_BY_MANIFEST: dict[str, type[SerializationNode]] = {}
 MANIFEST_TAG_REGISTRY: dict[str, list[str]] = {}
-TAG_MANIFEST_REGISTRY: dict[str, str] = {}
+TAG_MANIFEST_REGISTRY: dict[str, type[SerializationNode]] = {}

--- a/src/roman_datamodels/_stnode/_registry.py
+++ b/src/roman_datamodels/_stnode/_registry.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ._tagged import SerializationNode, TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
+    from ._manifest import ManifestNode
+    from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode, tagged_type
 
 OBJECT_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedObjectNode]] = {}
 LIST_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedListNode]] = {}
 SCALAR_NODE_CLASSES_BY_PATTERN: dict[str, type[TaggedScalarNode]] = {}
 NODE_CLASSES_BY_TAG: dict[str, tagged_type] = {}
 SCHEMA_URIS_BY_TAG: dict[str, str] = {}
-SERIALIZATION_BY_MANIFEST: dict[str, type[SerializationNode]] = {}
 MANIFEST_TAG_REGISTRY: dict[str, list[str]] = {}
-TAG_MANIFEST_REGISTRY: dict[str, type[SerializationNode]] = {}
+TAG_MANIFEST_REGISTRY: dict[str, type[ManifestNode]] = {}

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -13,8 +13,8 @@ import yaml
 from asdf.extension import ManifestExtension
 from rad import resources
 
-from ._converters import SerializationNodeConverter, TaggedNodeConverter
 from ._factories import stnode_factory
+from ._manifest import ManifestNode
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
     MANIFEST_TAG_REGISTRY,
@@ -24,7 +24,6 @@ from ._registry import (
     SCHEMA_URIS_BY_TAG,
     TAG_MANIFEST_REGISTRY,
 )
-from ._tagged import SerializationNode
 
 __all__ = ["NODE_CLASSES", "NODE_EXTENSIONS"]
 
@@ -63,10 +62,8 @@ def _factory(pattern, latest_manifest, tag_def):
 _generated = {}
 NODE_EXTENSIONS: dict[str, ManifestExtension] = {}
 for manifest in _MANIFESTS:
-    _serialization = _add_cls(SerializationNode._factory(manifest_uri := manifest["id"]))
-    NODE_EXTENSIONS[manifest_uri] = ManifestExtension.from_uri(
-        manifest_uri, converters=(SerializationNodeConverter(manifest_uri), TaggedNodeConverter())
-    )
+    _manifest = _add_cls(ManifestNode.factory(manifest_uri := manifest["id"]))
+    NODE_EXTENSIONS[manifest_uri] = _manifest.extension
 
     MANIFEST_TAG_REGISTRY[manifest_uri] = []
     for tag_def in manifest["tags"]:
@@ -81,7 +78,7 @@ for manifest in _MANIFESTS:
 
         # Make serialization intermediate
         if tag_uri not in TAG_MANIFEST_REGISTRY:
-            TAG_MANIFEST_REGISTRY[tag_uri] = _serialization
+            TAG_MANIFEST_REGISTRY[tag_uri] = _manifest
             MANIFEST_TAG_REGISTRY[manifest_uri].append(tag_uri)
 
 

--- a/src/roman_datamodels/_stnode/_stnode.py
+++ b/src/roman_datamodels/_stnode/_stnode.py
@@ -13,13 +13,12 @@ import yaml
 from asdf.extension import ManifestExtension
 from rad import resources
 
-from ._converters import SerializationNodeConverter
+from ._converters import SerializationNodeConverter, TaggedNodeConverter
 from ._factories import stnode_factory
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
     MANIFEST_TAG_REGISTRY,
     NODE_CLASSES_BY_TAG,
-    NODE_CONVERTERS,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SCHEMA_URIS_BY_TAG,
@@ -62,8 +61,12 @@ def _factory(pattern, latest_manifest, tag_def):
 # Main dynamic class creation loop
 #   Reads each tag entry from the manifest and creates a class for it
 _generated = {}
+NODE_EXTENSIONS: dict[str, ManifestExtension] = {}
 for manifest in _MANIFESTS:
-    _add_cls(SerializationNode._factory(manifest_uri := manifest["id"]))
+    _serialization = _add_cls(SerializationNode._factory(manifest_uri := manifest["id"]))
+    NODE_EXTENSIONS[manifest_uri] = ManifestExtension.from_uri(
+        manifest_uri, converters=(SerializationNodeConverter(manifest_uri), TaggedNodeConverter())
+    )
 
     MANIFEST_TAG_REGISTRY[manifest_uri] = []
     for tag_def in manifest["tags"]:
@@ -78,18 +81,8 @@ for manifest in _MANIFESTS:
 
         # Make serialization intermediate
         if tag_uri not in TAG_MANIFEST_REGISTRY:
-            TAG_MANIFEST_REGISTRY[tag_uri] = manifest_uri
+            TAG_MANIFEST_REGISTRY[tag_uri] = _serialization
             MANIFEST_TAG_REGISTRY[manifest_uri].append(tag_uri)
-
-
-# Create the ASDF extension for the STNode classes.
-#    ASDF extension is setup here so that it is after the dynamic object creation
-NODE_EXTENSIONS = {
-    manifest_uri: ManifestExtension.from_uri(
-        manifest_uri, converters=(SerializationNodeConverter(manifest_uri), *tuple(NODE_CONVERTERS.values()))
-    )
-    for manifest_uri in MANIFEST_TAG_REGISTRY
-}
 
 
 # List of node classes made available by this library.

--- a/src/roman_datamodels/_stnode/_stnode.pyi
+++ b/src/roman_datamodels/_stnode/_stnode.pyi
@@ -2,7 +2,7 @@ from typing import Any
 
 from asdf.extension import ManifestExtension
 
-from ._tagged import TaggedObjectNode
+from ._tagged import TaggedListNode, TaggedObjectNode, TaggedScalarNode
 
 class AbvegaoffsetRef(TaggedObjectNode): ...
 class ApcorrRef(TaggedObjectNode): ...
@@ -50,3 +50,4 @@ class WfiWcs(TaggedObjectNode): ...
 
 _MANIFESTS: list[dict[str, Any]]
 NODE_EXTENSIONS: dict[str, ManifestExtension]
+NODE_CLASSES: list[type[TaggedObjectNode | TaggedListNode | TaggedScalarNode]]

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -7,7 +7,8 @@ Base classes for all the tagged objects defined by RAD.
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Generic, TypeVar
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Generic, TypeVar, final
 
 from ._node import DNode, LNode
 from ._registry import (
@@ -15,12 +16,15 @@ from ._registry import (
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
     SERIALIZATION_BY_MANIFEST,
+    TAG_MANIFEST_REGISTRY,
 )
 from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, _get_schema_from_tag
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping
     from typing import Any, ClassVar, Self, TypeAlias
+
+    from asdf.extension import SerializationContext
 
     from ._node import _NodeMixin as NodeMixin
 else:
@@ -191,6 +195,29 @@ class _TaggedNodeMixin(NodeMixin):
         """Retrieve the schema associated with this tag"""
         return _get_schema_from_tag(self.tag)
 
+    @abstractmethod
+    def _to_asdf_tree(self, ctx: SerializationContext) -> Any:
+        """
+        Convert this object to a ManifestNode for ASDF serialization.
+
+        Parameters
+        ----------
+        ctx: SerializationContext
+            The ASDF serialization context to use when converting this object to a ManifestNode.
+        """
+
+    @final
+    def to_asdf_tree(self, ctx: SerializationContext) -> SerializationNode:
+        """
+        Convert this object to a ManifestNode for ASDF serialization.
+
+        Parameters
+        ----------
+        ctx: SerializationContext
+            The ASDF serialization context to use when converting this object to a ManifestNode.
+        """
+        return TAG_MANIFEST_REGISTRY[self._tag](data=self._to_asdf_tree(ctx), tag=self._tag)
+
 
 class TaggedObjectNode(DNode, _TaggedNodeMixin):
     """
@@ -212,6 +239,9 @@ class TaggedObjectNode(DNode, _TaggedNodeMixin):
                 raise RuntimeError(f"TaggedObjectNode class for tag '{cls._pattern}' has been defined twice")
             OBJECT_NODE_CLASSES_BY_PATTERN[cls._pattern] = cls
 
+    def _to_asdf_tree(self, ctx: SerializationContext) -> Any:
+        return dict(self._data)
+
 
 class TaggedListNode(LNode, _TaggedNodeMixin):
     """
@@ -232,6 +262,9 @@ class TaggedListNode(LNode, _TaggedNodeMixin):
             if cls._pattern in LIST_NODE_CLASSES_BY_PATTERN:
                 raise RuntimeError(f"TaggedListNode class for tag '{cls._pattern}' has been defined twice")
             LIST_NODE_CLASSES_BY_PATTERN[cls._pattern] = cls
+
+    def _to_asdf_tree(self, ctx: SerializationContext) -> Any:
+        return list(self.data)
 
 
 class TaggedScalarNode(_TaggedNodeMixin):
@@ -275,6 +308,17 @@ class TaggedScalarNode(_TaggedNodeMixin):
 
     def copy(self):
         return copy.copy(self)
+
+    def _to_asdf_tree(self, ctx: SerializationContext) -> Any:
+        from astropy.time import Time
+
+        match self:
+            case str():
+                return str(self)
+
+            case Time():
+                converter = ctx.extension_manager.get_converter_for_type(Time)
+                return converter.to_yaml_tree(self, self._tag, ctx)
 
 
 _T = TypeVar("_T", bound=TaggedObjectNode | TaggedListNode | TaggedScalarNode)

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -8,14 +8,13 @@ from __future__ import annotations
 
 import copy
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Generic, TypeVar, final
+from typing import TYPE_CHECKING, final
 
 from ._node import DNode, LNode
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
     OBJECT_NODE_CLASSES_BY_PATTERN,
     SCALAR_NODE_CLASSES_BY_PATTERN,
-    SERIALIZATION_BY_MANIFEST,
     TAG_MANIFEST_REGISTRY,
 )
 from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, _get_schema_from_tag
@@ -26,11 +25,12 @@ if TYPE_CHECKING:
 
     from asdf.extension import SerializationContext
 
+    from ._manifest import ManifestNode
     from ._node import _NodeMixin as NodeMixin
 else:
     NodeMixin: TypeAlias = object
 
-__all__ = ["SerializationNode", "TaggedListNode", "TaggedObjectNode", "TaggedScalarNode"]
+__all__ = ["TaggedListNode", "TaggedObjectNode", "TaggedScalarNode"]
 
 
 def name_from_tag_uri(tag_uri: str) -> str:
@@ -207,7 +207,7 @@ class _TaggedNodeMixin(NodeMixin):
         """
 
     @final
-    def to_asdf_tree(self, ctx: SerializationContext) -> SerializationNode:
+    def to_asdf_tree(self, ctx: SerializationContext) -> ManifestNode:
         """
         Convert this object to a ManifestNode for ASDF serialization.
 
@@ -319,54 +319,6 @@ class TaggedScalarNode(_TaggedNodeMixin):
             case Time():
                 converter = ctx.extension_manager.get_converter_for_type(Time)
                 return converter.to_yaml_tree(self, self._tag, ctx)
-
-
-_T = TypeVar("_T", bound=TaggedObjectNode | TaggedListNode | TaggedScalarNode)
-
-
-class SerializationNode(Generic[_T]):
-    """
-    Intermediate class used to assist in serialization of Tagged objects
-    so that the extension is correctly written.
-    """
-
-    _manifest: ClassVar[str]
-
-    def __init_subclass__(cls, **kwargs) -> None:
-        """
-        Register any subclasses of this class in the SCALAR_NODE_CLASSES_BY_PATTERN registry.
-        """
-        super().__init_subclass__(**kwargs)
-        if cls.__name__ != "SerializationTaggedNode":
-            if cls._manifest in SERIALIZATION_BY_MANIFEST:
-                raise RuntimeError(f"SerializationNode class for '{cls._manifest}' has been defined twice")
-            SERIALIZATION_BY_MANIFEST[cls._manifest] = cls
-
-    def __init__(self, data: _T, tag: str):
-        self._data = data
-        self._tag = tag
-
-    @property
-    def tag(self) -> str:
-        return self._tag
-
-    @property
-    def data(self) -> _T:
-        return self._data
-
-    @classmethod
-    def _factory(cls, manifest: str) -> type[SerializationNode]:
-        """Create a subclass of this for the given tag"""
-        tag_uri, version = manifest.rsplit("-", maxsplit=1)
-
-        return type(
-            f"SerializationNode_{class_name_from_tag_uri(tag_uri)}__{version.replace('.', '_')}",
-            (SerializationNode,),
-            {
-                "_manifest": manifest,
-                "__module__": "roman_datamodels._stnode",
-            },
-        )
 
 
 tagged_type: TypeAlias = type[TaggedObjectNode] | type[TaggedListNode] | type[TaggedScalarNode]

--- a/src/roman_datamodels/_stnode/_tagged.py
+++ b/src/roman_datamodels/_stnode/_tagged.py
@@ -10,6 +10,8 @@ import copy
 from abc import abstractmethod
 from typing import TYPE_CHECKING, final
 
+from asdf.extension import SerializationContext
+
 from ._node import DNode, LNode
 from ._registry import (
     LIST_NODE_CLASSES_BY_PATTERN,
@@ -22,8 +24,6 @@ from ._schema import _NO_VALUE, Builder, FakeDataBuilder, NodeBuilder, _get_sche
 if TYPE_CHECKING:
     from collections.abc import Mapping, MutableMapping
     from typing import Any, ClassVar, Self, TypeAlias
-
-    from asdf.extension import SerializationContext
 
     from ._manifest import ManifestNode
     from ._node import _NodeMixin as NodeMixin
@@ -202,7 +202,7 @@ class _TaggedNodeMixin(NodeMixin):
 
         Parameters
         ----------
-        ctx: SerializationContext
+        ctx:
             The ASDF serialization context to use when converting this object to a ManifestNode.
         """
 
@@ -213,7 +213,7 @@ class _TaggedNodeMixin(NodeMixin):
 
         Parameters
         ----------
-        ctx: SerializationContext
+        ctx:
             The ASDF serialization context to use when converting this object to a ManifestNode.
         """
         return TAG_MANIFEST_REGISTRY[self._tag](data=self._to_asdf_tree(ctx), tag=self._tag)

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -59,9 +59,9 @@ def test_history(tmp_path, node_tag, node_instance):
 
     datamodel_uris = sorted([extension_uri.replace("extensions", "manifests") for extension_uri in extension_uris])
     # node_tag should be the list of datamodel_uris
-    assert TAG_MANIFEST_REGISTRY[node_tag] in datamodel_uris
+    assert TAG_MANIFEST_REGISTRY[node_tag]._manifest in datamodel_uris
 
     # If a tag is in a given manifest then all of its referenced tags are also in that manifest
     #    so the earliest manifest and extension can be is the latest one for the node_tag.
     #    all other manifests must be the same or newer.
-    assert TAG_MANIFEST_REGISTRY[node_tag] == datamodel_uris[0]
+    assert TAG_MANIFEST_REGISTRY[node_tag]._manifest == datamodel_uris[0]

--- a/tests/stnode/test_save.py
+++ b/tests/stnode/test_save.py
@@ -59,9 +59,9 @@ def test_history(tmp_path, node_tag, node_instance):
 
     datamodel_uris = sorted([extension_uri.replace("extensions", "manifests") for extension_uri in extension_uris])
     # node_tag should be the list of datamodel_uris
-    assert TAG_MANIFEST_REGISTRY[node_tag]._manifest in datamodel_uris
+    assert TAG_MANIFEST_REGISTRY[node_tag].manifest_uri in datamodel_uris
 
     # If a tag is in a given manifest then all of its referenced tags are also in that manifest
     #    so the earliest manifest and extension can be is the latest one for the node_tag.
     #    all other manifests must be the same or newer.
-    assert TAG_MANIFEST_REGISTRY[node_tag]._manifest == datamodel_uris[0]
+    assert TAG_MANIFEST_REGISTRY[node_tag].manifest_uri == datamodel_uris[0]


### PR DESCRIPTION
This PR refactors the ASDF converter support for RDM so that there are fewer converters and moves the directly manifest related objects into its own module.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
