### PR TITLE
Set array_inline_threshold to save small arrays in the YAML tree.

### DIFF
--- a/changes/686.feature.rst
+++ b/changes/686.feature.rst
@@ -1,0 +1,1 @@
+Save small arrays "inline" rather than storing them in binary ASDF blocks.

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -526,9 +526,9 @@ class FakeDataBuilder(Builder):
     def make_array(self, schema, defaults):
         import numpy as np
 
-        ndim = _get_keyword(schema, "ndim") or 0
+        ndim = _get_keyword(schema, "ndim") or 1
         dtype = _get_keyword(schema, "datatype") or "float32"
-        shape = [0] * ndim
+        shape = [1] * ndim
         if self._shape is not None:
             for i, v in enumerate(self._shape):
                 if i == len(shape):

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -526,6 +526,10 @@ class FakeDataBuilder(Builder):
     def make_array(self, schema, defaults):
         import numpy as np
 
+        # Ideally we default to 0 instead of 1 for ndim and shape here but
+        # cannot until asdf fixes issues with 0-length inline arrays.
+        # Likely we can switch back to 1 when our minimum asdf version is 5.4
+        # which is not yet released.
         ndim = _get_keyword(schema, "ndim") or 1
         dtype = _get_keyword(schema, "datatype") or "float32"
         shape = [1] * ndim

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -22,6 +22,7 @@ import asdf
 import numpy as np
 from asdf.exceptions import ValidationError
 from asdf.tags.core.ndarray import NDArrayType
+from asdf.util import NotSet
 from astropy.time import Time
 
 from roman_datamodels._stnode import NODE_EXTENSIONS, DNode, TaggedObjectNode
@@ -275,13 +276,15 @@ class DataModel(abc.ABC):
         target._files_to_close = []
         target._shape = source._shape
 
-    def save(self, path, dir_path=None, *args, all_array_compression="lz4", **kwargs):
+    def save(self, path, dir_path=None, *args, all_array_compression="lz4", all_array_storage=NotSet, **kwargs):
         path = Path(path(self.meta.filename) if callable(path) else path)
         output_path = Path(dir_path) / path.name if dir_path else path
         ext = path.suffix.decode(sys.getfilesystemencoding()) if isinstance(path.suffix, bytes) else path.suffix
 
         if ext == ".asdf":
-            self.to_asdf(output_path, *args, all_array_compression=all_array_compression, **kwargs)
+            self.to_asdf(
+                output_path, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
+            )
         elif ext == ".parquet" and hasattr(self, "to_parquet"):
             self.to_parquet(output_path)
         else:
@@ -297,23 +300,20 @@ class DataModel(abc.ABC):
 
         return asdf.AsdfFile(init, **kwargs)
 
-    def to_asdf(self, init, *args, all_array_compression="lz4", **kwargs):
+    def to_asdf(self, init, *args, all_array_compression="lz4", all_array_storage=NotSet, **kwargs):
         from ._utils import temporary_update_filedate, temporary_update_filename
 
         with (
             temporary_update_filename(self, Path(init).name),
             temporary_update_filedate(self, Time.now()),
         ):
-            all_array_storage = kwargs.pop("all_array_storage", None)
             asdf_file = self.open_asdf(**kwargs)
             asdf_file["roman"] = self._instance
             with asdf.config_context() as cfg:
                 # only set array inline threshold if not already set by the user
-                if cfg.array_inline_threshold is None and all_array_storage is None:
+                if cfg.array_inline_threshold is None and all_array_storage is NotSet:
                     cfg.array_inline_threshold = DEFAULT_ARRAY_INLINE_THRESHOLD
 
-                if all_array_storage is not None:
-                    kwargs["all_array_storage"] = all_array_storage
                 asdf_file.write_to(init, *args, all_array_compression=all_array_compression, **kwargs)
 
     def get_primary_array_name(self):

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -314,7 +314,9 @@ class DataModel(abc.ABC):
                 if cfg.array_inline_threshold is None and all_array_storage is NotSet:
                     cfg.array_inline_threshold = DEFAULT_ARRAY_INLINE_THRESHOLD
 
