### PR TITLE
fix test for pytest 9.1

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -264,7 +264,7 @@ def test_datamodel_schema_info_values():
 
 
 @pytest.mark.parametrize(
-    "name", (name for name in datamodel_names() if not name.startswith("Fps") and not name.startswith("Tvac"))
+    "name", [name for name in datamodel_names() if not name.startswith("Fps") and not name.startswith("Tvac")]
 )
 def test_datamodel_schema_info_existence(name):
     # Loop over datamodels that have archive_catalog entries


### PR DESCRIPTION
Fix one test that used a generator to parametrize a test. In python 9.1 this causes a warning (that gets turned into an error). This PR replaces it with a list.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
