### PR TITLE
Handle missing minItems.

### DIFF
--- a/changes/692.bugfix.rst
+++ b/changes/692.bugfix.rst
@@ -1,0 +1,3 @@
+Preserve provided defaults in ``create_minimal`` for required array attributes
+that lack ``minItems`` in the schema (for example ``exposure.read_pattern`` and
+``cal_logs``) instead of returning an empty array.

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -332,7 +332,10 @@ class Builder:
 
         min_items = _get_keyword(schema, "minItems")
         if min_items is _MISSING_KEYWORD:
-            return arr
+            # The schema imposes no minimum length, so preserve a provided
+            # default (as the scalar builders do) instead of discarding it.
+            # Without a default this yields an empty array.
+            return [copy.deepcopy(sub_default) for sub_default in defaults]
 
         for sub_default in defaults[:min_items]:
             arr.append(copy.deepcopy(sub_default))

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -332,10 +332,10 @@ class Builder:
 
         min_items = _get_keyword(schema, "minItems")
         if min_items is _MISSING_KEYWORD:
-            # The schema imposes no minimum length, so preserve a provided
-            # default (as the scalar builders do) instead of discarding it.
-            # Without a default this yields an empty array.
-            return [copy.deepcopy(sub_default) for sub_default in defaults]
+            # No minimum length is imposed by the schema, so keep however many
+            # defaults were provided (as the scalar builders do) instead of
+            # discarding them.  Without a default this yields an empty array.
+            min_items = len(defaults)
 
         for sub_default in defaults[:min_items]:
             arr.append(copy.deepcopy(sub_default))

--- a/src/roman_datamodels/_stnode/_schema.py
+++ b/src/roman_datamodels/_stnode/_schema.py
@@ -335,7 +335,7 @@ class Builder:
             # No minimum length is imposed by the schema, so keep however many
             # defaults were provided (as the scalar builders do) instead of
             # discarding them.  Without a default this yields an empty array.
-            min_items = len(defaults)
+            return copy.deepcopy(defaults)
 
         for sub_default in defaults[:min_items]:
             arr.append(copy.deepcopy(sub_default))

--- a/tests/stnode/test_schema.py
+++ b/tests/stnode/test_schema.py
@@ -67,6 +67,10 @@ def test_type(schema, type_):
             {"a": 0},
         ),
         ({"items": {"enum": [0]}}, None, []),
+        # a provided default is preserved when the schema has no minItems
+        ({"items": {"enum": [0]}}, [1, 2], [1, 2]),
+        # nested arrays (e.g. exposure.read_pattern) are preserved
+        ({"type": "array", "items": {"type": "array"}}, [[1], [2, 3]], [[1], [2, 3]]),
         ({"items": {"enum": [0]}, "minItems": 1}, None, [0]),
         ({"items": [{"enum": [0]}, {"enum": [1]}], "minItems": 2}, None, [0, 1]),
         ({"items": [{"enum": [0]}, {"enum": [1]}], "minItems": 1}, None, [0]),


### PR DESCRIPTION
This PR intends to improve the handling of read_pattern and other array attributes lacking minItems (c.f. https://github.com/spacetelescope/romancal/pull/2390).  With the existing code in combination with use of create_minimal in the source catalog step to make the segmentation map and source catalog files
https://github.com/spacetelescope/romancal/blob/main/romancal/source_catalog/source_catalog_step.py#L304
https://github.com/spacetelescope/romancal/blob/main/romancal/source_catalog/source_catalog_step.py#L317
array-valued metadata end up getting truncated and lost.

Regression tests are clean: https://github.com/spacetelescope/RegressionTests/actions/runs/30117477542
which points to a separate issue where maybe we should be testing the segmentation maps, and that Brett is working on in adding parquet-based regression tests (c.f. https://github.com/spacetelescope/romancal/pull/2237).

Brett points out that we have a handful of creation routines:
- create_minimal: only minimal required attributes from defaults; previously only took in the minimum number of items, leading to this issue
- create_from_model: copies everything over, including things not in the schema; undesired here because it would bring over many columns that we don't want in the source catalog / segmentation map metadata
- create_fake_data: copies everything over and invents things if necessary to make a valid schema

For this particular application, we want something in between create_minimal and create_from_model, which copies over things present in the rad schema (whether required or not), but not other items absent from the schema.  That is a separate PR.

## Tasks
- [X] Update or add relevant `roman_datamodels` tests.
- [X] Update relevant docstrings and / or `docs/` page.
- [X] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [X] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [X] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