-                asdf_file.write_to(init, *args, all_array_compression=all_array_compression, **kwargs)
+                asdf_file.write_to(
+                    init, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
+                )
 
     def get_primary_array_name(self):
         """

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -34,6 +34,8 @@ __all__ = ["MODEL_REGISTRY", "DataModel"]
 
 MODEL_REGISTRY: dict[str, type[DataModel]] = {}
 
+DEFAULT_ARRAY_INLINE_THRESHOLD = 512
+
 
 def _set_default_asdf(func):
     """
@@ -273,15 +275,13 @@ class DataModel(abc.ABC):
         target._files_to_close = []
         target._shape = source._shape
 
-    def save(self, path, dir_path=None, *args, all_array_compression="lz4", all_array_storage="internal", **kwargs):
+    def save(self, path, dir_path=None, *args, all_array_compression="lz4", **kwargs):
         path = Path(path(self.meta.filename) if callable(path) else path)
         output_path = Path(dir_path) / path.name if dir_path else path
         ext = path.suffix.decode(sys.getfilesystemencoding()) if isinstance(path.suffix, bytes) else path.suffix
 
         if ext == ".asdf":
-            self.to_asdf(
-                output_path, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
-            )
+            self.to_asdf(output_path, *args, all_array_compression=all_array_compression, **kwargs)
         elif ext == ".parquet" and hasattr(self, "to_parquet"):
             self.to_parquet(output_path)
         else:
@@ -297,24 +297,24 @@ class DataModel(abc.ABC):
 
         return asdf.AsdfFile(init, **kwargs)
 
-    def to_asdf(self, init, *args, all_array_compression="lz4", all_array_storage=None, **kwargs):
+    def to_asdf(self, init, *args, all_array_compression="lz4", **kwargs):
         from ._utils import temporary_update_filedate, temporary_update_filename
 
         with (
             temporary_update_filename(self, Path(init).name),
             temporary_update_filedate(self, Time.now()),
         ):
+            all_array_storage = kwargs.pop("all_array_storage", None)
             asdf_file = self.open_asdf(**kwargs)
             asdf_file["roman"] = self._instance
             with asdf.config_context() as cfg:
                 # only set array inline threshold if not already set by the user
                 if cfg.array_inline_threshold is None and all_array_storage is None:
-                    # inline arrays 512 bytes or less
-                    cfg.array_inline_threshold = 512
+                    cfg.array_inline_threshold = DEFAULT_ARRAY_INLINE_THRESHOLD
 
-                asdf_file.write_to(
-                    init, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
-                )
+                if all_array_storage is not None:
+                    kwargs["all_array_storage"] = all_array_storage
+                asdf_file.write_to(init, *args, all_array_compression=all_array_compression, **kwargs)
 
     def get_primary_array_name(self):
         """

--- a/src/roman_datamodels/datamodels/_core.py
+++ b/src/roman_datamodels/datamodels/_core.py
@@ -278,7 +278,6 @@ class DataModel(abc.ABC):
         output_path = Path(dir_path) / path.name if dir_path else path
         ext = path.suffix.decode(sys.getfilesystemencoding()) if isinstance(path.suffix, bytes) else path.suffix
 
-        # TODO: Support gzip-compressed fits
         if ext == ".asdf":
             self.to_asdf(
                 output_path, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
@@ -298,7 +297,7 @@ class DataModel(abc.ABC):
 
         return asdf.AsdfFile(init, **kwargs)
 
-    def to_asdf(self, init, *args, all_array_compression="lz4", all_array_storage="internal", **kwargs):
+    def to_asdf(self, init, *args, all_array_compression="lz4", all_array_storage=None, **kwargs):
         from ._utils import temporary_update_filedate, temporary_update_filename
 
         with (
@@ -307,9 +306,15 @@ class DataModel(abc.ABC):
         ):
             asdf_file = self.open_asdf(**kwargs)
             asdf_file["roman"] = self._instance
-            asdf_file.write_to(
-                init, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
-            )
+            with asdf.config_context() as cfg:
+                # only set array inline threshold if not already set by the user
+                if cfg.array_inline_threshold is None and all_array_storage is None:
+                    # inline arrays 512 bytes or less
+                    cfg.array_inline_threshold = 512
+
+                asdf_file.write_to(
+                    init, *args, all_array_compression=all_array_compression, all_array_storage=all_array_storage, **kwargs
+                )
 
     def get_primary_array_name(self):
         """

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -617,9 +617,8 @@ class SkycellsRefModel(DataModel):
         # Set all SkycellRefModel arrays to internal so test
         # files with unrealistically small arrays don't get inlined
         # triggering: https://github.com/spacetelescope/rad/issues/887
