### PR TITLE
[TEMPLATE] move towncrier config to its own file and explicitly order changelog categories to put breaking changes on top

### DIFF
--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,10 @@
+# Writing News Fragments for the Changelog
+
+This `changes/` directory contains "news fragments": small reStructuredText (`.rst`) files describing a change in a few sentences.
+When making a release, run `towncrier build --version <VERSION>` to consume existing fragments in `changes/`
+and insert them as a full changelog entry at the top of [`CHANGES.rst`](../CHANGES.rst) for the released version.
+
+News fragment filenames consist of the pull request number and the changelog category.
+Make a news fragment for every relevant category affected by your change.
+A single change can have more than one news fragment, if it spans multiple categories.
+Categories are listed in [`towncrier.toml`](../towncrier.toml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,26 +89,3 @@ python_version = "3.11"
 
 [tool.codespell]
 skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
-
-[tool.towncrier]
-filename = "CHANGES.rst"
-directory = "changes"
-package = "roman_datamodels"
-title_format = "{version} ({project_date})"
-ignore = [".gitkeep"]
-wrap = true
-issue_format = "`#{issue} <https://github.com/spacetelescope/roman_datamodels/issues/{issue}>`_"
-
-[tool.towncrier.fragment.feature]
-name = "New Features"
-
-[tool.towncrier.fragment.bugfix]
-name = "Bug Fixes"
-
-[tool.towncrier.fragment.doc]
-name = "Documentation"
-
-[tool.towncrier.fragment.removal]
-name = "Deprecations and Removals"
-
-[tool.towncrier.fragment.misc]

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,28 @@
+[tool.towncrier]
+filename = "CHANGES.rst"
+directory = "changes"
+package = "roman_datamodels"
+title_format = "{version} ({project_date})"
+ignore = ["README.md"]
+wrap = true
+issue_format = "`#{issue} <https://github.com/spacetelescope/roman_datamodels/issues/{issue}>`_"
+
+[[tool.towncrier.type]]
+directory = "removal"
+name = "Deprecations and Removals"
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "New Features"
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bug Fixes"
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Documentation"
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Other Changes"


### PR DESCRIPTION
<!-- If this PR addresses a JIRA ticket: -->
<!-- Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn) -->

<!-- If this PR will close an existing GitHub issue (that is not already attached to a JIRA ticket): -->
<!-- Closes # -->

<!-- Describe your changes here: -->

## Description

1. putting changelog categories in their own file makes them easier to find for people looking to make new news fragments, and we can link directly to `towncrier.toml` from the `changes/README.md`
2. we can order changelog categories using the `[[tool.towncrier.type]]` table syntax

<!-- If you can't perform these tasks due to permissions, reach out to a maintainer. -->

## Tasks

- [ ] Update or add relevant `roman_datamodels` tests.
- [ ] Update relevant docstrings and / or `docs/` page.
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/roman_datamodels/blob/main/changes/README.rst) for instructions)
  - [ ] Start a `romancal` regression test (https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) with this branch installed (`"git+https://github.com/<fork>/rad@<branch>"`).

## Generative AI Usage Disclosure

<!-- If generative AI or LLMs were used in the process of making this change, describe their use here. -->
<!-- Otherwise, indicate "No genAI tools used". -->

no genAI tools used