### PR TITLE
Deprecate from_science_raw and from_tvac_raw

### DIFF
--- a/changes/690.removal.rst
+++ b/changes/690.removal.rst
@@ -1,0 +1,1 @@
+Deprecate ``from_science_raw`` and ``from_tvac_raw`` use ``create_from_model`` instead.

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -13,6 +13,7 @@ import functools
 import itertools
 import logging
 import pathlib
+import warnings
 from collections import abc
 from typing import TYPE_CHECKING
 
@@ -380,6 +381,7 @@ class RampModel(_RomanDataModel):
             a RampModel, it is simply returned.
 
         """
+        warnings.warn("from_science_raw is deprecated. Use create_from_model instead", DeprecationWarning, stacklevel=2)
         ALLOWED_MODELS = (FpsModel, RampModel, ScienceRawModel, TvacModel)
 
         if isinstance(model, cls):

--- a/src/roman_datamodels/datamodels/_datamodels.py
+++ b/src/roman_datamodels/datamodels/_datamodels.py
@@ -317,6 +317,7 @@ class ScienceRawModel(_RomanDataModel):
             If the input was a ScienceRawModel, that model is simply returned.
 
         """
+        warnings.warn("from_tvac_raw is deprecated. Use create_from_model instead", DeprecationWarning, stacklevel=2)
         ALLOWED_MODELS = (FpsModel, ScienceRawModel, TvacModel)
 
         if isinstance(model, cls):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -346,7 +346,8 @@ def test_model_only_init_with_correct_node(node_class, correct, model):
 )
 def test_ramp_from_science_raw(mk_raw):
     raw = mk_raw()
-    ramp = datamodels.RampModel.from_science_raw(raw)
+    with pytest.warns(DeprecationWarning, match="from_science_raw is deprecated"):
+        ramp = datamodels.RampModel.from_science_raw(raw)
     for key in ramp:
         if not hasattr(raw, key):
             continue
@@ -385,7 +386,8 @@ def test_science_raw_missing_required():
     """Test that from_science_raw does not fill in required but missing values"""
     raw = datamodels.ScienceRawModel.create_fake_data()
     del raw.meta.exposure._data["hga_move"]
-    ramp = datamodels.RampModel.from_science_raw(raw)
+    with pytest.warns(DeprecationWarning, match="from_science_raw is deprecated"):
+        ramp = datamodels.RampModel.from_science_raw(raw)
     assert "hga_move" not in raw.meta.exposure
     with pytest.raises(ValidationError, match="hga_move"):
         ramp.validate()
@@ -528,12 +530,16 @@ def test_rampmodel_from_science_raw(model_class, expect_success):
         defaults={"meta": {"calibration_software_version": "1.2.3", "exposure": {"read_pattern": [[1], [2], [3]]}}}
     )
     if expect_success:
-        ramp = datamodels.RampModel.from_science_raw(model)
+        with pytest.warns(DeprecationWarning, match="from_science_raw is deprecated"):
+            ramp = datamodels.RampModel.from_science_raw(model)
 
         assert ramp.meta.calibration_software_version == model.meta.calibration_software_version
         assert ramp.meta.exposure.read_pattern == model.meta.exposure.read_pattern
     else:
-        with pytest.raises((ValueError, ValidationError)):
+        with (
+            pytest.raises((ValueError, ValidationError)),
+            pytest.warns(DeprecationWarning, match="from_science_raw is deprecated"),
+        ):
             datamodels.RampModel.from_science_raw(model)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -396,7 +396,7 @@ def test_science_raw_missing_required():
 def test_science_raw_from_tvac_raw_invalid_input():
     """Test for invalid input"""
     model = datamodels.RampModel.create_fake_data()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError), pytest.warns(DeprecationWarning, match="from_tvac_raw is deprecated"):
         _ = datamodels.ScienceRawModel.from_tvac_raw(model)
 
 
@@ -413,7 +413,8 @@ def test_science_raw_from_tvac_raw(mk_tvac):
     tvac = mk_tvac()
     tvac.meta.statistics = {"mean_counts_per_second": 1}
 
-    raw = datamodels.ScienceRawModel.from_tvac_raw(tvac)
+    with pytest.warns(DeprecationWarning, match="from_tvac_raw is deprecated"):
+        raw = datamodels.ScienceRawModel.from_tvac_raw(tvac)
     for key in raw:
         if not hasattr(tvac, key):
             continue


### PR DESCRIPTION
Work towards https://github.com/spacetelescope/roman_datamodels/issues/631

Deprecate from_science_raw and from_tvac_raw. These are no longer used by romancal.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/29117293007

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