-        if "all_array_storage" not in kwargs:
-            kwargs["all_array_storage"] = "internal"
-        return super().to_asdf(*args, **kwargs)
+        kwargs.pop("all_array_storage")
+        return super().to_asdf(*args, all_array_storage="internal", **kwargs)
 
 
 class SuperbiasRefModel(DataModel):

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -613,6 +613,11 @@ class SkycellsRefModel(DataModel):
     __slots__ = ()
     _node_type = SkycellsRef
 
+    def to_asdf(self, *args, **kwargs):
+        if "all_array_storage" not in kwargs:
+            kwargs["all_array_storage"] = "internal"
+        return super().to_asdf(*args, **kwargs)
+
 
 class SuperbiasRefModel(DataModel):
     from roman_datamodels._stnode import SuperbiasRef

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -614,6 +614,9 @@ class SkycellsRefModel(DataModel):
     _node_type = SkycellsRef
 
     def to_asdf(self, *args, **kwargs):
+        # Set all SkycellRefModel arrays to internal so test
+        # files with unrealistically small arrays don't get inlined
+        # triggering: https://github.com/spacetelescope/rad/issues/887
         if "all_array_storage" not in kwargs:
             kwargs["all_array_storage"] = "internal"
         return super().to_asdf(*args, **kwargs)

--- a/tests/stnode/test_schema.py
+++ b/tests/stnode/test_schema.py
@@ -219,14 +219,14 @@ def test_node_builder_tag_mismatch(tag, value):
 @pytest.mark.parametrize(
     "ndim, shape, expected",
     (
-        (None, None, tuple()),
-        (1, None, (0,)),
-        (2, None, (0, 0)),
-        (None, (10, 20, 30), tuple()),
+        (None, None, (1,)),
+        (1, None, (1,)),
+        (2, None, (1, 1)),
+        (None, (10, 20, 30), (10,)),
         (1, (10, 20, 30), (10,)),
         (2, (10, 20, 30), (10, 20)),
         (3, (10, 20, 30), (10, 20, 30)),
-        (4, (10, 20, 30), (10, 20, 30, 0)),
+        (4, (10, 20, 30), (10, 20, 30, 1)),
     ),
 )
 def test_array_shape(ndim, shape, expected):

--- a/tests/test_moc_expectations.py
+++ b/tests/test_moc_expectations.py
@@ -16,6 +16,8 @@ def test_l2_compression(tmp_path):
     Test that L2 files use lz4 compression.
     """
     fn = tmp_path / "test.asdf"
+    # Set shape large enough to make sure the arrays are stored
+    # in internal ASDF blocks instead of inline (which won't be compressed).
     ImageModel.create_fake_data(shape=(1000, 1000)).save(fn)
 
     compression_codes = set()

--- a/tests/test_moc_expectations.py
+++ b/tests/test_moc_expectations.py
@@ -16,7 +16,7 @@ def test_l2_compression(tmp_path):
     Test that L2 files use lz4 compression.
     """
     fn = tmp_path / "test.asdf"
