### PR TITLE
[SCSB-273] freeze ruff rules with explicit selection

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,25 @@
+line-length = 130
+
+[lint]
+select = [
+  "S",   # flake8-bandit
+  "B",   # flake8-bugbear
+  "I",   # isort
+  "E4",
+  "E7",
+  "E9",  # pycodestyle
+  "F",   # Pyflakes
+  "UP",  # pyupgrade
+  "RUF", # Ruff-specific rules
+]
+extend-select = [
+  "NPY", # numpy specific
+]
+
+[lint.per-file-ignores]
+"tests/**.py" = [
+  "S101", # Bandit: Use of assert detected (fine in test files)
+]
+"src/roman_datamodels/testing.py" = [
+  "S101", # Bandit: Use of assert detected (useful public API for testing only)
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,27 +80,6 @@ exclude_lines = [
   "pass\\n",
 ]
 
-[tool.ruff]
-line-length = 130
-
-[tool.ruff.lint]
-extend-select = [
-  "UP",  # PyUpgrade
-  "I",   # isort
-  "B",   # BugBear
-  "S",   # Bandit
-  "RUF", # ruff specific
-  "NPY", # numpy specific
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**.py" = [
-  "S101", # Bandit: Use of assert detected (fine in test files)
-]
-"src/roman_datamodels/testing.py" = [
-  "S101", # Bandit: Use of assert detected (useful public API for testing only)
-]
-
 [tool.mypy]
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-273](https://jira.stsci.edu/browse/SCSB-273)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
[`ruff 0.16.0` added a lot more default rules](https://astral.sh/blog/ruff-v0.16.0); to avoid a bunch of new Ruff failures, we can explicitly set the rules we're using with `select`. The pre-0.16.0 default rules were `select = ["E4", "E7", "E9", "F"]`

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
