### PR TITLE
Updated tests to prepare for future ASDF changes

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -161,14 +161,18 @@ def test_core_schema(tmp_path):
     newcontents = fcontents[:romanloc] + bytes("X", "utf-8") + fcontents[romanloc + 1 :]
     with open(file_path, "wb") as fp:
         fp.write(newcontents)
-    with pytest.raises(ValidationError):
-        with datamodels.open(file_path) as model:
-            pass
-    asdf.get_config().validate_on_read = False
-    # Filename mismatch warning, because did not save through datamodel to_asdf method
-    with pytest.warns(datamodels.FilenameMismatchWarning), datamodels.open(file_path) as model:
-        assert model.meta.telescope == "XOMAN"
-    asdf.get_config().validate_on_read = True
+
+    with asdf.config_context() as cfg:
+        cfg.validate_on_read = True
+        with pytest.raises(ValidationError):
+            with datamodels.open(file_path) as model:
+                pass
+
+    with asdf.config_context() as cfg:
+        cfg.validate_on_read = False
+        # Filename mismatch warning, because did not save through datamodel to_asdf method
+        with pytest.warns(datamodels.FilenameMismatchWarning), datamodels.open(file_path) as model:
+            assert model.meta.telescope == "XOMAN"
 
 
 def test_add_model_attribute(tmp_path):

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -225,8 +225,10 @@ def test_read_pattern_properties():
     Regression test for reading pattern properties
     """
     # This file has been modified by hand to break the `photmjsr` value
-    with pytest.raises(asdf.ValidationError):
-        datamodels.open(Path(__file__).parent / "data" / "photmjsm.asdf")
+    with asdf.config_context() as cfg:
+        cfg.validate_on_read = True
+        with pytest.raises(asdf.ValidationError):
+            datamodels.open(Path(__file__).parent / "data" / "photmjsm.asdf")
 
 
 def test_rdm_open_non_datamodel():


### PR DESCRIPTION
Closes #700

- Updated `test_core_schema` to manually set `validate_on_read` to `True`/`False` instead of relying on ASDF default
- Updated `test_read_pattern_properties` to set `validate_on_read = True`

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change any API used downstream? (If not, label with `no-changelog-entry-needed`.)
  - [ ] Write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types).
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

<details><summary>News fragment change types:</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details