-    ImageModel.create_fake_data().save(fn)
+    ImageModel.create_fake_data(shape=(1000, 1000)).save(fn)
 
     compression_codes = set()
     with asdf.open(fn) as af:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -595,7 +595,7 @@ def test_array_compression_override(tmp_path, compression):
         assert af.get_array_compression(af["roman"]["data"]) == compression
 
 
-@pytest.mark.parametrize("storage", [None, "inline", "internal", "external"])
+@pytest.mark.parametrize("storage", ["inline", "internal", "external"])
 def test_array_storage_override(tmp_path, storage):
     """
     Test that providing a compression argument changes the
@@ -605,7 +605,7 @@ def test_array_storage_override(tmp_path, storage):
     model = datamodels.ImageModel.create_fake_data(shape=(DEFAULT_ARRAY_INLINE_THRESHOLD + 1, 1))
     model.save(fn, all_array_storage=storage)
     with asdf.open(fn) as af:
-        assert af.get_array_storage(af["roman"]["data"]) == "internal" if storage is None else storage
+        assert af.get_array_storage(af["roman"]["data"]) == storage
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -602,7 +602,7 @@ def test_array_storage_override(tmp_path, storage):
     array compression.
     """
     fn = tmp_path / "foo.asdf"
-    model = datamodels.ImageModel.create_fake_data(shape=(200, 200))
+    model = datamodels.ImageModel.create_fake_data(shape=(DEFAULT_ARRAY_INLINE_THRESHOLD + 1, 1))
     model.save(fn, all_array_storage=storage)
     with asdf.open(fn) as af:
         assert af.get_array_storage(af["roman"]["data"]) == "internal" if storage is None else storage
@@ -632,6 +632,9 @@ def test_array_inline_threshold(tmp_path, threshold, shape, storage):
 
 
 def test_wcs_array_inline(tmp_path):
+    """
+    Test that saving a file with a wcs with an array results in that array inline.
+    """
     fn = tmp_path / "foo.asdf"
     model = datamodels.ImageModel.create_fake_data()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,8 +6,12 @@ import asdf
 import numpy as np
 import pytest
 from asdf.exceptions import ValidationError
+from astropy import coordinates
 from astropy import units as u
+from astropy.modeling import models
 from astropy.time import Time
+from gwcs import coordinate_frames
+from gwcs.wcs import WCS
 from numpy.testing import assert_array_equal
 
 from roman_datamodels import datamodels
@@ -625,6 +629,38 @@ def test_array_inline_threshold(tmp_path, threshold, shape, storage):
         model.save(fn)
         with asdf.open(fn) as af:
             assert af.get_array_storage(af["roman"]["data"]) == storage
+
+
+def test_wcs_array_inline(tmp_path):
+    fn = tmp_path / "foo.asdf"
+    model = datamodels.ImageModel.create_fake_data()
+
+    # make a WCS with a model containing an array
+    transform = models.AffineTransformation2D([[1, 0], [0, 1]])
+
+    detector_frame = coordinate_frames.Frame2D(name="detector", axes_names=("x", "y"), unit=(u.pix, u.pix))
+    sky_frame = coordinate_frames.CelestialFrame(reference_frame=coordinates.ICRS(), name="icrs", unit=(u.deg, u.deg))
+    model.meta.wcs = WCS(
+        [
+            (detector_frame, transform),
+            (sky_frame, None),
+        ]
+    )
+    model.save(fn)
+
+    # load just the YAML from the ASDF file
+    wcs_tree = asdf.util.load_yaml(fn, tagged=True)["roman"]["meta"]["wcs"]
+
+    # Check for inline data (ndarray tagged items contain "data" and not "source")
+    for node in asdf.treeutil.iter_tree(wcs_tree):
+        tag = asdf.tagged.get_tag(node)
+        if not tag or "/ndarray-" not in tag:
+            continue
+        assert "data" in node
+
+    # Also check that the WCS is functional with no ASDF blocks
+    wcs = asdf.yamlutil.tagged_tree_to_custom_tree(wcs_tree, asdf.AsdfFile())
+    assert wcs.pixel_to_world_values(1, 1)
 
 
 def test_apcorr_none_array():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -597,7 +597,7 @@ def test_array_storage_override(tmp_path, storage):
     array compression.
     """
     fn = tmp_path / "foo.asdf"
-    model = datamodels.ImageModel.create_fake_data(shape=(2, 2))
+    model = datamodels.ImageModel.create_fake_data(shape=(200, 200))
     model.save(fn, all_array_storage=storage)
     with asdf.open(fn) as af:
         assert af.get_array_storage(af["roman"]["data"]) == "internal" if storage is None else storage

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,6 +27,7 @@ from roman_datamodels._stnode import (
 )
 from roman_datamodels._stnode._registry import NODE_CLASSES_BY_TAG
 from roman_datamodels._stnode._tagged import _NO_VALUE
+from roman_datamodels.datamodels._core import DEFAULT_ARRAY_INLINE_THRESHOLD
 from roman_datamodels.testing import assert_node_equal, assert_node_is_copy
 
 from .conftest import MANIFESTS
@@ -571,7 +572,7 @@ def test_default_array_compression(tmp_path):
     for default options.
     """
     fn = tmp_path / "foo.asdf"
-    model = datamodels.ImageModel.create_fake_data()
+    model = datamodels.ImageModel.create_fake_data(shape=(DEFAULT_ARRAY_INLINE_THRESHOLD + 1, 1))
     model.save(fn)
     with asdf.open(fn) as af:
         assert af.get_array_compression(af["roman"]["data"]) == "lz4"
@@ -584,7 +585,7 @@ def test_array_compression_override(tmp_path, compression):
     array compression.
     """
     fn = tmp_path / "foo.asdf"
-    model = datamodels.ImageModel.create_fake_data()
+    model = datamodels.ImageModel.create_fake_data(shape=(DEFAULT_ARRAY_INLINE_THRESHOLD + 1, 1))
     model.save(fn, all_array_compression=compression)
     with asdf.open(fn) as af:
         assert af.get_array_compression(af["roman"]["data"]) == compression
@@ -601,6 +602,29 @@ def test_array_storage_override(tmp_path, storage):
     model.save(fn, all_array_storage=storage)
     with asdf.open(fn) as af:
         assert af.get_array_storage(af["roman"]["data"]) == "internal" if storage is None else storage
+
+
+@pytest.mark.parametrize(
+    "threshold, shape, storage",
+    [
+        (100, (10, 1), "inline"),
+        (100, (100, 1), "internal"),
+        (None, (DEFAULT_ARRAY_INLINE_THRESHOLD // 10, 1), "inline"),
+        (None, (DEFAULT_ARRAY_INLINE_THRESHOLD * 2, 1), "internal"),
+    ],
+)
+def test_array_inline_threshold(tmp_path, threshold, shape, storage):
+    """
+    Test a provided array_inline_threshold is respected or the default is used.
+    """
+    fn = tmp_path / "foo.asdf"
+    # thresholds are in bytes, assuming data is 4 bytes per element
+    with asdf.config_context() as cfg:
+        cfg.array_inline_threshold = threshold
+        model = datamodels.ImageModel.create_fake_data(shape=shape)
+        model.save(fn)
+        with asdf.open(fn) as af:
+            assert af.get_array_storage(af["roman"]["data"]) == storage
 
 
 def test_apcorr_none_array():


### PR DESCRIPTION
Closes: https://github.com/spacetelescope/roman_datamodels/issues/681

Sets `array_inline_threshold` to trigger asdf to save small arrays (<512 bytes) inline (not in a binary block).

Some test code changes were needed to work around some asdf bugs (that are being addressed). Since these bugs only impact test code it seems reasonable to use the work arounds.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/28631348130/job/84909023280
all pass

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
